### PR TITLE
Adds Vagrant VM for local development

### DIFF
--- a/appliance/.gitignore
+++ b/appliance/.gitignore
@@ -1,0 +1,2 @@
+k3s.yaml
+.vagrant/*

--- a/appliance/Makefile
+++ b/appliance/Makefile
@@ -1,0 +1,3 @@
+setup:
+	[[ -f flatcar_production_vagrant.box ]] || curl -LO https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.box
+	vagrant box add --force flatcar-alpha flatcar_production_vagrant.box

--- a/appliance/Makefile
+++ b/appliance/Makefile
@@ -1,3 +1,0 @@
-setup:
-	[[ -f flatcar_production_vagrant.box ]] || curl -LO https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.box
-	vagrant box add --force flatcar-alpha flatcar_production_vagrant.box

--- a/appliance/README.md
+++ b/appliance/README.md
@@ -11,7 +11,7 @@ IP provisioned, you can set it with `export K8S_IP=x.x.x.x` before running vagra
 
 ```bash
 vagrant up
-vagrant ssh control1 -- -t 'cat /etc/rancher/k3s/k3s.yaml' > k3s.yaml
+vagrant ssh control1 -- -t 'sudo cat /etc/rancher/k3s/k3s.yaml' > k3s.yaml
 export KUBECONFIG=$PWD/k3s.yaml
 k get nodes
 NAME       STATUS   ROLES                       AGE     VERSION

--- a/appliance/README.md
+++ b/appliance/README.md
@@ -1,17 +1,19 @@
 # Appliance VM
 
-This VM is built on flatcar linux and k3s
+This VM is built on flatcar linux and k3s.
 
 ## Quickstart
+
+The following commands are for local development using Vagrant.
+
+Note: The VM is provisioned with a 2nd NIC (eth1) with an IP of 192.168.56.10. If you need a different
+IP provisioned, you can set it with `export K8S_IP=x.x.x.x` before running vagrant up.
 
 ```bash
 vagrant up
 vagrant ssh control1 -- -t 'cat /etc/rancher/k3s/k3s.yaml' > k3s.yaml
-export KUBECONFIG=k3s.yaml
+export KUBECONFIG=$PWD/k3s.yaml
 k get nodes
 NAME       STATUS   ROLES                       AGE     VERSION
 control1   Ready    control-plane,etcd,master   8m19s   v1.30.0+k3s1
 ```
-
-Note: The VM is provisioned with a 2nd NIC (eth1) with an IP of 192.168.56.10. If you need a different
-IP provisioned, you can set it with `export K8S_IP=x.x.x.x` before running vagrant up.

--- a/appliance/README.md
+++ b/appliance/README.md
@@ -1,0 +1,17 @@
+# Appliance VM
+
+This VM is built on flatcar linux and k3s
+
+## Quickstart
+
+```bash
+vagrant up
+vagrant ssh control1 -- -t 'cat /etc/rancher/k3s/k3s.yaml' > k3s.yaml
+export KUBECONFIG=k3s.yaml
+k get nodes
+NAME       STATUS   ROLES                       AGE     VERSION
+control1   Ready    control-plane,etcd,master   8m19s   v1.30.0+k3s1
+```
+
+Note: The VM is provisioned with a 2nd NIC (eth1) with an IP of 192.168.56.10. If you need a different
+IP provisioned, you can set it with `export K8S_IP=x.x.x.x` before running vagrant up.

--- a/appliance/Vagrantfile
+++ b/appliance/Vagrantfile
@@ -1,0 +1,45 @@
+ENV["TERM"] = "xterm-256color"
+ENV["LC_ALL"] = "en_US.UTF-8"
+
+K8S_IP = ENV["K8S_IP"] || "192.168.56.10"
+
+$script = <<-SCRIPT
+curl -sfL https://get.k3s.io | \
+  K3S_KUBECONFIG_MODE="644" \
+  INSTALL_K3S_VERSION="v1.30.0+k3s1" \
+  INSTALL_K3S_EXEC="server \
+    --node-external-ip #{K8S_IP} \
+    --node-ip #{K8S_IP} \
+    --bind-address #{K8S_IP} \
+    --advertise-address #{K8S_IP} \
+    --flannel-iface eth1 \
+    --disable servicelb \
+    --disable traefik \
+    --disable local-storage \
+    --cluster-init" \
+  sh -
+SCRIPT
+
+Vagrant.configure("2") do |config|
+    # General configuration
+    config.vm.box = "https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.box"
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+    config.vbguest.auto_update = false
+    config.ssh.username = 'core'
+    config.ssh.insert_key = true
+
+    config.vm.provider :virtualbox do |v|
+        v.check_guest_additions = false
+        v.functional_vboxsf = false
+        v.memory = 8192
+        v.cpus = 2
+        v.linked_clone = true
+    end
+
+    config.vm.define "control1" do |control1|
+        control1.vm.hostname = "control1"
+        control1.vm.network "private_network", ip: "#{K8S_IP}"
+    end
+
+    config.vm.provision "shell", inline: $script
+end

--- a/appliance/Vagrantfile
+++ b/appliance/Vagrantfile
@@ -5,7 +5,7 @@ K8S_IP = ENV["K8S_IP"] || "192.168.56.10"
 
 $script = <<-SCRIPT
 curl -sfL https://get.k3s.io | \
-  K3S_KUBECONFIG_MODE="644" \
+  K3S_KUBECONFIG_MODE="640" \
   INSTALL_K3S_VERSION="v1.30.0+k3s1" \
   INSTALL_K3S_EXEC="server \
     --node-external-ip #{K8S_IP} \


### PR DESCRIPTION
This adds a Vagrant VM using flatcar linux and installs k3s on it. It will allow us to locally develop the k8s service components.

Closes https://github.com/platform9/vjailbreak/issues/2