### PR TITLE
Retry a failed migration in migrationplan

### DIFF
--- a/k8s/migration/api/v1alpha1/migrationplan_types.go
+++ b/k8s/migration/api/v1alpha1/migrationplan_types.go
@@ -25,8 +25,10 @@ import (
 
 type MigrationPlanStrategy struct {
 	// +kubebuilder:validation:Enum=hot;cold
-	Type          string      `json:"type"`
-	DataCopyStart metav1.Time `json:"dataCopyStart"`
+	Type string `json:"type"`
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format:=date-time
+	DataCopyStart metav1.Time `json:"dataCopyStart,omitempty"`
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format:=date-time
 	VMCutoverStart metav1.Time `json:"vmCutoverStart,omitempty"`
@@ -39,6 +41,7 @@ type MigrationPlanStrategy struct {
 type MigrationPlanSpec struct {
 	MigrationTemplate string                `json:"migrationTemplate"`
 	MigrationStrategy MigrationPlanStrategy `json:"migrationStrategy"`
+	Retry             bool                  `json:"retry,omitempty"`
 	VirtualMachines   [][]string            `json:"virtualmachines"`
 }
 

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationplans.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationplans.yaml
@@ -56,11 +56,12 @@ spec:
                     format: date-time
                     type: string
                 required:
-                - dataCopyStart
                 - type
                 type: object
               migrationTemplate:
                 type: string
+              retry:
+                type: boolean
               virtualmachines:
                 items:
                   items:

--- a/k8s/migration/config/manager/manager.yaml
+++ b/k8s/migration/config/manager/manager.yaml
@@ -83,14 +83,10 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        # TODO(user): Configure the resources accordingly based on the project requirements.
-        # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        # This doesn't need so much. It is just to ensure QoL of the node
         resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
           requests:
-            cpu: 10m
-            memory: 64Mi
+            cpu: 200m
+            memory: 256Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -50,6 +50,8 @@ var migrationPlanFinalizer = "migrationplan.vjailbreak.pf9.io/finalizer"
 
 const v2vimage = "platform9/v2v-helper:v0.1"
 
+const terminationPeriod = int64(120)
+
 // Used to facilitate removal of our finalizer
 func RemoveString(s []string, r string) []string {
 	for i, v := range s {
@@ -261,6 +263,8 @@ func (r *MigrationPlanReconciler) CreateMigration(ctx context.Context,
 	return migrationobj, nil
 }
 
+func int64Ptr(i int64) *int64 { return &i }
+
 func (r *MigrationPlanReconciler) CreatePod(ctx context.Context,
 	migrationplan *vjailbreakv1alpha1.MigrationPlan,
 	migrationobj *vjailbreakv1alpha1.Migration, vm string, configMapName string) error {
@@ -280,8 +284,9 @@ func (r *MigrationPlanReconciler) CreatePod(ctx context.Context,
 				},
 			},
 			Spec: corev1.PodSpec{
-				RestartPolicy:      corev1.RestartPolicyNever,
-				ServiceAccountName: "migration-controller-manager",
+				RestartPolicy:                 corev1.RestartPolicyNever,
+				ServiceAccountName:            "migration-controller-manager",
+				TerminationGracePeriodSeconds: int64Ptr(terminationPeriod),
 				Containers: []corev1.Container{
 					{
 						Name:            "fedora",

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -154,9 +154,11 @@ func GetVMwNetworks(ctx context.Context, vmwcreds *vjailbreakv1alpha1.VMwareCred
 	}
 
 	for _, device := range o.Config.Hardware.Device {
-		if _, ok := device.(*types.VirtualE1000e); ok {
-			nic := device.(*types.VirtualE1000e)
-			networks = append(networks, nic.DeviceInfo.GetDescription().Summary)
+		switch dev := device.(type) {
+		case *types.VirtualE1000e:
+			networks = append(networks, dev.DeviceInfo.GetDescription().Summary)
+		case *types.VirtualVmxnet3:
+			networks = append(networks, dev.DeviceInfo.GetDescription().Summary)
 		}
 	}
 

--- a/v2v-helper/main.go
+++ b/v2v-helper/main.go
@@ -113,6 +113,7 @@ func main() {
 
 	err = migrationobj.MigrateVM(ctx)
 	if err != nil {
+		cancel()
 		log.Fatalf("Failed to migrate VM: %s\n", err)
 	}
 

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -188,7 +188,7 @@ func (migobj *Migrate) WaitforCutover() error {
 	return nil
 }
 
-func (migobj *Migrate) LiveReplicateDisks(vminfo vm.VMInfo) (vm.VMInfo, error) {
+func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo) (vm.VMInfo, error) {
 	vmops := migobj.VMops
 	nbdops := migobj.Nbdops
 	envURL := migobj.URL
@@ -235,7 +235,7 @@ func (migobj *Migrate) LiveReplicateDisks(vminfo vm.VMInfo) (vm.VMInfo, error) {
 					return vminfo, fmt.Errorf("failed to attach volume: %s", err)
 				}
 
-				err = nbdops[idx].CopyDisk(vminfo.VMDisks[idx].Path)
+				err = nbdops[idx].CopyDisk(ctx, vminfo.VMDisks[idx].Path)
 				if err != nil {
 					return vminfo, fmt.Errorf("failed to copy disk: %s", err)
 				}
@@ -348,7 +348,7 @@ func (migobj *Migrate) LiveReplicateDisks(vminfo vm.VMInfo) (vm.VMInfo, error) {
 	return vminfo, nil
 }
 
-func (migobj *Migrate) ConvertVolumes(vminfo vm.VMInfo) error {
+func (migobj *Migrate) ConvertVolumes(ctx context.Context, vminfo vm.VMInfo) error {
 	migobj.logMessage("Converting disk")
 	path, err := migobj.AttachVolume(vminfo.VMDisks[0])
 	if err != nil {
@@ -363,7 +363,7 @@ func (migobj *Migrate) ConvertVolumes(vminfo vm.VMInfo) error {
 			}
 		}
 
-		err := virtv2v.ConvertDisk(path, vminfo.OSType, migobj.Virtiowin)
+		err := virtv2v.ConvertDisk(ctx, path, vminfo.OSType, migobj.Virtiowin)
 		if err != nil {
 			return fmt.Errorf("failed to run virt-v2v: %s", err)
 		}
@@ -432,17 +432,19 @@ func (migobj *Migrate) CreateTargetInstance(vminfo vm.VMInfo) error {
 	return nil
 }
 
-func (migobj *Migrate) gracefulTerminate(vminfo vm.VMInfo) {
+func (migobj *Migrate) gracefulTerminate(vminfo vm.VMInfo, cancel context.CancelFunc) {
 	gracefulShutdown := make(chan os.Signal, 1)
 	// Handle SIGTERM
 	signal.Notify(gracefulShutdown, syscall.SIGTERM, syscall.SIGINT)
 	<-gracefulShutdown
 	migobj.logMessage("Gracefully terminating")
+	cancel()
 	migobj.cleanup(vminfo)
 	os.Exit(0)
 }
 
 func (migobj *Migrate) MigrateVM(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
 	// Wait until the data copy start time
 	var zerotime time.Time
 	if !migobj.MigrationTimes.DataCopyStart.Equal(zerotime) && migobj.MigrationTimes.DataCopyStart.After(time.Now()) {
@@ -453,11 +455,12 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 	// Get Info about VM
 	vminfo, err := migobj.VMops.GetVMInfo(migobj.Ostype)
 	if err != nil {
+		cancel()
 		return fmt.Errorf("failed to get all info: %s", err)
 	}
 
 	// Graceful Termination
-	go migobj.gracefulTerminate(vminfo)
+	go migobj.gracefulTerminate(vminfo, cancel)
 
 	// Create and Add Volumes to Host
 	vminfo, err = migobj.CreateVolumes(vminfo)
@@ -477,14 +480,14 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 	}
 
 	// Live Replicate Disks
-	vminfo, err = migobj.LiveReplicateDisks(vminfo)
+	vminfo, err = migobj.LiveReplicateDisks(ctx, vminfo)
 	if err != nil {
 		migobj.cleanup(vminfo)
 		return fmt.Errorf("failed to live replicate disks: %s", err)
 	}
 
 	// Convert the Boot Disk to raw format
-	err = migobj.ConvertVolumes(vminfo)
+	err = migobj.ConvertVolumes(ctx, vminfo)
 	if err != nil {
 		migobj.cleanup(vminfo)
 		return fmt.Errorf("failed to convert disks: %s", err)
@@ -495,6 +498,7 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 		migobj.cleanup(vminfo)
 		return fmt.Errorf("failed to create target instance: %s", err)
 	}
+	cancel()
 	return nil
 }
 

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -462,7 +462,6 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 	// Create and Add Volumes to Host
 	vminfo, err = migobj.CreateVolumes(vminfo)
 	if err != nil {
-		migobj.cleanup(vminfo)
 		return fmt.Errorf("failed to add volumes to host: %s", err)
 	}
 

--- a/v2v-helper/migrate/migrate_test.go
+++ b/v2v-helper/migrate/migrate_test.go
@@ -2,6 +2,7 @@
 package migrate
 
 import (
+	"context"
 	"testing"
 	"vjailbreak/nbd"
 	"vjailbreak/openstack"
@@ -172,13 +173,13 @@ func TestLiveReplicateDisks(t *testing.T) {
 			Times(1),
 		mockOpenStackOps.EXPECT().AttachVolumeToVM("id1").Return(nil).Times(1),
 		mockOpenStackOps.EXPECT().FindDevice("id1").Return("/dev/sda", nil).Times(1),
-		mockNBD.EXPECT().CopyDisk("/dev/sda").Return(nil).Times(1),
+		mockNBD.EXPECT().CopyDisk(context.TODO(), "/dev/sda").Return(nil).Times(1),
 		mockOpenStackOps.EXPECT().DetachVolumeFromVM("id1").Return(nil).Times(1),
 		mockOpenStackOps.EXPECT().WaitForVolume("id1").Return(nil).Times(1),
 
 		mockOpenStackOps.EXPECT().AttachVolumeToVM("id2").Return(nil).Times(1),
 		mockOpenStackOps.EXPECT().FindDevice("id2").Return("/dev/sda", nil).Times(1),
-		mockNBD.EXPECT().CopyDisk("/dev/sda").Return(nil).Times(1),
+		mockNBD.EXPECT().CopyDisk(context.TODO(), "/dev/sda").Return(nil).Times(1),
 		mockOpenStackOps.EXPECT().DetachVolumeFromVM("id2").Return(nil).Times(1),
 		mockOpenStackOps.EXPECT().WaitForVolume("id2").Return(nil).Times(1),
 		// 1. Both Disks Change
@@ -372,7 +373,7 @@ func TestLiveReplicateDisks(t *testing.T) {
 		EventReporter:    dummychan,
 		MigrationType:    "hot",
 	}
-	updatedVMInfo, err := migobj.LiveReplicateDisks(inputvminfo)
+	updatedVMInfo, err := migobj.LiveReplicateDisks(context.TODO(), inputvminfo)
 	assert.NoError(t, err)
 	assert.Equal(t, vm.VMInfo{
 		Name:   "test-vm",

--- a/v2v-helper/nbd/nbdops_mock.go
+++ b/v2v-helper/nbd/nbdops_mock.go
@@ -5,6 +5,7 @@
 package nbd
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -50,17 +51,17 @@ func (mr *MockNBDOperationsMockRecorder) CopyChangedBlocks(changedAreas, path in
 }
 
 // CopyDisk mocks base method.
-func (m *MockNBDOperations) CopyDisk(dest string) error {
+func (m *MockNBDOperations) CopyDisk(ctx context.Context, dest string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CopyDisk", dest)
+	ret := m.ctrl.Call(m, "CopyDisk", ctx, dest)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CopyDisk indicates an expected call of CopyDisk.
-func (mr *MockNBDOperationsMockRecorder) CopyDisk(dest interface{}) *gomock.Call {
+func (mr *MockNBDOperationsMockRecorder) CopyDisk(ctx, dest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyDisk", reflect.TypeOf((*MockNBDOperations)(nil).CopyDisk), dest)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyDisk", reflect.TypeOf((*MockNBDOperations)(nil).CopyDisk), ctx, dest)
 }
 
 // StartNBDServer mocks base method.

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -5,6 +5,7 @@ package virtv2v
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -21,7 +22,7 @@ type VirtV2VOperations interface {
 	RetainAlphanumeric(input string) string
 	GetPartitions(disk string) ([]string, error)
 	NTFSFix(path string) error
-	ConvertDisk(path string, ostype string, virtiowindriver string) error
+	ConvertDisk(ctx context.Context, path string, ostype string, virtiowindriver string) error
 	AddWildcardNetplan(path string) error
 }
 
@@ -112,7 +113,7 @@ func downloadFile(url, filePath string) error {
 	return nil
 }
 
-func ConvertDisk(path string, ostype string, virtiowindriver string) error {
+func ConvertDisk(ctx context.Context, path string, ostype string, virtiowindriver string) error {
 	// Convert the disk
 
 	if ostype == "windows" {
@@ -128,7 +129,7 @@ func ConvertDisk(path string, ostype string, virtiowindriver string) error {
 
 	}
 	os.Setenv("LIBGUESTFS_BACKEND", "direct")
-	cmd := exec.Command("virt-v2v-in-place", "-i", "disk", path)
+	cmd := exec.CommandContext(ctx, "virt-v2v-in-place", "-i", "disk", path)
 	log.Printf("Executing %s", cmd.String())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/v2v-helper/virtv2v/virtv2vops_mock.go
+++ b/v2v-helper/virtv2v/virtv2vops_mock.go
@@ -5,6 +5,7 @@
 package virtv2v
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -48,17 +49,17 @@ func (mr *MockVirtV2VOperationsMockRecorder) AddWildcardNetplan(path interface{}
 }
 
 // ConvertDisk mocks base method.
-func (m *MockVirtV2VOperations) ConvertDisk(path, ostype, virtiowindriver string) error {
+func (m *MockVirtV2VOperations) ConvertDisk(ctx context.Context, path, ostype, virtiowindriver string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConvertDisk", path, ostype, virtiowindriver)
+	ret := m.ctrl.Call(m, "ConvertDisk", ctx, path, ostype, virtiowindriver)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ConvertDisk indicates an expected call of ConvertDisk.
-func (mr *MockVirtV2VOperationsMockRecorder) ConvertDisk(path, ostype, virtiowindriver interface{}) *gomock.Call {
+func (mr *MockVirtV2VOperationsMockRecorder) ConvertDisk(ctx, path, ostype, virtiowindriver interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConvertDisk", reflect.TypeOf((*MockVirtV2VOperations)(nil).ConvertDisk), path, ostype, virtiowindriver)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConvertDisk", reflect.TypeOf((*MockVirtV2VOperations)(nil).ConvertDisk), ctx, path, ostype, virtiowindriver)
 }
 
 // GetPartitions mocks base method.


### PR DESCRIPTION
Close #39 

Retries one failed migration in the migration plan once. Changes retry field from true to false when it does this. If you wish to retry another failed migration in the same plan, you must set retry to true again manually.