### PR TITLE
add IpAddress and VM state info to migrationtemplate status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-export UI_IMG ?= platform9/vjailbreak-ui:v0.2
-export V2V_IMG ?= platform9/v2v-helper:v0.2
-export CONTROLLER_IMG ?= platform9/vjailbreak-controller:v0.2
+export REPO ?= platform9
+export UI_IMG ?= ${REPO}/vjailbreak-ui
+export V2V_IMG ?= ${REPO}/v2v-helper
+export TAG ?= latest 
+export CONTROLLER_IMG ?= ${REPO}/vjailbreak-controller:${TAG}
 
 .PHONY: ui
 ui:
@@ -14,6 +16,10 @@ v2v-helper:
 
 .PHONY: vjail-controller
 vjail-controller: v2v-helper
+	make -C k8s/migration/ docker-build docker-push
+
+.PHONY: vjail-controller-only
+vjail-controller-only:
 	make -C k8s/migration/ docker-build docker-push
 
 .PHONY: generate-manifests
@@ -32,4 +38,3 @@ docker-build-image: generate-manifests
 build-image: generate-manifests
 	rm -rf artifacts/ && mkdir artifacts/
 	docker build --platform linux/amd64 --output=artifacts/ -t vjailbreak-image:local image_builder/ 
-

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export REPO ?= platform9
 export UI_IMG ?= ${REPO}/vjailbreak-ui
 export V2V_IMG ?= ${REPO}/v2v-helper
-export TAG ?= latest 
+export TAG ?= latest
 export CONTROLLER_IMG ?= ${REPO}/vjailbreak-controller:${TAG}
 
 .PHONY: ui

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export REPO ?= platform9
-export UI_IMG ?= ${REPO}/vjailbreak-ui
-export V2V_IMG ?= ${REPO}/v2v-helper
 export TAG ?= latest
+export UI_IMG ?= ${REPO}/vjailbreak-ui:${TAG}
+export V2V_IMG ?= ${REPO}/v2v-helper:${TAG}
 export CONTROLLER_IMG ?= ${REPO}/vjailbreak-controller:${TAG}
 
 .PHONY: ui

--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -1,571 +1,3 @@
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
-  name: migrationplans.vjailbreak.k8s.pf9.io
-spec:
-  group: vjailbreak.k8s.pf9.io
-  names:
-    kind: MigrationPlan
-    listKind: MigrationPlanList
-    plural: migrationplans
-    singular: migrationplan
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: MigrationPlan is the Schema for the migrationplans API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: MigrationPlanSpec defines the desired state of MigrationPlan
-            properties:
-              migrationStrategy:
-                properties:
-                  dataCopyStart:
-                    format: date-time
-                    type: string
-                  type:
-                    enum:
-                    - hot
-                    - cold
-                    type: string
-                  vmCutoverEnd:
-                    format: date-time
-                    type: string
-                  vmCutoverStart:
-                    format: date-time
-                    type: string
-                required:
-                - type
-                type: object
-              migrationTemplate:
-                type: string
-              retry:
-                type: boolean
-              virtualmachines:
-                items:
-                  items:
-                    type: string
-                  type: array
-                type: array
-            required:
-            - migrationStrategy
-            - migrationTemplate
-            - virtualmachines
-            type: object
-          status:
-            description: MigrationPlanStatus defines the observed state of MigrationPlan
-            properties:
-              migrationMessage:
-                type: string
-              migrationStatus:
-                type: string
-            required:
-            - migrationMessage
-            - migrationStatus
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
-  name: migrations.vjailbreak.k8s.pf9.io
-spec:
-  group: vjailbreak.k8s.pf9.io
-  names:
-    kind: Migration
-    listKind: MigrationList
-    plural: migrations
-    singular: migration
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Migration is the Schema for the migrations API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: MigrationSpec defines the desired state of Migration
-            properties:
-              migrationPlan:
-                type: string
-              podRef:
-                type: string
-              vmName:
-                type: string
-            required:
-            - migrationPlan
-            - podRef
-            - vmName
-            type: object
-          status:
-            description: MigrationStatus defines the observed state of Migration
-            properties:
-              conditions:
-                items:
-                  description: PodCondition contains details for the current condition
-                    of this pod.
-                  properties:
-                    lastProbeTime:
-                      description: Last time we probed the condition.
-                      format: date-time
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
-                      format: date-time
-                      type: string
-                    message:
-                      description: Human-readable message indicating details about
-                        last transition.
-                      type: string
-                    reason:
-                      description: Unique, one-word, CamelCase reason for the condition's
-                        last transition.
-                      type: string
-                    status:
-                      description: |-
-                        Status is the status of the condition.
-                        Can be True, False, Unknown.
-                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
-                      type: string
-                    type:
-                      description: |-
-                        Type is the type of the condition.
-                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              phase:
-                type: string
-            required:
-            - conditions
-            - phase
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
-  name: migrationtemplates.vjailbreak.k8s.pf9.io
-spec:
-  group: vjailbreak.k8s.pf9.io
-  names:
-    kind: MigrationTemplate
-    listKind: MigrationTemplateList
-    plural: migrationtemplates
-    singular: migrationtemplate
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: MigrationTemplate is the Schema for the migrationtemplates API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: MigrationTemplateSpec defines the desired state of MigrationTemplate
-            properties:
-              destination:
-                description: MigrationTemplateDestination defines the destination
-                  details for the migrationtemplate
-                properties:
-                  openstackRef:
-                    type: string
-                required:
-                - openstackRef
-                type: object
-              networkMapping:
-                type: string
-              osType:
-                enum:
-                - windows
-                - linux
-                type: string
-              source:
-                description: MigrationTemplateSource defines the source details for
-                  the migrationtemplate
-                properties:
-                  datacenter:
-                    type: string
-                  vmwareRef:
-                    type: string
-                required:
-                - datacenter
-                - vmwareRef
-                type: object
-              storageMapping:
-                type: string
-              virtioWinDriver:
-                type: string
-            required:
-            - destination
-            - networkMapping
-            - source
-            - storageMapping
-            type: object
-          status:
-            description: MigrationTemplateStatus defines the observed state of MigrationTemplate
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
-  name: networkmappings.vjailbreak.k8s.pf9.io
-spec:
-  group: vjailbreak.k8s.pf9.io
-  names:
-    kind: NetworkMapping
-    listKind: NetworkMappingList
-    plural: networkmappings
-    singular: networkmapping
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: NetworkMapping is the Schema for the networkmappings API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: NetworkMappingSpec defines the desired state of NetworkMapping
-            properties:
-              networks:
-                description: Networks is the list of networks
-                items:
-                  properties:
-                    source:
-                      type: string
-                    target:
-                      type: string
-                  required:
-                  - source
-                  - target
-                  type: object
-                type: array
-            required:
-            - networks
-            type: object
-          status:
-            description: NetworkMappingStatus defines the observed state of NetworkMapping
-            properties:
-              networkMappingValidationMessage:
-                type: string
-              networkMappingValidationStatus:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
-  name: openstackcreds.vjailbreak.k8s.pf9.io
-spec:
-  group: vjailbreak.k8s.pf9.io
-  names:
-    kind: OpenstackCreds
-    listKind: OpenstackCredsList
-    plural: openstackcreds
-    singular: openstackcreds
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: OpenstackCreds is the Schema for the openstackcreds API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: OpenstackCredsSpec defines the desired state of OpenstackCreds
-            properties:
-              OS_AUTH_URL:
-                description: OsAuthURL is the OpenStack authentication URL
-                type: string
-              OS_DOMAIN_NAME:
-                description: OsDomainName is the OpenStack domain name
-                type: string
-              OS_PASSWORD:
-                description: OsPassword is the OpenStack password
-                type: string
-              OS_REGION_NAME:
-                description: OsRegionName is the OpenStack region name
-                type: string
-              OS_TENANT_NAME:
-                description: OsTenantName is the OpenStack tenant name
-                type: string
-              OS_USERNAME:
-                description: OsUsername is the OpenStack username
-                type: string
-            type: object
-          status:
-            description: OpenstackCredsStatus defines the observed state of OpenstackCreds
-            properties:
-              openstackValidationMessage:
-                type: string
-              openstackValidationStatus:
-                description: |-
-                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
-  name: storagemappings.vjailbreak.k8s.pf9.io
-spec:
-  group: vjailbreak.k8s.pf9.io
-  names:
-    kind: StorageMapping
-    listKind: StorageMappingList
-    plural: storagemappings
-    singular: storagemapping
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: StorageMapping is the Schema for the storagemappings API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: StorageMappingSpec defines the desired state of StorageMapping
-            properties:
-              storages:
-                items:
-                  properties:
-                    source:
-                      type: string
-                    target:
-                      type: string
-                  required:
-                  - source
-                  - target
-                  type: object
-                type: array
-            required:
-            - storages
-            type: object
-          status:
-            description: StorageMappingStatus defines the observed state of StorageMapping
-            properties:
-              storageMappingValidationMessage:
-                type: string
-              storageMappingValidationStatus:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
-  name: vmwarecreds.vjailbreak.k8s.pf9.io
-spec:
-  group: vjailbreak.k8s.pf9.io
-  names:
-    kind: VMwareCreds
-    listKind: VMwareCredsList
-    plural: vmwarecreds
-    singular: vmwarecreds
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: VMwareCreds is the Schema for the vmwarecreds API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: VMwareCredsSpec defines the desired state of VMwareCreds
-            properties:
-              VCENTER_HOST:
-                type: string
-              VCENTER_INSECURE:
-                type: boolean
-              VCENTER_PASSWORD:
-                type: string
-              VCENTER_USERNAME:
-                type: string
-            required:
-            - VCENTER_HOST
-            - VCENTER_INSECURE
-            - VCENTER_PASSWORD
-            - VCENTER_USERNAME
-            type: object
-          status:
-            description: VMwareCredsStatus defines the observed state of VMwareCreds
-            properties:
-              vmwareValidationMessage:
-                type: string
-              vmwareValidationStatus:
-                description: |-
-                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -615,11 +47,38 @@ spec:
           spec:
             description: MigrationPlanSpec defines the desired state of MigrationPlan
             properties:
+              advancedOptions:
+                properties:
+                  granularNetworks:
+                    items:
+                      type: string
+                    type: array
+                  granularPorts:
+                    items:
+                      type: string
+                    type: array
+                  granularVolumeTypes:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              firstBootScript:
+                default: echo "Add your startup script here!"
+                type: string
               migrationStrategy:
                 properties:
+                  adminInitiatedCutOver:
+                    default: false
+                    type: boolean
                   dataCopyStart:
                     format: date-time
                     type: string
+                  healthCheckPort:
+                    default: "443"
+                    type: string
+                  performHealthChecks:
+                    default: false
+                    type: boolean
                   type:
                     enum:
                     - hot
@@ -706,6 +165,8 @@ spec:
           spec:
             description: MigrationSpec defines the desired state of Migration
             properties:
+              initiateCutover:
+                type: boolean
               migrationPlan:
                 type: string
               podRef:
@@ -713,6 +174,7 @@ spec:
               vmName:
                 type: string
             required:
+            - initiateCutover
             - migrationPlan
             - podRef
             - vmName
@@ -850,6 +312,44 @@ spec:
             type: object
           status:
             description: MigrationTemplateStatus defines the observed state of MigrationTemplate
+            properties:
+              openstack:
+                properties:
+                  networks:
+                    items:
+                      type: string
+                    type: array
+                  volumeTypes:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              vmware:
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
+                items:
+                  properties:
+                    datastores:
+                      items:
+                        type: string
+                      type: array
+                    ipAddress:
+                      type: string
+                    name:
+                      type: string
+                    networks:
+                      items:
+                        type: string
+                      type: array
+                    osType:
+                      type: string
+                    vmState:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
             type: object
         type: object
     served: true
@@ -973,6 +473,11 @@ spec:
               OS_DOMAIN_NAME:
                 description: OsDomainName is the OpenStack domain name
                 type: string
+              OS_INSECURE:
+                default: false
+                description: OsInsecure is the flag to skip verification of the OpenStack
+                  TLS Certificate
+                type: boolean
               OS_PASSWORD:
                 description: OsPassword is the OpenStack password
                 type: string
@@ -1289,9 +794,27 @@ rules:
   resources:
   - migrationtemplates
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
+- apiGroups:
+  - vjailbreak.k8s.pf9.io
+  resources:
+  - migrationtemplates/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - vjailbreak.k8s.pf9.io
+  resources:
+  - migrationtemplates/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - vjailbreak.k8s.pf9.io
   resources:
@@ -1803,7 +1326,7 @@ spec:
     spec:
       containers:
       - args:
-        - --leader-elect
+        - --leader-elect=false
         - --health-probe-bind-address=:8081
         command:
         - /manager
@@ -1831,6 +1354,8 @@ spec:
           capabilities:
             drop:
             - ALL
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
       securityContext:
         runAsNonRoot: true
       serviceAccountName: migration-controller-manager

--- a/k8s/migration/api/v1alpha1/migrationtemplate_types.go
+++ b/k8s/migration/api/v1alpha1/migrationtemplate_types.go
@@ -49,7 +49,7 @@ type VMInfo struct {
 	Name       string   `json:"name"`
 	Datastores []string `json:"datastores,omitempty"`
 	Networks   []string `json:"networks,omitempty"`
-	IpAddress  string   `json:"ipAddress,omitempty"`
+	IPAddress  string   `json:"ipAddress,omitempty"`
 	VMState    string   `json:"vmstate,omitempty"`
 }
 

--- a/k8s/migration/api/v1alpha1/migrationtemplate_types.go
+++ b/k8s/migration/api/v1alpha1/migrationtemplate_types.go
@@ -50,7 +50,8 @@ type VMInfo struct {
 	Datastores []string `json:"datastores,omitempty"`
 	Networks   []string `json:"networks,omitempty"`
 	IPAddress  string   `json:"ipAddress,omitempty"`
-	VMState    string   `json:"vmstate,omitempty"`
+	VMState    string   `json:"vmState,omitempty"`
+	OSType     string   `json:"osType,omitempty"`
 }
 
 type OpenstackInfo struct {

--- a/k8s/migration/api/v1alpha1/migrationtemplate_types.go
+++ b/k8s/migration/api/v1alpha1/migrationtemplate_types.go
@@ -49,6 +49,8 @@ type VMInfo struct {
 	Name       string   `json:"name"`
 	Datastores []string `json:"datastores,omitempty"`
 	Networks   []string `json:"networks,omitempty"`
+	IpAddress  string   `json:"ipAddress,omitempty"`
+	VMState    string   `json:"vmstate,omitempty"`
 }
 
 type OpenstackInfo struct {

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationtemplates.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationtemplates.yaml
@@ -109,7 +109,9 @@ spec:
                       items:
                         type: string
                       type: array
-                    vmstate:
+                    osType:
+                      type: string
+                    vmState:
                       type: string
                   required:
                   - name

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationtemplates.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationtemplates.yaml
@@ -101,12 +101,16 @@ spec:
                       items:
                         type: string
                       type: array
+                    ipAddress:
+                      type: string
                     name:
                       type: string
                     networks:
                       items:
                         type: string
                       type: array
+                    vmstate:
+                      type: string
                   required:
                   - name
                   type: object

--- a/k8s/migration/config/manager/manager.yaml
+++ b/k8s/migration/config/manager/manager.yaml
@@ -63,7 +63,7 @@ spec:
       - command:
         - /manager
         args:
-          - --leader-elect
+          - --leader-elect=false
           - --health-probe-bind-address=:8081
         image: controller:latest
         imagePullPolicy: IfNotPresent

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -271,7 +271,7 @@ func GetAllVMs(ctx context.Context, vmwcreds *vjailbreakv1alpha1.VMwareCreds, da
 			Name:       vmProps.Config.Name,
 			Datastores: datastores,
 			Networks:   networks,
-			IpAddress:  vmProps.Guest.IpAddress,
+			IPAddress:  vmProps.Guest.IpAddress,
 			VMState:    vmProps.Guest.GuestState,
 		})
 	}

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -234,7 +234,7 @@ func GetAllVMs(ctx context.Context, vmwcreds *vjailbreakv1alpha1.VMwareCreds, da
 	var vminfo []vjailbreakv1alpha1.VMInfo
 	for _, vm := range vms {
 		var vmProps mo.VirtualMachine
-		err = vm.Properties(ctx, vm.Reference(), []string{"config"}, &vmProps)
+		err = vm.Properties(ctx, vm.Reference(), []string{"config", "guest"}, &vmProps)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get VM properties: %w", err)
 		}
@@ -266,10 +266,13 @@ func GetAllVMs(ctx context.Context, vmwcreds *vjailbreakv1alpha1.VMwareCreds, da
 				datastores = append(datastores, ds.Name)
 			}
 		}
+
 		vminfo = append(vminfo, vjailbreakv1alpha1.VMInfo{
 			Name:       vmProps.Config.Name,
 			Datastores: datastores,
 			Networks:   networks,
+			IpAddress:  vmProps.Guest.IpAddress,
+			VMState:    vmProps.Guest.GuestState,
 		})
 	}
 

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -273,6 +273,7 @@ func GetAllVMs(ctx context.Context, vmwcreds *vjailbreakv1alpha1.VMwareCreds, da
 			Networks:   networks,
 			IPAddress:  vmProps.Guest.IpAddress,
 			VMState:    vmProps.Guest.GuestState,
+			OSType:     vmProps.Guest.GuestFamily,
 		})
 	}
 

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -146,7 +146,7 @@ func (migobj *Migrate) DeleteAllVolumes(vminfo vm.VMInfo) error {
 	return nil
 }
 
-// This function enables CBT on the VM if it not enabled and takes a snapshot for initializing CBT
+// This function enables CBT on the VM if it is not enabled and takes a snapshot for initializing CBT
 func (migobj *Migrate) EnableCBTWrapper() error {
 	vmops := migobj.VMops
 	cbt, err := vmops.IsCBTEnabled()
@@ -420,6 +420,7 @@ systemctl enable --now serial-getty@ttyS0.service`
 		}
 	}
 
+	//TODO(omkar): can disable DHCP here
 	if vminfo.OSType == "linux" {
 		if strings.Contains(osRelease, "ubuntu") {
 			// Add Wildcard Netplan

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -202,6 +202,7 @@ DHCP=yes`
 	}
 	return nil
 }
+
 func AddFirstBootScript(firstbootscript, firstbootscriptname string) error {
 	// Create the firstboot script
 	firstbootscriptpath := fmt.Sprintf("/home/fedora/%s.sh", firstbootscriptname)


### PR DESCRIPTION
# This PR includes
- Adding IpAddress and VM state info to migrationtemplate status
- Adding helper make targets
- Resolving need to scale-down and scale-up controller manager deployment every time a new image is created. Done by setting `leader-election` to `false` which was anyway ineffective since we have only one replica

#132 