### PR TITLE
141 UI handle vm refresh with additional put call to migration template and addadjust the timeout needed for it to reflect latest detail

### DIFF
--- a/ui/src/api/migration-templates/migrationTemplates.ts
+++ b/ui/src/api/migration-templates/migrationTemplates.ts
@@ -41,6 +41,19 @@ export const postMigrationTemplate = async (
   return response
 }
 
+export const putMigrationTemplate = async (
+  templateName,
+  body,
+  namespace = VJAILBREAK_DEFAULT_NAMESPACE
+) => {
+  const endpoint = `${VJAILBREAK_API_BASE_PATH}/namespaces/${namespace}/migrationtemplates/${templateName}`
+  const response = await axios.put<MigrationTemplate>({
+    endpoint,
+    data: body,
+  })
+  return response
+}
+
 export const patchMigrationTemplate = async (
   templateName,
   body,

--- a/ui/src/api/migration-templates/model.ts
+++ b/ui/src/api/migration-templates/model.ts
@@ -17,69 +17,19 @@ export interface MigrationTemplateMetadata {
   annotations: Annotations
   creationTimestamp: Date
   generation: number
-  managedFields: ManagedField[]
   name: string
   namespace: string
   resourceVersion: string
   uid: string
+  labels: Labels
 }
 
 export interface Annotations {
   "kubectl.kubernetes.io/last-applied-configuration": string
 }
 
-export interface ManagedField {
-  apiVersion: string
-  fieldsType: string
-  fieldsV1: FieldsV1
-  manager: string
-  operation: string
-  time?: Date
-  subresource?: string
-}
-
-export interface FieldsV1 {
-  "f:metadata"?: FMetadata
-  "f:spec"?: FSpec
-  "f:status"?: FStatus
-}
-
-export interface FMetadata {
-  "f:annotations": FAnnotations
-}
-
-export interface FAnnotations {
-  "f:kubectl.kubernetes.io/last-applied-configuration": FNetworkMapping
-}
-
-export type FNetworkMapping = object
-
-export interface FSpec {
-  "f:destination": FDestination
-  "f:networkMapping": FNetworkMapping
-  "f:source": FSource
-  "f:storageMapping": FNetworkMapping
-}
-
-export interface FDestination {
-  "f:openstackRef": FNetworkMapping
-}
-
-export interface FSource {
-  "f:datacenter": FNetworkMapping
-  "f:vmwareRef": FNetworkMapping
-}
-
-export interface FStatus {
-  ".": FNetworkMapping
-  "f:openstack": FOpenstack
-  "f:vmware": FNetworkMapping
-}
-
-export interface FOpenstack {
-  ".": FNetworkMapping
-  "f:networks": FNetworkMapping
-  "f:volumeTypes": FNetworkMapping
+export interface Labels {
+  refresh: string
 }
 
 export interface MigrationTemplateSpec {

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -3,4 +3,6 @@ export const defaultNamespace = "migration-system"
 // Polling intervals
 export const THREE_SECONDS = 1000 * 3
 export const FIVE_SECONDS = 1000 * 5
+export const TEN_SECONDS = 1000 * 10
 export const THIRTY_SECONDS = 1000 * 30
+export const ONE_MINUTE = 1000 * 60

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -4,5 +4,6 @@ export const defaultNamespace = "migration-system"
 export const THREE_SECONDS = 1000 * 3
 export const FIVE_SECONDS = 1000 * 5
 export const TEN_SECONDS = 1000 * 10
+export const TWENTY_SECONDS = 1000 * 20
 export const THIRTY_SECONDS = 1000 * 30
 export const ONE_MINUTE = 1000 * 60

--- a/ui/src/features/migration/MigrationForm.tsx
+++ b/ui/src/features/migration/MigrationForm.tsx
@@ -35,7 +35,7 @@ import {
   postVmwareCredentials,
   deleteVmwareCredentials,
 } from "src/api/vmware-creds/vmwareCreds"
-import { TEN_SECONDS, THREE_SECONDS } from "src/constants"
+import { THREE_SECONDS, TWENTY_SECONDS } from "src/constants"
 import { MIGRATIONS_QUERY_KEY } from "src/hooks/api/useMigrationsQuery"
 import { useInterval } from "src/hooks/useInterval"
 import useParams from "src/hooks/useParams"
@@ -345,8 +345,8 @@ export default function MigrationFormDrawer({
         },
       })
 
-      // Wait for 10 seconds before fetching, as the VM statuses are not updated immediately
-      await new Promise(resolve => setTimeout(resolve, TEN_SECONDS))
+      // Wait for 20 seconds before fetching, as the VM statuses are not updated immediately
+      await new Promise(resolve => setTimeout(resolve, TWENTY_SECONDS))
       await fetchMigrationTemplate()
 
     } catch (err) {

--- a/ui/src/features/migration/VmsSelectionStep.tsx
+++ b/ui/src/features/migration/VmsSelectionStep.tsx
@@ -81,6 +81,7 @@ const columns: GridColDef[] = [
 const paginationModel = { page: 0, pageSize: 5 };
 
 const DISABLED_TOOLTIP_MESSAGE = "Turn on the VM to enable migration.";
+const NO_IP_TOOLTIP_MESSAGE = "VM is running but does not have an IP, try refreshing.";
 
 interface VmsSelectionStepProps {
   vms: VmData[];
@@ -122,7 +123,9 @@ export default function VmsSelectionStep({
               rowHeight={45}
               onRowSelectionModelChange={handleVmSelection}
               getRowId={(row) => row.name}
-              isRowSelectable={(params) => params.row.vmState === "running"}
+              isRowSelectable={(params) =>
+                params.row.vmState === "running" && !!params.row.ipAddress
+              }
               slots={{
                 toolbar: (props) => (
                   <CustomSearchToolbar
@@ -136,10 +139,18 @@ export default function VmsSelectionStep({
                   <CustomLoadingOverlay loadingMessage="Scanning for VMs" />
                 ),
                 row: (props) => {
-                  const isDisabled = props.row.vmState !== "running";
+                  const isVmStopped = props.row.vmState !== "running";
+                  const runningButNoIp = props.row.vmState === "running" && !props.row.ipAddress;
+
+                  const tooltipMessage = isVmStopped
+                    ? DISABLED_TOOLTIP_MESSAGE
+                    : runningButNoIp
+                      ? NO_IP_TOOLTIP_MESSAGE
+                      : "";
+
                   return (
                     <Tooltip
-                      title={isDisabled ? DISABLED_TOOLTIP_MESSAGE : ""}
+                      title={tooltipMessage}
                       followCursor
                     >
                       <span style={{ display: 'contents' }}>
@@ -154,7 +165,7 @@ export default function VmsSelectionStep({
               disableColumnMenu
               disableColumnResize
               getRowClassName={(params) =>
-                params.row.vmState !== "running" ? "disabled-row" : ""
+                params.row.vmState !== "running" || !params.row.ipAddress ? "disabled-row" : ""
               }
             />
           </Paper>

--- a/ui/src/features/migration/VmsSelectionStep.tsx
+++ b/ui/src/features/migration/VmsSelectionStep.tsx
@@ -81,7 +81,7 @@ const columns: GridColDef[] = [
 const paginationModel = { page: 0, pageSize: 5 };
 
 const DISABLED_TOOLTIP_MESSAGE = "Turn on the VM to enable migration.";
-const NO_IP_TOOLTIP_MESSAGE = "VM is running but does not have an IP, try refreshing.";
+const NO_IP_TOOLTIP_MESSAGE = "VM has not been assigned an IP address yet. Please refresh again.";
 
 interface VmsSelectionStepProps {
   vms: VmData[];


### PR DESCRIPTION

https://github.com/user-attachments/assets/91402e24-2e85-44a2-9cd4-553829817fcb

Changes ->

1. Make the dummy PATCH call for the migration template to trigger reconciliation in order to get latest VM details on manual refresh.
2. Added a 20-second forced timeout for every manual refresh, as it takes time for the latest VM details to reflect.
3. Disabled migration with a tooltip informing user to refresh, if the VM does not have an IP.