### PR TITLE
Fix GH workflow runs on release event

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -10,6 +10,10 @@ on:
   release:
     types:
       - created
+      - published
+      - edited
+      - released
+      - updated
   workflow_dispatch:
 
 

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -10,6 +10,8 @@ on:
   release:
     types:
       - created
+  workflow_dispatch:
+
 
 env:
   PACKER_VERSION: "latest"


### PR DESCRIPTION
- Fix GH workflow runs on release event add these events
```
- published
      - edited
      - released
      - updated
```

- allow manual workflow runs