### PR TITLE
More robust handling of vmmetadataexporter CLI args

### DIFF
--- a/vm_metadata_export/go.mod
+++ b/vm_metadata_export/go.mod
@@ -3,3 +3,8 @@ module vmmetadataexport
 go 1.22.5
 
 require github.com/vmware/govmomi v0.46.1
+
+require (
+        golang.org/x/sys v0.30.0
+        golang.org/x/term v0.29.0
+)

--- a/vm_metadata_export/go.sum
+++ b/vm_metadata_export/go.sum
@@ -10,5 +10,9 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vmware/govmomi v0.46.1 h1:RBoIR/vlGBYn+t7I1LFLLbDQSoBn+xN6gPYYMbFZ+80=
 github.com/vmware/govmomi v0.46.1/go.mod h1:uoLVU9zlXC4p4GmLVG+ZJmBC0Gn3Q7mytOJvi39OhxA=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.29.0 h1:L6pJp37ocefwRRtYPKSWOWzOtWSxVajvz2ldH/xi3iU=
+golang.org/x/term v0.29.0/go.mod h1:6bl4lRlvVuDgSf3179VpIxBF0o10JUpXWOnI7nErv7s=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/vm_metadata_export/main.go
+++ b/vm_metadata_export/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strconv"
 
+	"golang.org/x/term"
+
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/session/cache"
@@ -101,6 +103,28 @@ func main() {
 	host := flag.String("host", "", "vCenter host")
 
 	flag.Parse()
+
+    if *host == "" {
+            fmt.Println("A vCenter host must be specified.")
+            fmt.Println("Usage:")
+            flag.PrintDefaults()
+            return
+    }
+
+    if *username == "" {
+            fmt.Print("Enter vCenter username: ")
+            fmt.Scanln(username)
+    }
+
+    if *password == "" {
+            fmt.Print("Enter vCenter password: ")
+            bytePassword, err := term.ReadPassword(int(os.Stdin.Fd()))
+            fmt.Println()
+            if err != nil {
+                    fmt.Errorf("Error reading password: %w", err)
+            }
+            *password = string(bytePassword)
+    }
 
 	c, err := validateVCenter(*username, *password, *host, true)
 	if err != nil {


### PR DESCRIPTION
This change does more validation of the CLI args given to vmmetadataexporter to avoid panics. If host isn't given, it errors and exits. If username or password isn't given, it prompts the user to input them.

This handles a variety of scenarios around giving or not giving these three arguments. It is also a better solution around handling a password, since a CLI password arg gets leaked to the shell history and potentially other logs.

Fixes #165