### PR TITLE
Fix panic caused by OpenstackCreds CA cert check

### DIFF
--- a/k8s/migration/internal/controller/openstackcreds_controller.go
+++ b/k8s/migration/internal/controller/openstackcreds_controller.go
@@ -163,8 +163,8 @@ func validateOpenstackCreds(ctxlog logr.Logger, openstackcreds *vjailbreakv1alph
 		// Get the certificate for the Openstack endpoint
 		caCert, certerr := getCert(openstackCredential.AuthURL)
 		if certerr != nil {
-			ctxlog.Error(err, fmt.Sprintf("Error getting certificate for '%s'", openstackCredential.AuthURL))
-			return nil, err
+			ctxlog.Error(certerr, fmt.Sprintf("Error getting certificate for '%s'", openstackCredential.AuthURL))
+			return nil, certerr
 		}
 		// Logging the certificate
 		ctxlog.Info(fmt.Sprintf("Trusting certificate for '%s'", openstackCredential.AuthURL))


### PR DESCRIPTION
Currently, the check passes even when there is a failure to get certificate from the endpoint. This is due to a typo in error check, we end up checking for wrong err variable.

Because of it ends up with a nil pointer dereference panic in GetOpenstackInfo when it is called by migration controller to get details of volume etc.

Test plan:

1. Built a new controller image.
2. Uploaded a OpenStack RC file with HTTP auth URL and without OS_INSECURE.
3. The validation failed as expected.

![Screenshot 2025-02-28 at 16-44-33 vJailbreak](https://github.com/user-attachments/assets/3f6ee40d-c4cb-4f29-b845-cfbbafbcbfb5)

Fixes https://github.com/platform9/vjailbreak/issues/234