### PR TITLE
Support rollback for failed VM

### DIFF
--- a/v2v-helper/main.go
+++ b/v2v-helper/main.go
@@ -158,6 +158,8 @@ func main() {
 		if poweronerr != nil {
 			log.Fatalf("Failed to power on VM after migration failure: %s\n", poweronerr)
 		}
+
+		log.Printf("VM powered on after migration failure\n")
 	}
 
 	cancel()

--- a/v2v-helper/main.go
+++ b/v2v-helper/main.go
@@ -152,6 +152,12 @@ func main() {
 			migrationobj.EventReporter <- msg
 		}
 		log.Fatalf(msg)
+
+		// Power on the VM
+		poweronerr := vmops.VMPowerOn()
+		if poweronerr != nil {
+			log.Fatalf("Failed to power on VM after migration failure: %s\n", poweronerr)
+		}
 	}
 
 	cancel()


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #299 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements rollback support for failed VM migrations by adding VM power-on recovery functionality. The changes include updating the main application to trigger recovery steps and refining error messages. A new VMPowerOn function verifies and corrects VM power states when necessary, improving system resilience during failures.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>