### PR TITLE
fix migration status with random pod ref name

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -266,8 +266,9 @@ func (r *MigrationPlanReconciler) CreateMigration(ctx context.Context,
 				},
 			},
 			Spec: vjailbreakv1alpha1.MigrationSpec{
-				MigrationPlan:   migrationplan.Name,
-				VMName:          vm,
+				MigrationPlan: migrationplan.Name,
+				VMName:        vm,
+				// PodRef will be set in the migration controller
 				PodRef:          fmt.Sprintf("v2v-helper-%s", vmname),
 				InitiateCutover: !migrationplan.Spec.MigrationStrategy.AdminInitiatedCutOver,
 			},

--- a/k8s/migration/pkg/constants/constants.go
+++ b/k8s/migration/pkg/constants/constants.go
@@ -14,6 +14,7 @@ const (
 	VjailbreakNodeControllerName = "vjailbreaknode-controller"
 	OpenstackCredsControllerName = "openstackcreds-controller" //nolint:gosec // not a password string
 	VMwareCredsControllerName    = "vmwarecreds-controller"    //nolint:gosec // not a password string
+	MigrationControllerName      = "migration-controller"
 
 	K8sMasterNodeAnnotation = "node-role.kubernetes.io/control-plane"
 	NodeRoleMaster          = "master"

--- a/v2v-helper/main.go
+++ b/v2v-helper/main.go
@@ -44,28 +44,28 @@ func main() {
 	// Validate vCenter and Openstack connection
 	vcclient, err := vcenter.VCenterClientBuilder(ctx, vCenterUserName, vCenterPassword, vCenterURL, vCenterInsecure)
 	if err != nil {
-		log.Fatalf("Failed to validate vCenter connection: %v", err)
+		log.Fatalf("Failed to migrate VM: Failed to validate vCenter connection: %v", err)
 	}
 	log.Printf("Connected to vCenter: %s\n", vCenterURL)
 
 	// IMP: Must have one from OS_DOMAIN_NAME or OS_DOMAIN_ID only set in the rc file
 	openstackclients, err := openstack.NewOpenStackClients(openstackInsecure)
 	if err != nil {
-		log.Fatalf("Failed to validate OpenStack connection: %v", err)
+		log.Fatalf("Failed to migrate VM: Failed to validate OpenStack connection: %v", err)
 	}
 	log.Println("Connected to OpenStack")
 
 	// Get thumbprint
 	thumbprint, err := vcenter.GetThumbprint(vCenterURL)
 	if err != nil {
-		log.Fatalf("Failed to get thumbprint: %s\n", err)
+		log.Fatalf("Failed to migrate VM: Failed to get thumbprint: %s\n", err)
 	}
 	log.Printf("VCenter Thumbprint: %s\n", thumbprint)
 
 	// Retrieve the source VM
 	vmops, err := vm.VMOpsBuilder(ctx, *vcclient, migrationparams.SourceVMName)
 	if err != nil {
-		log.Fatalf("Failed to get source VM: %s\n", err)
+		log.Fatalf("Failed to migrate VM: Failed to get source VM: %v", err)
 	}
 
 	migrationobj := migrate.Migrate{
@@ -100,7 +100,7 @@ func main() {
 
 	eventReporter, err := reporter.NewReporter()
 	if err != nil {
-		log.Fatalf("Failed to create reporter: %s\n", err)
+		log.Fatalf("Failed to migrate VM: Failed to create reporter: %v", err)
 	}
 	eventReporter.UpdatePodEvents(ctx, migrationobj.EventReporter)
 	eventReporter.WatchPodLabels(ctx, migrationobj.PodLabelWatcher)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes a bug in the migration controller by properly assigning pod references, which resolves erratic migration status behavior. It enhances logging with updated context loggers and standardized error messages, introduces a new constant for consistent naming, and improves clarity in migration plan controller and v2v helper modules.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>