### PR TITLE
update astro action to use v4

### DIFF
--- a/.github/workflows/01_update_release_notes.yaml
+++ b/.github/workflows/01_update_release_notes.yaml
@@ -98,7 +98,7 @@ jobs:
             #If you are working on a repo with no initial release, you need to add a commit message.
             LAST_TAG=$RELEASE_TAG
           fi
-          sed -i "s|$LAST_TAG|$RELEASE_TAG|g" docs/src/content/docs/introduction/getting_started.md
+          sed -i "s|$LAST_TAG|$RELEASE_TAG|g" docs/src/content/docs/introduction/getting_started.mdx
           sed -i "s|$LAST_TAG|$RELEASE_TAG|g" docs/src/components/githubRelease.astro
           sed -i "s|$LAST_TAG|$RELEASE_TAG|g" docs/src/content/docs/index.mdx
 

--- a/.github/workflows/deploy_gh_page.yaml
+++ b/.github/workflows/deploy_gh_page.yaml
@@ -28,7 +28,7 @@ jobs:
         env:
           SITE_URL: ${{ env.SITE_URL }}
           BASE: ${{ github.event.repository.name }}
-        uses: withastro/action@v3
+        uses: withastro/action@v4
         with:
           path: docs/ # The root location of your Astro project inside the repository. (optional)
           # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR updates two GitHub workflow files: modifying the release notes workflow to reference the correct documentation file extension and upgrading the Astro action to version 4 in the deployment workflow. These changes enhance documentation reliability and improve the deployment process.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>