### PR TITLE
UI: Delete secret call

### DIFF
--- a/ui/src/api/helpers.ts
+++ b/ui/src/api/helpers.ts
@@ -149,21 +149,7 @@ export const deleteVMwareCredsWithSecretFlow = async (
   namespace = VJAILBREAK_DEFAULT_NAMESPACE
 ) => {
   try {
-    const credential = await getVmwareCredentials(credName, namespace)
-
     await deleteVmwareCredentials(credName, namespace)
-
-    if (credential?.spec?.secretRef?.name) {
-      await deleteSecret(credential.spec.secretRef.name, namespace)
-    } else {
-      const secretName = `${credName}-vmware-secret`
-      try {
-        await deleteSecret(secretName, namespace)
-      } catch (error) {
-        console.log(`No secret found with name ${secretName} : ${error}`)
-      }
-    }
-
     return { success: true }
   } catch (error) {
     console.error(`Error deleting VMware credential ${credName}:`, error)
@@ -177,21 +163,7 @@ export const deleteOpenStackCredsWithSecretFlow = async (
   namespace = VJAILBREAK_DEFAULT_NAMESPACE
 ) => {
   try {
-    const credential = await getOpenstackCredentials(credName, namespace)
-
     await deleteOpenstackCredentials(credName, namespace)
-
-    if (credential?.spec?.secretRef?.name) {
-      await deleteSecret(credential.spec.secretRef.name, namespace)
-    } else {
-      const secretName = `${credName}-openstack-secret`
-      try {
-        await deleteSecret(secretName, namespace)
-      } catch (error) {
-        console.log(`No secret found with name ${secretName} : ${error}`)
-      }
-    }
-
     return { success: true }
   } catch (error) {
     console.error(`Error deleting OpenStack credential ${credName}:`, error)

--- a/ui/src/api/helpers.ts
+++ b/ui/src/api/helpers.ts
@@ -12,7 +12,6 @@ import {
 } from "./network-mapping/networkMappings"
 import {
   deleteOpenstackCredentials,
-  getOpenstackCredentials,
   getOpenstackCredentialsList,
 } from "./openstack-creds/openstackCreds"
 import {
@@ -21,13 +20,12 @@ import {
 } from "./storage-mappings/storageMappings"
 import {
   deleteVmwareCredentials,
-  getVmwareCredentials,
+  
   getVmwareCredentialsList,
 } from "./vmware-creds/vmwareCreds"
 import {
   createOpenstackCredsSecret,
   createVMwareCredsSecret,
-  deleteSecret,
 } from "./secrets/secrets"
 import { createOpenstackCredsWithSecret } from "./openstack-creds/openstackCreds"
 import { createVMwareCredsWithSecret } from "./vmware-creds/vmwareCreds"

--- a/ui/src/api/secrets/secrets.ts
+++ b/ui/src/api/secrets/secrets.ts
@@ -161,20 +161,3 @@ export const getSecret = async (
   }
 }
 
-// Function to delete a Kubernetes secret
-export const deleteSecret = async (
-  name: string,
-  namespace = VJAILBREAK_DEFAULT_NAMESPACE
-) => {
-  const endpoint = `/api/v1/namespaces/${namespace}/secrets/${name}`
-
-  try {
-    const response = await axios.del({
-      endpoint,
-    })
-    return response
-  } catch (error) {
-    console.error(`Error deleting secret ${name}:`, error)
-    throw error
-  }
-}


### PR DESCRIPTION
**What this PR does / why we need it**:
UI shouldn't delete the secret, when we delete the creds respective secrets must be deleted by the backend itself.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #301 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR removes UI-based secret deletion logic from VMware and OpenStack credential deletion flows by removing outdated deletion calls from helper and secrets modules. The changes eliminate code that fetched credentials and conditionally deleted secrets, centralizing secret management exclusively in the backend instead of the UI, promoting more secure and consistent behavior.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>