### PR TITLE
Update the readme to point to the 'Getting Started'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A free and open-source tool that simplifies the migration of virtual machines fr
 * Select virtual machines to migrate
   * VM disks are converted from `vmdk` to `qcow2`
   * VMware Tools are uninstalled
-  * Virtual devices & drivers are installed
+  * Virtual devices & drivers are installed (for windows)
 * Post-migration health checks are performed
 
 ----
@@ -19,8 +19,7 @@ All documentation for vJailbreak can be found here: [Documentation](https://plat
 # Demonstration
 ## Video Demo
 
-https://github.com/user-attachments/assets/1f829fba-60dc-422e-b28d-ff79347a1d87
-
+[![vJailbreak demo](https://img.youtube.com/vi/seThilJ5ujM/0.jpg)](https://www.youtube.com/watch?v=seThilJ5ujM)
 ## Sample Screenshots
 
 ### Form to start a migration

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A free and open-source tool that simplifies the migration of virtual machines fr
 
 ----
 # Documentation
-All documentation for vJailbreak can be found here: [Documentation](https://platform9.github.io/vjailbreak/)
+All documentation for vJailbreak can be found here: [Documentation](https://platform9.github.io/vjailbreak/introduction/getting_started/)
 # Demonstration
 ## Video Demo
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -29,7 +29,7 @@ export default defineConfig({
 				//SocialIcons: './src/components/githubRelease.astro',
 			},
 			logo: {
-				src: './src/assets/classic_logo.jpeg',
+				src: './src/assets/platform9-logo.svg',
 				replacesTitle: true,
 			},
 			head: [

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -2,6 +2,10 @@
 title: vJailbreak
 description: A free and open-source tool that simplifies the migration of virtual machines from VMware to any OpenStack-compliant cloud.
 template: splash
+head:
+  - tag: script
+    content: |
+      window.location.href = 'https://platform9.com/vjailbreak/';
 hero:
   tagline: Effortless Open-Source VMware to OpenStack Migration
   image:


### PR DESCRIPTION
The updated URL to the actual getting started page instead of the landing page

 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request updates documentation and configuration files to reflect new branding and correct navigation. The astro.config.mjs file now uses an SVG logo instead of a JPEG, aligning with the updated platform9 identity. Additionally, a redirection script has been added to the documentation index to guide users to the actual 'Getting Started' page.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>