### PR TITLE
 ( release ) Create vmwaremachines batch wise of 100 parallely. 

### DIFF
--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -138,6 +138,9 @@ func (r *VMwareCredsReconciler) reconcileDelete(ctx context.Context, scope *scop
 		return ctrl.Result{}, errors.Wrap(err, "failed to delete associated secret")
 	}
 	controllerutil.RemoveFinalizer(scope.VMwareCreds, constants.VMwareCredsFinalizer)
+	if err := r.Update(ctx, scope.VMwareCreds); err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "failed to remove finalizer")
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -89,10 +89,6 @@ func (r *VMwareCredsReconciler) reconcileNormal(ctx context.Context, scope *scop
 	ctxlog.Info(fmt.Sprintf("Reconciling VMwareCreds '%s' object", scope.Name()))
 	controllerutil.AddFinalizer(scope.VMwareCreds, constants.VMwareCredsFinalizer)
 
-	if err := r.Update(ctx, scope.VMwareCreds); err != nil {
-		return ctrl.Result{}, errors.Wrap(err, "failed to add finalizer")
-	}
-
 	if _, err := utils.ValidateVMwareCreds(scope.VMwareCreds); err != nil {
 		// Update the status of the VMwareCreds object
 		scope.VMwareCreds.Status.VMwareValidationStatus = string(corev1.PodFailed)
@@ -138,9 +134,6 @@ func (r *VMwareCredsReconciler) reconcileDelete(ctx context.Context, scope *scop
 		return ctrl.Result{}, errors.Wrap(err, "failed to delete associated secret")
 	}
 	controllerutil.RemoveFinalizer(scope.VMwareCreds, constants.VMwareCredsFinalizer)
-	if err := r.Update(ctx, scope.VMwareCreds); err != nil {
-		return ctrl.Result{}, errors.Wrap(err, "failed to remove finalizer")
-	}
 	return ctrl.Result{}, nil
 }
 

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -89,6 +89,10 @@ func (r *VMwareCredsReconciler) reconcileNormal(ctx context.Context, scope *scop
 	ctxlog.Info(fmt.Sprintf("Reconciling VMwareCreds '%s' object", scope.Name()))
 	controllerutil.AddFinalizer(scope.VMwareCreds, constants.VMwareCredsFinalizer)
 
+	if err := r.Update(ctx, scope.VMwareCreds); err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "failed to add finalizer")
+	}
+
 	if _, err := utils.ValidateVMwareCreds(scope.VMwareCreds); err != nil {
 		// Update the status of the VMwareCreds object
 		scope.VMwareCreds.Status.VMwareValidationStatus = string(corev1.PodFailed)

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
@@ -622,13 +623,32 @@ func AppendUnique(slice []string, values ...string) []string {
 
 func CreateOrUpdateVMwareMachines(ctx context.Context, client client.Client,
 	vmwcreds *vjailbreakv1alpha1.VMwareCreds, vminfo []vjailbreakv1alpha1.VMInfo) error {
+
+	var wg sync.WaitGroup
 	for i := range vminfo {
-		vm := &vminfo[i] // Use a pointer
-		err := CreateOrUpdateVMwareMachine(ctx, client, vmwcreds, vm)
-		if err != nil {
-			return err
+		// Batch wise create or update 100 vms Parallely
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Don't panic on error
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Printf("Panic: %v\n", r)
+				}
+			}()
+			vm := &vminfo[i] // Use a pointer
+			err := CreateOrUpdateVMwareMachine(ctx, client, vmwcreds, vm)
+			if err != nil {
+				fmt.Printf("Error creating or updating VM '%s': %v\n", vm.Name, err)
+			}
+		}(i)
+		if i%100 == 0 {
+			// Wait for 100 vms to be created or updated
+			wg.Wait()
 		}
 	}
+	// Wait for all vms to be created or updated
+	wg.Wait()
 	return nil
 }
 

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -642,8 +642,8 @@ func CreateOrUpdateVMwareMachines(ctx context.Context, client client.Client,
 				fmt.Printf("Error creating or updating VM '%s': %v\n", vm.Name, err)
 			}
 		}(i)
-		if i%100 == 0 {
-			// Wait for 100 vms to be created or updated
+		if i%200 == 0 {
+			// Wait for 200 vms to be created or updated
 			wg.Wait()
 		}
 	}

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -642,10 +642,6 @@ func CreateOrUpdateVMwareMachines(ctx context.Context, client client.Client,
 				fmt.Printf("Error creating or updating VM '%s': %v\n", vm.Name, err)
 			}
 		}(i)
-		if i%200 == 0 {
-			// Wait for 200 vms to be created or updated
-			wg.Wait()
-		}
 	}
 	// Wait for all vms to be created or updated
 	wg.Wait()


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request optimizes VMware machine creation by implementing concurrent processing with Go's sync.WaitGroup, handling VMs in batches of 100 simultaneously. The implementation includes panic recovery and error logging in goroutines, with strategic wg.Wait calls to ensure completion before progression, significantly improving system efficiency.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>