### PR TITLE
backend: close scope in vmware creds controller 

### DIFF
--- a/k8s/migration/internal/controller/openstackcreds_controller.go
+++ b/k8s/migration/internal/controller/openstackcreds_controller.go
@@ -78,7 +78,7 @@ func (r *OpenstackCredsReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, err
 	}
 
-	// Always close the scope when exiting this function such that we can persist any Migration changes.
+	// Always close the scope when exiting this function such that we can persist any OpenstackCreds changes.
 	defer func() {
 		if err := scope.Close(); err != nil && reterr == nil {
 			reterr = err

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -129,6 +129,7 @@ func (r *VMwareCredsReconciler) reconcileNormal(ctx context.Context, scope *scop
 	return ctrl.Result{RequeueAfter: constants.VMwareCredsRequeueAfter}, nil
 }
 
+// nolint:unparam
 func (r *VMwareCredsReconciler) reconcileDelete(ctx context.Context, scope *scope.VMwareCredsScope) (ctrl.Result, error) {
 	ctxlog := log.FromContext(ctx)
 	ctxlog.Info(fmt.Sprintf("Reconciling deletion of VMwareCreds '%s' object", scope.Name()))

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -94,8 +94,6 @@ func (r *VMwareCredsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 func (r *VMwareCredsReconciler) reconcileNormal(ctx context.Context, scope *scope.VMwareCredsScope) (ctrl.Result, error) {
 	ctxlog := log.FromContext(ctx)
 	ctxlog.Info(fmt.Sprintf("Reconciling VMwareCreds '%s' object", scope.Name()))
-	controllerutil.AddFinalizer(scope.VMwareCreds, constants.VMwareCredsFinalizer)
-	ctxlog.Info("Adding finalizer to VMwareCreds", "name", scope.Name(), "finalizer", scope.VMwareCreds.Finalizers)
 
 	if _, err := utils.ValidateVMwareCreds(scope.VMwareCreds); err != nil {
 		// Update the status of the VMwareCreds object
@@ -115,6 +113,10 @@ func (r *VMwareCredsReconciler) reconcileNormal(ctx context.Context, scope *scop
 	if err := r.Status().Update(ctx, scope.VMwareCreds); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, fmt.Sprintf("Error updating status of VMwareCreds '%s'", scope.Name()))
 	}
+
+	controllerutil.AddFinalizer(scope.VMwareCreds, constants.VMwareCredsFinalizer)
+	ctxlog.Info("Adding finalizer to VMwareCreds", "name", scope.Name(), "finalizer", scope.VMwareCreds.Finalizers)
+
 	ctxlog.Info("Successfully validated VMwareCreds", "name", scope.Name(), "finalizers", scope.VMwareCreds.Finalizers)
 	vminfo, err := utils.GetAllVMs(ctx, scope.VMwareCreds, scope.VMwareCreds.Spec.DataCenter)
 	if err != nil {

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -79,7 +79,7 @@ func (r *VMwareCredsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	// Always close the scope when exiting this function such that we can persist any vmwarecreds changes.
 	defer func() {
-		if err := scope.Close(); err != nil && reterr == nil {
+		if err := scope.Close(ctx); err != nil && reterr == nil {
 			reterr = err
 		}
 	}()

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -115,7 +115,7 @@ func (r *VMwareCredsReconciler) reconcileNormal(ctx context.Context, scope *scop
 	if err := r.Status().Update(ctx, scope.VMwareCreds); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, fmt.Sprintf("Error updating status of VMwareCreds '%s'", scope.Name()))
 	}
-
+	ctxlog.Info("Successfully validated VMwareCreds", "name", scope.Name(), "finalizers", scope.VMwareCreds.Finalizers)
 	vminfo, err := utils.GetAllVMs(ctx, scope.VMwareCreds, scope.VMwareCreds.Spec.DataCenter)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, fmt.Sprintf("Error getting info of all VMs for VMwareCreds '%s'", scope.Name()))

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -56,7 +56,7 @@ type VMwareCredsReconciler struct {
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.18.4/pkg/reconcile
-func (r *VMwareCredsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *VMwareCredsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctxlog := log.FromContext(ctx)
 
 	// Get the VMwareCreds object
@@ -77,9 +77,10 @@ func (r *VMwareCredsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	// Always close the scope when exiting this function such that we can persist any vmwarecreds changes.
 	defer func() {
-		if err := scope.Close(); err != nil {
-			ctxlog.Error(err, fmt.Sprintf("Failed to close scope for VMWareCreds '%s'", vmwcreds.Name))
+		if err := scope.Close(); err != nil && reterr == nil {
+			reterr = err
 		}
 	}()
 

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -94,7 +94,7 @@ func (r *VMwareCredsReconciler) reconcileNormal(ctx context.Context, scope *scop
 	ctxlog := log.FromContext(ctx)
 	ctxlog.Info(fmt.Sprintf("Reconciling VMwareCreds '%s' object", scope.Name()))
 	controllerutil.AddFinalizer(scope.VMwareCreds, constants.VMwareCredsFinalizer)
-	ctxlog.Info("Adding finalizer to VMwareCreds", "name", scope.Name(), "finalizer", constants.VMwareCredsFinalizer)
+	ctxlog.Info("Adding finalizer to VMwareCreds", "name", scope.Name(), "finalizer", scope.VMwareCreds.Finalizers)
 
 	if _, err := utils.ValidateVMwareCreds(scope.VMwareCreds); err != nil {
 		// Update the status of the VMwareCreds object

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -84,7 +84,6 @@ func (r *VMwareCredsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			reterr = err
 		}
 	}()
-
 	if vmwcreds.ObjectMeta.DeletionTimestamp.IsZero() {
 		return r.reconcileNormal(ctx, scope)
 	}

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -94,6 +94,7 @@ func (r *VMwareCredsReconciler) reconcileNormal(ctx context.Context, scope *scop
 	ctxlog := log.FromContext(ctx)
 	ctxlog.Info(fmt.Sprintf("Reconciling VMwareCreds '%s' object", scope.Name()))
 	controllerutil.AddFinalizer(scope.VMwareCreds, constants.VMwareCredsFinalizer)
+	ctxlog.Info("Adding finalizer to VMwareCreds", "name", scope.Name(), "finalizer", constants.VMwareCredsFinalizer)
 
 	if _, err := utils.ValidateVMwareCreds(scope.VMwareCreds); err != nil {
 		// Update the status of the VMwareCreds object

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -77,6 +77,11 @@ func (r *VMwareCredsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	defer func() {
+		if err := scope.Close(); err != nil {
+			ctxlog.Error(err, fmt.Sprintf("Failed to close scope for VMWareCreds '%s'", vmwcreds.Name))
+		}
+	}()
 
 	if vmwcreds.ObjectMeta.DeletionTimestamp.IsZero() {
 		return r.reconcileNormal(ctx, scope)

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -79,6 +79,7 @@ func (r *VMwareCredsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	// Always close the scope when exiting this function such that we can persist any vmwarecreds changes.
 	defer func() {
+		ctxlog.Info("Closing scope for VMWareCreds", "name", scope.Name(), "finalizer", scope.VMwareCreds.Finalizers)
 		if err := scope.Close(ctx); err != nil && reterr == nil {
 			reterr = err
 		}

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -80,7 +80,7 @@ func (r *VMwareCredsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Always close the scope when exiting this function such that we can persist any vmwarecreds changes.
 	defer func() {
 		ctxlog.Info("Closing scope for VMWareCreds", "name", scope.Name(), "finalizer", scope.VMwareCreds.Finalizers)
-		if err := scope.Close(ctx); err != nil && reterr == nil {
+		if err := scope.Close(); err != nil && reterr == nil {
 			reterr = err
 		}
 	}()

--- a/k8s/migration/pkg/scope/vmwarecredsscope.go
+++ b/k8s/migration/pkg/scope/vmwarecredsscope.go
@@ -40,8 +40,8 @@ type VMwareCredsScope struct {
 }
 
 // Close closes the current scope persisting the VMwareCreds configuration and status.
-func (s *VMwareCredsScope) Close() error {
-	err := s.Client.Update(context.TODO(), s.VMwareCreds, &client.UpdateOptions{})
+func (s *VMwareCredsScope) Close(ctx context.Context) error {
+	err := s.Client.Update(ctx, s.VMwareCreds, &client.UpdateOptions{})
 	if err != nil {
 		return err
 	}

--- a/k8s/migration/pkg/scope/vmwarecredsscope.go
+++ b/k8s/migration/pkg/scope/vmwarecredsscope.go
@@ -41,7 +41,6 @@ type VMwareCredsScope struct {
 
 // Close closes the current scope persisting the VMwareCreds configuration and status.
 func (s *VMwareCredsScope) Close(ctx context.Context) error {
-	s.Logger.Info("Closing scope for VMwareCreds", "name", s.Name(), "finalizer", s.VMwareCreds.Finalizers)
 	err := s.Client.Update(ctx, s.VMwareCreds, &client.UpdateOptions{})
 	if err != nil {
 		return err

--- a/k8s/migration/pkg/scope/vmwarecredsscope.go
+++ b/k8s/migration/pkg/scope/vmwarecredsscope.go
@@ -41,6 +41,7 @@ type VMwareCredsScope struct {
 
 // Close closes the current scope persisting the VMwareCreds configuration and status.
 func (s *VMwareCredsScope) Close(ctx context.Context) error {
+	s.Logger.Info("Closing scope for VMwareCreds", "name", s.Name(), "finalizer", s.VMwareCreds.Finalizers)
 	err := s.Client.Update(ctx, s.VMwareCreds, &client.UpdateOptions{})
 	if err != nil {
 		return err

--- a/k8s/migration/pkg/scope/vmwarecredsscope.go
+++ b/k8s/migration/pkg/scope/vmwarecredsscope.go
@@ -40,8 +40,8 @@ type VMwareCredsScope struct {
 }
 
 // Close closes the current scope persisting the VMwareCreds configuration and status.
-func (s *VMwareCredsScope) Close(ctx context.Context) error {
-	err := s.Client.Update(ctx, s.VMwareCreds, &client.UpdateOptions{})
+func (s *VMwareCredsScope) Close() error {
+	err := s.Client.Update(context.TODO(), s.VMwareCreds, &client.UpdateOptions{})
 	if err != nil {
 		return err
 	}

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -623,10 +623,8 @@ func AppendUnique(slice []string, values ...string) []string {
 
 func CreateOrUpdateVMwareMachines(ctx context.Context, client client.Client,
 	vmwcreds *vjailbreakv1alpha1.VMwareCreds, vminfo []vjailbreakv1alpha1.VMInfo) error {
-
 	var wg sync.WaitGroup
 	for i := range vminfo {
-		// Batch wise create or update 100 vms Parallely
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances controller functionality by updating both OpenstackCreds and VMwareCreds controllers with improved context-aware scope closure behavior and error handling. It standardizes the code by updating function signatures, removing unnecessary context parameters, eliminating redundant finalizer addition, and adding deferred blocks for scope closure error management, resulting in more reliable and clearer controller logic.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>