### PR TITLE
Proxy env injection via configmap

### DIFF
--- a/image_builder/configs/daemonset.yaml
+++ b/image_builder/configs/daemonset.yaml
@@ -20,6 +20,8 @@ spec:
           image: alpine:latest
           securityContext:
             privileged: true
+            runAsUser: 0
+            runAsGroup: 0
           ports:
             - containerPort: 873
           volumeMounts:
@@ -71,3 +73,7 @@ spec:
           hostPath:
             path: /home/ubuntu/vmware-vix-disklib-distrib
             type: DirectoryOrCreate
+        - name: env
+          hostPath:
+            type: Directory
+            path: /etc/pf9/env

--- a/image_builder/configs/env
+++ b/image_builder/configs/env
@@ -1,0 +1,4 @@
+# This file is used to set environment variables to be injected into v2v-helper 
+# User can populate this file via cloud-init
+
+

--- a/image_builder/scripts/install.sh
+++ b/image_builder/scripts/install.sh
@@ -123,6 +123,12 @@ EOF
 
   log "Rsync daemon started successfully."
 
+  # Create a config map from env file. 
+  kubectl create configmap pf9-env --from-file=/etc/pf9/env
+  check_command "Creating config map from env file"
+
+  log "Config map created successfully."
+
 else
   log "Setting up K3s Worker..."
 

--- a/image_builder/scripts/install.sh
+++ b/image_builder/scripts/install.sh
@@ -124,7 +124,7 @@ EOF
   log "Rsync daemon started successfully."
 
   # Create a config map from env file. 
-  kubectl create configmap pf9-env --from-file=/etc/pf9/env
+  kubectl create configmap pf9-env -n migration-system --from-file=/etc/pf9/env
   check_command "Creating config map from env file"
 
   log "Config map created successfully."

--- a/image_builder/vjailbreak-image.pkr.hcl
+++ b/image_builder/vjailbreak-image.pkr.hcl
@@ -63,6 +63,11 @@ build {
     destination = "/tmp/rsyncd.conf"
   }
 
+  provisioner "file" {
+    source      = "${path.root}/configs/env"
+    destination = "/tmp/env"
+  }
+
   provisioner "shell" {
     inline = [
       "sudo curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3",
@@ -74,9 +79,11 @@ build {
       "sudo mv /tmp/yamls /etc/pf9/yamls",
       "sudo mv /tmp/rsyncd.conf /etc/pf9/rsyncd.conf",
       "sudo mv /tmp/daemonset.yaml /etc/pf9/yamls/daemonset.yaml",
+      "sudo mv /tmp/env /etc/pf9/env",
       "sudo chmod +x /etc/pf9/install.sh",
       "sudo chown root:root /etc/pf9/k3s.env",
       "sudo chmod 644 /etc/pf9/k3s.env",
+      "sudo chmod 644 /etc/pf9/env",
       "echo '@reboot root /etc/pf9/install.sh' | sudo tee -a /etc/crontab"
     ]
   }

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -371,6 +371,13 @@ func (r *MigrationPlanReconciler) CreateJob(ctx context.Context,
 											},
 										},
 									},
+									{
+										ConfigMapRef: &corev1.ConfigMapEnvSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "pf9-env",
+											},
+										},
+									},
 								},
 								VolumeMounts: []corev1.VolumeMount{
 									{


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/bda859ff-c553-4293-a8aa-ca2ba4a4c939" />

From now on for any env which needs to be injected to v2v helper pod, can be done via this.  user is expected to populate /etc/pf9/env via cloud-init, and the script creates a config-map. In case later the user wants to add some env, he would have to recreate the configmap with the updated values.  
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enables proxy environment variable injection via a configmap by enhancing multiple components. The daemonset configuration, install script, and packer build file have been updated to support the new environment injection mechanism. Additionally, the migration controller now references the newly created configmap, ensuring a cohesive implementation.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>