### PR TITLE
Backend: Change ownership of /home/ubuntu/vmware-vix-disklib-distrib to ubuntu:ubuntu via init container. 

### DIFF
--- a/image_builder/configs/daemonset.yaml
+++ b/image_builder/configs/daemonset.yaml
@@ -15,6 +15,20 @@ spec:
         app: sync-daemon
     spec:
       hostNetwork: true
+      initContainers:
+        - name: fix-perms
+          image: alpine:latest
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Fixing permissions on /home/ubuntu/vmware-vix-disklib-distrib..."
+              chown -R 1000:1000 /home/ubuntu/vmware-vix-disklib-distrib
+          volumeMounts:
+            - name: vmwarelib
+              mountPath: /home/ubuntu/vmware-vix-disklib-distrib
       containers:
         - name: sync-container
           image: alpine:latest
@@ -33,17 +47,13 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              # Install required packages
-              apk add --no-cache rsync coreutils grep;
-              # Extract variables from environment file
+              apk add --no-cache rsync coreutils grep
               IS_MASTER=$(grep -E '^export IS_MASTER=' /etc/pf9/k3s.env | cut -d'=' -f2)
               MASTER_IP=$(grep -E '^export MASTER_IP=' /etc/pf9/k3s.env | cut -d'=' -f2)
               if [ "$IS_MASTER" = "true" ]; then
                 echo "Master node detected. IP: $MASTER_IP"
-                # Start rsync daemon using the pre-created config file
                 echo "Starting rsync daemon..."
                 rsync --daemon --config=/etc/pf9/rsyncd.conf --no-detach
-                # Verify rsync daemon is running
                 if ps aux | grep rsync | grep -v grep; then
                   echo "rsync daemon is running."
                 else
@@ -61,7 +71,7 @@ spec:
                   else
                     echo "Sync failed. Retrying in 60 seconds..."
                   fi
-                  sleep 20  # Retry every 60 seconds
+                  sleep 20
                 done
               fi
       volumes:
@@ -72,7 +82,7 @@ spec:
         - name: vmwarelib
           hostPath:
             path: /home/ubuntu/vmware-vix-disklib-distrib
-            type: Directory
+            type: DirectoryOrCreate
         - name: env
           hostPath:
             type: Directory

--- a/image_builder/configs/daemonset.yaml
+++ b/image_builder/configs/daemonset.yaml
@@ -72,7 +72,7 @@ spec:
         - name: vmwarelib
           hostPath:
             path: /home/ubuntu/vmware-vix-disklib-distrib
-            type: DirectoryOrCreate
+            type: Directory
         - name: env
           hostPath:
             type: Directory


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #373

root@vjail-break:/home/ubuntu# ls -lrt
total 72928
-rwx------ 1 root   root      11913 Apr 10 06:58 get_helm.sh
-rw-r--r-- 1 ubuntu ubuntu 74646016 Apr 10 15:05 vmware-vix-disklib-distrib.tar
-rw-r--r-- 1 root   root       5051 Apr 22 04:49 script.sh
-rw-r--r-- 1 root   root       2966 Apr 22 05:30 daemonset.yaml
drwxr-xr-x 2 ubuntu ubuntu     4096 Apr 22 05:31 vmware-vix-disklib-distrib

directory is getting created and owner is ubuntu 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances daemonset configuration by adding an init container that fixes file ownership issues for vmware-vix-disklib-distrib directory. It ensures proper ubuntu:ubuntu permissions and streamlines the rsync daemon command block by removing redundant comments and optimizing command arguments, resulting in improved backend security and robustness.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>