### PR TITLE
Doc: Inject any environment variables required by user into v2v-helper pod. 

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -54,6 +54,7 @@ export default defineConfig({
 						{ label: 'Troubleshooting', slug: 'guides/troubleshooting' },
 						{ label: 'Building', slug: 'guides/building' },
 						{ label: 'Using APIs', slug: 'guides/using_apis' },
+						{ label: 'Injecting Custom Environment Variables', slug: 'guides/injecting_custom_env' },
 					],
 				},
 				{

--- a/docs/src/content/docs/guides/injecting_custom_env.md
+++ b/docs/src/content/docs/guides/injecting_custom_env.md
@@ -18,6 +18,14 @@ This update enables environment variable injection for the `v2v-helper` pod usin
    ```bash
    kubectl create configmap pf9-env --from-env-file=/etc/pf9/env -n <namespace>
 
+# Example
+   If you want proxy variables to be injected into the v2v-helper pod, you can add the following to the `/etc/pf9/env` file:
+   ```bash
+   http_proxy=http://<proxy-server>:<proxy-port>
+   https_proxy=http://<proxy-server>:<proxy-port>
+   no_proxy=localhost,127.0.0.1
+   ```
+   now this will be picked up by the v2v-helper pod and the proxy variables will be available in the pod and it would be respected by the v2v-helper pod.
 
 ## Injecting Environment Variables Post-Provisioning
 

--- a/docs/src/content/docs/guides/injecting_custom_env.md
+++ b/docs/src/content/docs/guides/injecting_custom_env.md
@@ -40,13 +40,20 @@ If you would like to inject environment variables after the vjailbreak VM has be
    ```bash
    kubectl delete configmap pf9-env -n migration-system
    ```
+2. **Populate the `/etc/pf9/env` file with whatever env variables needed**
 
-2. **Create a new ConfigMap**
+   ```bash
+   echo "http_proxy=http://<proxy-server>:<proxy-port>" >> /etc/pf9/env
+   echo "https_proxy=http://<proxy-server>:<proxy-port>" >> /etc/pf9/env
+   echo "no_proxy=localhost,127.0.0.1" >> /etc/pf9/env
+   ```
+
+3. **Create a new ConfigMap**
 
    ```bash
    kubectl create configmap pf9-env --from-env-file=/etc/pf9/env -n migration-system
    ```
-3. **Trigger a new migration for the envs to be reflected in the pod**
+4. **Trigger a new migration for the envs to be reflected in the pod**
 
     Trigger via UI or via api. 
 

--- a/docs/src/content/docs/guides/injecting_custom_env.md
+++ b/docs/src/content/docs/guides/injecting_custom_env.md
@@ -16,16 +16,21 @@ This update enables environment variable injection for the `v2v-helper` pod usin
    A helper script or manual command reads `/etc/pf9/env` and creates a Kubernetes ConfigMap named `pf9-env`.
    This is done while the vjailbreak VM is being provisioned.
    ```bash
-   kubectl create configmap pf9-env --from-env-file=/etc/pf9/env -n <namespace>
+   kubectl create configmap pf9-env --from-env-file=/etc/pf9/env -n migration-system
 
 # Example
-   If you want proxy variables to be injected into the v2v-helper pod, you can add the following to the `/etc/pf9/env` file:
+   If you want proxy variables to be injected into the v2v-helper pod, you can add the following to the `/etc/pf9/env` file via the cloud-init script:
    ```bash
    http_proxy=http://<proxy-server>:<proxy-port>
    https_proxy=http://<proxy-server>:<proxy-port>
    no_proxy=localhost,127.0.0.1
    ```
-   now this will be picked up by the v2v-helper pod and the proxy variables will be available in the pod and it would be respected by the v2v-helper pod.
+   You can either populate the `/etc/pf9/env` file via cloud-init or manually.
+
+   If done manually please follow the steps mentioned in [Injecting Environment Variables Post-Provisioning](#injecting-environment-variables-post-provisioning):
+   
+
+   Now this will be picked up by the v2v-helper pod and the proxy variables will be available in the pod and it would be respected by the v2v-helper pod.
 
 ## Injecting Environment Variables Post-Provisioning
 
@@ -33,13 +38,13 @@ If you would like to inject environment variables after the vjailbreak VM has be
 1. **Delete the existing ConfigMap**
 
    ```bash
-   kubectl delete configmap pf9-env -n <namespace>
+   kubectl delete configmap pf9-env -n migration-system
    ```
 
 2. **Create a new ConfigMap**
 
    ```bash
-   kubectl create configmap pf9-env --from-env-file=/etc/pf9/env -n <namespace>
+   kubectl create configmap pf9-env --from-env-file=/etc/pf9/env -n migration-system
    ```
 3. **Trigger a new migration for the envs to be reflected in the pod**
 

--- a/docs/src/content/docs/guides/injecting_custom_env.md
+++ b/docs/src/content/docs/guides/injecting_custom_env.md
@@ -13,7 +13,7 @@ This update enables environment variable injection for the `v2v-helper` pod usin
 
 2. **ConfigMap creation from /etc/pf9/env**
 
-   A helper script or manual command reads `/etc/pf9/env` and creates a Kubernetes ConfigMap named `v2v-env-config`.
+   A helper script or manual command reads `/etc/pf9/env` and creates a Kubernetes ConfigMap named `pf9-env`.
    This is done while the vjailbreak VM is being provisioned.
    ```bash
    kubectl create configmap pf9-env --from-env-file=/etc/pf9/env -n <namespace>

--- a/docs/src/content/docs/guides/injecting_custom_env.md
+++ b/docs/src/content/docs/guides/injecting_custom_env.md
@@ -1,0 +1,33 @@
+# v2v-helper Environment Variable Injection via ConfigMap
+
+## Summary
+
+This update enables environment variable injection for the `v2v-helper` pod using a Kubernetes ConfigMap. Multiple components, including the DaemonSet configuration, installation script, and Packer build file, have been enhanced to support this new environment injection mechanism. The `migration-controller` now references the created ConfigMap, ensuring a consistent and manageable configuration workflow.
+
+## How It Works
+
+1. **Cloud-init populates environment variables**
+
+   Users must provide environment variables in the `/etc/pf9/env` file during provisioning, typically using a cloud-init script.
+
+2. **ConfigMap creation from /etc/pf9/env**
+
+   A helper script or manual command reads `/etc/pf9/env` and creates a Kubernetes ConfigMap named `v2v-env-config`.
+   This is done while the vjailbreak VM is being provisioned.
+   ```bash
+   kubectl create configmap pf9-env --from-env-file=/etc/pf9/env -n <namespace>
+
+
+## What to do when you need to inject custom environment variables after the vjailbreak VM is provisioned
+
+1. **Create a new ConfigMap**
+
+   ```bash
+   kubectl create configmap pf9-env --from-env-file=/etc/pf9/env -n <namespace>
+   ```
+2. **Trigger a new migration for the envs to be reflected in the pod**
+
+    Trigger via UI or via api. 
+
+    
+   

--- a/docs/src/content/docs/guides/injecting_custom_env.md
+++ b/docs/src/content/docs/guides/injecting_custom_env.md
@@ -3,7 +3,7 @@ title: "v2v-helper Environment Variable Injection via ConfigMap"
 description: "Enabling environment variable injection for the v2v-helper pod using a Kubernetes ConfigMap"
 ---
 
-This update enables environment variable injection for the `v2v-helper` pod using a Kubernetes ConfigMap. Multiple components, including the DaemonSet configuration, installation script, and Packer build file, have been enhanced to support this new environment injection mechanism. The `migration-controller` now references the created ConfigMap, ensuring a consistent and manageable configuration workflow.
+Injecting environment variables into the v2v-helper pod is a feature that allows users to inject environment variables into the v2v-helper pod using a Kubernetes ConfigMap. 
 
 ## How It Works
 

--- a/docs/src/content/docs/guides/injecting_custom_env.md
+++ b/docs/src/content/docs/guides/injecting_custom_env.md
@@ -1,7 +1,7 @@
 ---
 title: "v2v-helper Environment Variable Injection via ConfigMap"
+description: "Enabling environment variable injection for the v2v-helper pod using a Kubernetes ConfigMap"
 ---
-## Summary
 
 This update enables environment variable injection for the `v2v-helper` pod using a Kubernetes ConfigMap. Multiple components, including the DaemonSet configuration, installation script, and Packer build file, have been enhanced to support this new environment injection mechanism. The `migration-controller` now references the created ConfigMap, ensuring a consistent and manageable configuration workflow.
 

--- a/docs/src/content/docs/guides/injecting_custom_env.md
+++ b/docs/src/content/docs/guides/injecting_custom_env.md
@@ -1,5 +1,6 @@
-# v2v-helper Environment Variable Injection via ConfigMap
-
+---
+title: "v2v-helper Environment Variable Injection via ConfigMap"
+---
 ## Summary
 
 This update enables environment variable injection for the `v2v-helper` pod using a Kubernetes ConfigMap. Multiple components, including the DaemonSet configuration, installation script, and Packer build file, have been enhanced to support this new environment injection mechanism. The `migration-controller` now references the created ConfigMap, ensuring a consistent and manageable configuration workflow.
@@ -18,14 +19,21 @@ This update enables environment variable injection for the `v2v-helper` pod usin
    kubectl create configmap pf9-env --from-env-file=/etc/pf9/env -n <namespace>
 
 
-## What to do when you need to inject custom environment variables after the vjailbreak VM is provisioned
+## Injecting Environment Variables Post-Provisioning
 
-1. **Create a new ConfigMap**
+If you would like to inject environment variables after the vjailbreak VM has been provisioned, follow these steps:
+1. **Delete the existing ConfigMap**
+
+   ```bash
+   kubectl delete configmap pf9-env -n <namespace>
+   ```
+
+2. **Create a new ConfigMap**
 
    ```bash
    kubectl create configmap pf9-env --from-env-file=/etc/pf9/env -n <namespace>
    ```
-2. **Trigger a new migration for the envs to be reflected in the pod**
+3. **Trigger a new migration for the envs to be reflected in the pod**
 
     Trigger via UI or via api. 
 

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -772,7 +772,7 @@ func (r *MigrationPlanReconciler) TriggerMigration(ctx context.Context,
 			return fmt.Errorf("failed to create Firstboot ConfigMap for VM %s: %w", vm, err)
 		}
 
-		if err := r.validateVDDKPresence(ctx, migrationobj, ctxlog); err != nil {
+		if err = r.validateVDDKPresence(ctx, migrationobj, ctxlog); err != nil {
 			return err
 		}
 

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -771,7 +771,7 @@ func (r *MigrationPlanReconciler) TriggerMigration(ctx context.Context,
 		if err != nil {
 			return fmt.Errorf("failed to create Firstboot ConfigMap for VM %s: %w", vm, err)
 		}
-
+		//nolint:gocritic // err is already declared above
 		if err = r.validateVDDKPresence(ctx, migrationobj, ctxlog); err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request introduces a feature to inject environment variables into the v2v-helper pod through a dedicated env file and updated configuration scripts. It enhances credentials handling by requiring and validating datacenter fields, while improving overall configuration management and strengthening the migration credentials process.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>