### PR TITLE
ensure correct permissions on shared vmwarelib directory for rsync ac…

### DIFF
--- a/image_builder/configs/daemonset.yaml
+++ b/image_builder/configs/daemonset.yaml
@@ -26,6 +26,7 @@ spec:
             - |
               echo "Fixing permissions on /home/ubuntu/vmware-vix-disklib-distrib..."
               chown -R 1000:1000 /home/ubuntu/vmware-vix-disklib-distrib
+              chmod 755 /home/ubuntu/vmware-vix-disklib-distrib
           volumeMounts:
             - name: vmwarelib
               mountPath: /home/ubuntu/vmware-vix-disklib-distrib

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -868,6 +868,12 @@ func (r *MigrationPlanReconciler) validateVDDKPresence(
 
 	// Clear previous VDDKCheck condition if directory is valid
 	cleanedConditions := []corev1.PodCondition{}
+	for _, c := range migrationobj.Status.Conditions {
+		if c.Type != "VDDKCheck" {
+			cleanedConditions = append(cleanedConditions, c)
+		}
+	}
+
 	migrationobj.Status.Conditions = cleanedConditions
 	migrationobj.Status.Phase = vjailbreakv1alpha1.MigrationPhasePending // Or your next logical phase
 

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -875,7 +875,6 @@ func (r *MigrationPlanReconciler) validateVDDKPresence(
 	}
 
 	migrationobj.Status.Conditions = cleanedConditions
-	migrationobj.Status.Phase = vjailbreakv1alpha1.MigrationPhasePending // Or your next logical phase
 
 	if err = r.Status().Update(ctx, migrationobj); err != nil {
 		return errors.Wrap(err, "failed to update migration status after validating VDDK presence")


### PR DESCRIPTION
…cess

**What this PR does / why we need it**:
The sync DaemonSet runs as root, but the shared /home/ubuntu/vmware-vix-disklib-distrib
directory is owned by 'ubuntu'. Previously, restricted permissions prevented
rsync from writing to this directory on worker nodes. This commit adds a chmod 755
to ensure the directory is accessible by the DaemonSet across all nodes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes a permissions issue affecting rsync access to the shared vmwarelib directory by adding a chmod 755 command to the DaemonSet configuration. The change ensures proper directory permissions across worker nodes, improving system reliability and file synchronization capabilities.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>