### PR TITLE
added counter for incremental copy

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -303,6 +303,7 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 					// 11. Copy Changed Blocks over
 					done = false
 					migobj.logMessage("Copying changed blocks")
+					migobj.logMessage(fmt.Sprintf("Syncing Changed blocks %d/20", incrementalCopyCount))
 
 					err = nbdops[idx].CopyChangedBlocks(ctx, changedAreas, vminfo.VMDisks[idx].Path)
 					if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances the logging mechanism in v2v-helper/migrate/migrate.go by adding an incremental counter to block copying operations. The improvement provides better visibility into migration progress, making the incremental copy process more transparent and easier to debug during VM disk migrations.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>