### PR TITLE
counter output for incremental copy

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -309,6 +309,7 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 						return vminfo, fmt.Errorf("failed to copy changed blocks: %s", err)
 					}
 					migobj.logMessage("Finished copying changed blocks")
+					migobj.logMessage(fmt.Sprintf("Syncing Changed blocks %d/20", incrementalCopyCount))
 				}
 			}
 			if final {

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -309,7 +309,7 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 						return vminfo, fmt.Errorf("failed to copy changed blocks: %s", err)
 					}
 					migobj.logMessage("Finished copying changed blocks")
-					migobj.logMessage(fmt.Sprintf("Syncing Changed blocks %d/20", incrementalCopyCount))
+					migobj.logMessage(fmt.Sprintf("Syncing Changed blocks [%d/20]", incrementalCopyCount))
 				}
 			}
 			if final {


### PR DESCRIPTION
**What this PR does / why we need it**: added counter output for incremental copy

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #85 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances the logging mechanism in the migration process by adding a counter output for incremental block copying in 'v2v-helper/migrate/migrate.go'. This improvement provides better visibility into migration progress and strengthens the system's diagnostic capabilities during block copy operations.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>