### PR TITLE
v2v-helper: Add check if subnet exists to avoid panic. 

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -590,6 +590,10 @@ func (migobj *Migrate) CreateTargetInstance(vminfo vm.VMInfo, flavorId string) e
 				return fmt.Errorf("failed to get network: %s", err)
 			}
 
+			if network == nil {
+				return fmt.Errorf("network not found")
+			}
+
 			ip := ""
 			if len(vminfo.Mac) != len(vminfo.IPs) {
 				ip = ""

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -358,6 +358,11 @@ func (osclient *OpenStackClients) CreatePort(network *networks.Network, mac, ip,
 	}
 	log.Printf("Port with MAC address %s does not exist, creating new port\n", mac)
 	log.Println("Trying with same IP address: ", ip)
+
+	// Check if subnet is valid to avoid panic.
+	if len(network.Subnets) == 0 {
+		return nil, fmt.Errorf("no subnets found for network: %s", network.ID)
+	}
 	port, err := ports.Create(osclient.NetworkingClient, ports.CreateOpts{
 		Name:       "port-" + vmname,
 		NetworkID:  network.ID,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #220 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances error handling in network operations by adding nil network checks in the migration file and verifying subnet existence in OpenStack operations. These improvements prevent potential panics and provide clearer error messages, ultimately increasing the robustness of network-related functionalities.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>