### PR TITLE
enable openstack re-auth

### DIFF
--- a/v2v-helper/openstack/openstackops.go
+++ b/v2v-helper/openstack/openstackops.go
@@ -70,6 +70,7 @@ func validateOpenStack(insecure bool) (*utils.OpenStackClients, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OpenStack auth options: %s", err)
 	}
+	opts.AllowReauth = true
 	providerClient, err := openstack.NewClient(opts.IdentityEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create provider client: %s", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #455 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enables re-authentication in OpenStack operations by setting the opts.AllowReauth flag to true. The change improves client resilience during transient failures by allowing automatic reauthentication. It maintains consistent error handling while enhancing operational stability, addressing issue #455.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>