### PR TITLE
do a guest shutdown before VM is powered off

### DIFF
--- a/v2v-helper/vm/vmops_mock.go
+++ b/v2v-helper/vm/vmops_mock.go
@@ -166,6 +166,20 @@ func (mr *MockVMOperationsMockRecorder) UpdateDiskInfo(vminfo interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDiskInfo", reflect.TypeOf((*MockVMOperations)(nil).UpdateDiskInfo), vminfo)
 }
 
+// VMGuestShutdown mocks base method.
+func (m *MockVMOperations) VMGuestShutdown() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VMGuestShutdown")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VMGuestShutdown indicates an expected call of VMGuestShutdown.
+func (mr *MockVMOperationsMockRecorder) VMGuestShutdown() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VMGuestShutdown", reflect.TypeOf((*MockVMOperations)(nil).VMGuestShutdown))
+}
+
 // VMPowerOff mocks base method.
 func (m *MockVMOperations) VMPowerOff() error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #412 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements a graceful guest OS shutdown mechanism before VM power-off, with timeout and fallback to forced shutdown. The implementation includes VMGuestShutdown function that checks power state, initiates shutdown, and waits for completion. Mock implementations were updated to support unit testing of the new functionality.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>