### PR TITLE
guest shutdown before power off

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ artifacts/*
 image_builder/deploy/*
 k8s/migration/dist/*
 k8s/migration/vendor/*
-k8s/migration/manager
 v2v-helper/vendor/*
 v2v-helper/manager
 pkg/vpwned/vendor/*

--- a/k8s/migration/internal/controller/bmconfig_controller.go
+++ b/k8s/migration/internal/controller/bmconfig_controller.go
@@ -109,9 +109,9 @@ func (r *BMConfigReconciler) reconcileNormal(ctx context.Context, scope *scope.B
 		bmConfig.Status.ValidationStatus = string(corev1.PodFailed)
 		bmConfig.Status.ValidationMessage = fmt.Sprintf("Error connecting to MAAS: %s", err)
 		if updateErr := r.Status().Update(ctx, bmConfig); updateErr != nil {
-			return ctrl.Result{}, errors.Wrap(err,
-				errors.Wrap(updateErr, fmt.Sprintf("Error updating status of BMConfig '%s'",
-					bmConfig.Name)).Error())
+			return ctrl.Result{}, errors.Wrap(
+				errors.Wrap(updateErr, fmt.Sprintf("Error updating status of BMConfig '%s'", bmConfig.Name)),
+				err.Error())
 		}
 		return ctrl.Result{RequeueAfter: constants.CredsRequeueAfter}, err
 	}
@@ -120,9 +120,8 @@ func (r *BMConfigReconciler) reconcileNormal(ctx context.Context, scope *scope.B
 	bmConfig.Status.ValidationStatus = string(corev1.PodSucceeded)
 	bmConfig.Status.ValidationMessage = "Successfully connected to MAAS"
 	if updateErr := r.Status().Update(ctx, bmConfig); updateErr != nil {
-		return ctrl.Result{}, errors.Wrap(err,
-			errors.Wrap(updateErr, fmt.Sprintf("Error updating status of BMConfig '%s'",
-				bmConfig.Name)).Error())
+		return ctrl.Result{}, errors.Wrap(
+			updateErr, fmt.Sprintf("Error updating status of BMConfig '%s'", bmConfig.Name))
 	}
 
 	ctxlog.Info("Successfully connected to MAAS", "bmconfig", bmConfig.Name)

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -101,9 +101,9 @@ func (r *VMwareCredsReconciler) reconcileNormal(ctx context.Context, scope *scop
 		scope.VMwareCreds.Status.VMwareValidationStatus = string(corev1.PodFailed)
 		scope.VMwareCreds.Status.VMwareValidationMessage = fmt.Sprintf("Error validating VMwareCreds '%s': %s", scope.Name(), err)
 		if updateErr := r.Status().Update(ctx, scope.VMwareCreds); updateErr != nil {
-			return ctrl.Result{}, errors.Wrap(err,
-				errors.Wrap(updateErr, fmt.Sprintf("Error updating status of VMwareCreds '%s'",
-					scope.Name())).Error())
+			return ctrl.Result{}, errors.Wrap(
+				errors.Wrap(updateErr, fmt.Sprintf("Error updating status of VMwareCreds '%s'", scope.Name())),
+				err.Error())
 		}
 		return ctrl.Result{}, errors.Wrap(err, fmt.Sprintf("Error validating VMwareCreds '%s'", scope.Name()))
 	}

--- a/v2v-helper/vm/vmops_mock.go
+++ b/v2v-helper/vm/vmops_mock.go
@@ -166,6 +166,20 @@ func (mr *MockVMOperationsMockRecorder) UpdateDiskInfo(vminfo interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDiskInfo", reflect.TypeOf((*MockVMOperations)(nil).UpdateDiskInfo), vminfo)
 }
 
+// VMGuestShutdown mocks base method.
+func (m *MockVMOperations) VMGuestShutdown() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VMGuestShutdown")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VMGuestShutdown indicates an expected call of VMGuestShutdown.
+func (mr *MockVMOperationsMockRecorder) VMGuestShutdown() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VMGuestShutdown", reflect.TypeOf((*MockVMOperations)(nil).VMGuestShutdown))
+}
+
 // VMPowerOff mocks base method.
 func (m *MockVMOperations) VMPowerOff() error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
fixes #412 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances error handling in BMConfig and VMwareCreds controllers while adding a new VMGuestShutdown feature for graceful VM shutdowns with power-off fallback. The changes improve error reporting clarity during status updates and include mock module updates to support comprehensive testing of the new functionality.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>