### PR TITLE
save migration debug logs at hostPath '/var/log/pf9' ( release )

### DIFF
--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -1661,8 +1661,8 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: docker.io/omkardespande7/vjailbreak-controller:vpwned6
-        imagePullPolicy: Always
+        image: quay.io/platform9/vjailbreak-controller:v0.1.12
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -222,6 +222,12 @@ spec:
                       description: Human-readable message indicating details about
                         last transition.
                       type: string
+                    observedGeneration:
+                      description: |-
+                        If set, this represents the .metadata.generation that the pod condition was set based upon.
+                        This is an alpha field. Enable PodObservedGenerationTracking to be able to use this field.
+                      format: int64
+                      type: integer
                     reason:
                       description: Unique, one-word, CamelCase reason for the condition's
                         last transition.
@@ -1655,8 +1661,8 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: quay.io/platform9/vjailbreak-controller:v0.1.8
-        imagePullPolicy: IfNotPresent
+        image: docker.io/omkardespande7/vjailbreak-controller:vpwned6
+        imagePullPolicy: Always
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1674,14 +1680,11 @@ spec:
           requests:
             cpu: 200m
             memory: 256Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
         volumeMounts:
         - mountPath: /etc/pf9/k3s
           name: master-token
+        - mountPath: /home/ubuntu
+          name: vddk
       hostNetwork: true
       securityContext:
         runAsGroup: 0
@@ -1693,3 +1696,7 @@ spec:
           path: /var/lib/rancher/k3s/server
           type: Directory
         name: master-token
+      - hostPath:
+          path: /home/ubuntu
+          type: Directory
+        name: vddk

--- a/image_builder/configs/rsyncd.conf
+++ b/image_builder/configs/rsyncd.conf
@@ -13,3 +13,11 @@ timeout = 300
     read only = no
     write only = no
     list = yes
+
+
+[logs]
+    path = /var/log/pf9
+    comment = Platform9 Logs
+    read only = yes
+    write only = no
+    list = yes

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrations.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrations.yaml
@@ -92,6 +92,12 @@ spec:
                       description: Human-readable message indicating details about
                         last transition.
                       type: string
+                    observedGeneration:
+                      description: |-
+                        If set, this represents the .metadata.generation that the pod condition was set based upon.
+                        This is an alpha field. Enable PodObservedGenerationTracking to be able to use this field.
+                      format: int64
+                      type: integer
                     reason:
                       description: Unique, one-word, CamelCase reason for the condition's
                         last transition.

--- a/k8s/migration/config/manager/kustomization.yaml
+++ b/k8s/migration/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/platform9/vjailbreak-controller
-  newTag: v0.1.8
+  newTag: vpwned6

--- a/k8s/migration/config/manager/kustomization.yaml
+++ b/k8s/migration/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/platform9/vjailbreak-controller
-  newTag: vpwned6
+  newTag: v0.1.12

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -399,6 +399,10 @@ func (r *MigrationPlanReconciler) CreateJob(ctx context.Context,
 										Name:      "firstboot",
 										MountPath: "/home/fedora/scripts",
 									},
+									{
+										Name:      "logs",
+										MountPath: "/var/log/pf9",
+									},
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
@@ -440,6 +444,15 @@ func (r *MigrationPlanReconciler) CreateJob(ctx context.Context,
 										LocalObjectReference: corev1.LocalObjectReference{
 											Name: firstbootconfigMapName,
 										},
+									},
+								},
+							},
+							{
+								Name: "logs",
+								VolumeSource: corev1.VolumeSource{
+									HostPath: &corev1.HostPathVolumeSource{
+										Path: "/var/log/pf9",
+										Type: utils.NewHostPathType("DirectoryOrCreate"),
 									},
 								},
 							},

--- a/v2v-helper/main.go
+++ b/v2v-helper/main.go
@@ -23,6 +23,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // Ensure context is canceled when we exit
 
+	utils.WriteToLogFile(fmt.Sprintf("-----	 Migration started at %s for VM %s -----", time.Now().Format(time.RFC3339), os.Getenv("SOURCE_VM_NAME")))
 	// Initialize error reporter early
 	eventReporter, err := reporter.NewReporter()
 	if err != nil {
@@ -146,5 +147,5 @@ func main() {
 		handleError(msg)
 	}
 
-	utils.PrintLog("Migration completed successfully")
+	utils.PrintLog(fmt.Sprintf("----- Migration completed successfully at %s for VM %s -----", time.Now().Format(time.RFC3339), migrationparams.SourceVMName))
 }

--- a/v2v-helper/main.go
+++ b/v2v-helper/main.go
@@ -5,7 +5,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -27,7 +26,7 @@ func main() {
 	// Initialize error reporter early
 	eventReporter, err := reporter.NewReporter()
 	if err != nil {
-		log.Printf("Failed to create reporter: %v", err)
+		utils.PrintLog(fmt.Sprintf("Failed to create reporter: %v", err))
 		return
 	}
 
@@ -49,7 +48,7 @@ func main() {
 			// Wait for the reporter to process the message
 			<-ackChan
 		}
-		log.Print(msg)
+		utils.PrintLog(msg)
 		os.Exit(1)
 	}
 
@@ -80,21 +79,21 @@ func main() {
 	if err != nil {
 		handleError(fmt.Sprintf("Failed to validate vCenter connection: %v", err))
 	}
-	log.Printf("Connected to vCenter: %s\n", vCenterURL)
+	utils.PrintLog(fmt.Sprintf("Connected to vCenter: %s\n", vCenterURL))
 
 	// Validate OpenStack connection
 	openstackclients, err := openstack.NewOpenStackClients(openstackInsecure)
 	if err != nil {
 		handleError(fmt.Sprintf("Failed to validate OpenStack connection: %v", err))
 	}
-	log.Println("Connected to OpenStack")
+	utils.PrintLog("Connected to OpenStack")
 
 	// Get thumbprint
 	thumbprint, err := vcenter.GetThumbprint(vCenterURL)
 	if err != nil {
 		handleError(fmt.Sprintf("Failed to get thumbprint: %s", err))
 	}
-	log.Printf("VCenter Thumbprint: %s\n", thumbprint)
+	utils.PrintLog(fmt.Sprintf("VCenter Thumbprint: %s\n", thumbprint))
 
 	// Retrieve the source VM
 	vmops, err := vm.VMOpsBuilder(ctx, *vcclient, migrationparams.SourceVMName)
@@ -141,12 +140,11 @@ func main() {
 		if powerOnErr != nil {
 			msg += fmt.Sprintf("\nAlso Failed to power on VM after migration failure: %v", powerOnErr)
 		} else {
-			msg += "\nVM was powered on after migration failure"
+			msg += fmt.Sprintf("\nVM %s was powered on after migration failure", migrationparams.SourceVMName)
 		}
 
 		handleError(msg)
 	}
 
-	log.Println("Migration completed successfully")
-	return
+	utils.PrintLog("Migration completed successfully")
 }

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -63,7 +63,7 @@ type MigrationTimes struct {
 }
 
 func (migobj *Migrate) logMessage(message string) {
-	log.Println(message)
+	utils.PrintLog(message)
 	if migobj.InPod {
 		migobj.EventReporter <- message
 	}
@@ -145,7 +145,7 @@ func (migobj *Migrate) DeleteAllVolumes(vminfo vm.VMInfo) error {
 		if err != nil {
 			return fmt.Errorf("failed to delete volume: %s", err)
 		}
-		log.Printf("Volume %s deleted\n", vmdisk.Name)
+		utils.PrintLog(fmt.Sprintf("Volume %s deleted\n", vmdisk.Name))
 	}
 	return nil
 }
@@ -175,12 +175,12 @@ func (migobj *Migrate) EnableCBTWrapper() error {
 		if err != nil {
 			return fmt.Errorf("failed to take snapshot of source VM: %s", err)
 		}
-		log.Println("Snapshot created successfully")
+		utils.PrintLog("Snapshot created successfully")
 		err = vmops.DeleteSnapshot("tmp-snap")
 		if err != nil {
 			return fmt.Errorf("failed to delete snapshot of source VM: %s", err)
 		}
-		fmt.Println("Snapshot deleted successfully")
+		utils.PrintLog("Snapshot deleted successfully")
 		migobj.logMessage("CBT enabled successfully")
 	}
 	return nil
@@ -227,7 +227,7 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 		}
 	}
 
-	log.Println("Starting NBD server")
+	utils.PrintLog("Starting NBD server")
 	err := vmops.TakeSnapshot(constants.MigrationSnapshotName)
 	if err != nil {
 		return vminfo, fmt.Errorf("failed to take snapshot of source VM: %s", err)
@@ -287,7 +287,7 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 				} else {
 					migobj.logMessage(fmt.Sprintf("Disk %d: Blocks have Changed.", idx))
 
-					log.Println("Restarting NBD server")
+					utils.PrintLog("Restarting NBD server")
 					err = nbdops[idx].StopNBDServer()
 					if err != nil {
 						return vminfo, fmt.Errorf("failed to stop NBD server: %s", err)
@@ -316,7 +316,7 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 				break
 			}
 			if done || incrementalCopyCount > 20 {
-				log.Println("Shutting down source VM and performing final copy")
+				utils.PrintLog("Shutting down source VM and performing final copy")
 				if err := migobj.WaitforCutover(); err != nil {
 					return vminfo, fmt.Errorf("failed to start VM Cutover: %s", err)
 				}
@@ -357,7 +357,7 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 		return vminfo, errors.Wrap(err, "Failed to detach all volumes from VM")
 	}
 
-	log.Println("Stopping NBD server")
+	utils.PrintLog("Stopping NBD server")
 	for _, nbdserver := range nbdops {
 		err = nbdserver.StopNBDServer()
 		if err != nil {
@@ -365,7 +365,7 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 		}
 	}
 
-	log.Println("Deleting migration snapshot")
+	utils.PrintLog("Deleting migration snapshot")
 	err = vmops.DeleteSnapshot(constants.MigrationSnapshotName)
 	if err != nil {
 		return vminfo, fmt.Errorf("failed to delete snapshot of source VM: %s", err)
@@ -410,7 +410,7 @@ func (migobj *Migrate) ConvertVolumes(ctx context.Context, vminfo vm.VMInfo) err
 		// check if individual disks are bootable
 		ans, err := virtv2v.RunCommandInGuest(vminfo.VMDisks[idx].Path, getBootCommand, false)
 		if err != nil {
-			log.Printf("Error running '%s'. Error: '%s', Output: %s\n", getBootCommand, err, strings.TrimSpace(ans))
+			utils.PrintLog(fmt.Sprintf("Error running '%s'. Error: '%s', Output: %s\n", getBootCommand, err, strings.TrimSpace(ans)))
 			continue
 		}
 
@@ -418,7 +418,7 @@ func (migobj *Migrate) ConvertVolumes(ctx context.Context, vminfo vm.VMInfo) err
 			// OS is not installed on this disk
 			continue
 		}
-		log.Printf("Output from '%s' - '%s'\n", getBootCommand, strings.TrimSpace(ans))
+		utils.PrintLog(fmt.Sprintf("Output from '%s' - '%s'\n", getBootCommand, strings.TrimSpace(ans)))
 
 		osPath = strings.TrimSpace(ans)
 		bootVolumeIndex = idx
@@ -451,7 +451,7 @@ func (migobj *Migrate) ConvertVolumes(ctx context.Context, vminfo vm.VMInfo) err
 			}
 		}
 		osDetected := strings.ToLower(strings.TrimSpace(osRelease))
-		fmt.Printf("OS detected by guestfish: %s", osDetected)
+		utils.PrintLog(fmt.Sprintf("OS detected by guestfish: %s", osDetected))
 		// Supported OSes
 		supportedOS := []string{
 			"redhat",
@@ -479,16 +479,16 @@ func (migobj *Migrate) ConvertVolumes(ctx context.Context, vminfo vm.VMInfo) err
 		if !supported {
 			return fmt.Errorf("unsupported OS detected by guestfish: %s", osDetected)
 		}
-		log.Println("OS compatibility check passed")
+		utils.PrintLog("OS compatibility check passed")
 
 	} else if vminfo.OSType == "windows" {
-		log.Println("OS compatibility check passed")
+		utils.PrintLog("OS compatibility check passed")
 	} else {
 		return fmt.Errorf("unsupported OS type: %s", vminfo.OSType)
 	}
 
 	// save the index of bootVolume
-	log.Printf("Setting up boot volume as: %s", vminfo.VMDisks[bootVolumeIndex].Name)
+	utils.PrintLog(fmt.Sprintf("Setting up boot volume as: %s", vminfo.VMDisks[bootVolumeIndex].Name))
 	vminfo.VMDisks[bootVolumeIndex].Boot = true
 	if migobj.Convert {
 		firstbootscripts := []string{}
@@ -528,12 +528,12 @@ func (migobj *Migrate) ConvertVolumes(ctx context.Context, vminfo vm.VMInfo) err
 	if vminfo.OSType == "linux" {
 		if strings.Contains(osRelease, "ubuntu") {
 			// Add Wildcard Netplan
-			log.Println("Adding wildcard netplan")
+			utils.PrintLog("Adding wildcard netplan")
 			err := virtv2v.AddWildcardNetplan(vminfo.VMDisks, useSingleDisk, vminfo.VMDisks[bootVolumeIndex].Path)
 			if err != nil {
 				return fmt.Errorf("failed to add wildcard netplan: %s", err)
 			}
-			log.Println("Wildcard netplan added successfully")
+			utils.PrintLog("Wildcard netplan added successfully")
 		}
 	}
 	err = migobj.DetachAllVolumes(vminfo)
@@ -556,7 +556,7 @@ func (migobj *Migrate) CreateTargetInstance(vminfo vm.VMInfo, flavorId string) e
 		if err != nil {
 			return fmt.Errorf("failed to get closest OpenStack flavor: %s", err)
 		}
-		log.Printf("Closest OpenStack flavor: %s: CPU: %dvCPUs\tMemory: %dMB\n", flavor.Name, flavor.VCPUs, flavor.RAM)
+		utils.PrintLog(fmt.Sprintf("Closest OpenStack flavor: %s: CPU: %dvCPUs\tMemory: %dMB\n", flavor.Name, flavor.VCPUs, flavor.RAM))
 	} else {
 		flavor, err = openstackops.GetFlavor(flavorId)
 		if err != nil {
@@ -605,7 +605,7 @@ func (migobj *Migrate) CreateTargetInstance(vminfo vm.VMInfo, flavorId string) e
 				return fmt.Errorf("failed to create port group: %s", err)
 			}
 
-			log.Printf("Port created successfully: MAC:%s IP:%s\n", port.MACAddress, port.FixedIPs[0].IPAddress)
+			utils.PrintLog(fmt.Sprintf("Port created successfully: MAC:%s IP:%s\n", port.MACAddress, port.FixedIPs[0].IPAddress))
 			networkids = append(networkids, network.ID)
 			portids = append(portids, port.ID)
 			ipaddresses = append(ipaddresses, port.FixedIPs[0].IPAddress)
@@ -620,7 +620,7 @@ func (migobj *Migrate) CreateTargetInstance(vminfo vm.VMInfo, flavorId string) e
 
 	// Wait for VM to become active
 	for i := 0; i < constants.MaxVMActiveCheckCount; i++ {
-		log.Printf("Waiting for VM to become active: %d/%d retries\n", i+1, constants.MaxVMActiveCheckCount)
+		utils.PrintLog(fmt.Sprintf("Waiting for VM to become active: %d/%d retries\n", i+1, constants.MaxVMActiveCheckCount))
 		active, err := openstackops.WaitUntilVMActive(newVM.ID)
 		if err != nil {
 			return fmt.Errorf("failed to wait for VM to become active: %s", err)
@@ -808,17 +808,9 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 		return errors.Wrap(err, "CBT Failure")
 	}
 
-	debug, err := utils.IsDebug(ctx, migobj.K8sClient)
-	if err != nil {
-		return errors.Wrap(err, "Failed to get debug value")
-	}
-
 	// Create NBD servers
 	for range vminfo.VMDisks {
-		migobj.Nbdops = append(migobj.Nbdops, &nbd.NBDServer{
-			// Add debug
-			Debug: debug,
-		})
+		migobj.Nbdops = append(migobj.Nbdops, &nbd.NBDServer{})
 	}
 
 	// Live Replicate Disks
@@ -857,15 +849,15 @@ func (migobj *Migrate) cleanup(vminfo vm.VMInfo, message string) error {
 	migobj.logMessage(fmt.Sprintf("%s. Trying to perform cleanup", message))
 	err := migobj.DetachAllVolumes(vminfo)
 	if err != nil {
-		log.Printf("Failed to detach all volumes from VM: %s\n", err)
+		utils.PrintLog(fmt.Sprintf("Failed to detach all volumes from VM: %s\n", err))
 	}
 	err = migobj.DeleteAllVolumes(vminfo)
 	if err != nil {
-		log.Printf("Failed to delete all volumes from host: %s\n", err)
+		utils.PrintLog(fmt.Sprintf("Failed to delete all volumes from host: %s\n", err))
 	}
 	err = migobj.VMops.DeleteSnapshot(constants.MigrationSnapshotName)
 	if err != nil {
-		log.Printf("Failed to delete snapshot of source VM: %s\n", err)
+		utils.PrintLog(fmt.Sprintf("Failed to delete snapshot of source VM: %s\n", err))
 		return errors.Wrap(err, fmt.Sprintf("Failed to delete snapshot of source VM: %s\n", err))
 	}
 	return nil

--- a/v2v-helper/pkg/constants/constants.go
+++ b/v2v-helper/pkg/constants/constants.go
@@ -29,6 +29,8 @@ systemctl enable --now serial-getty@ttyS0.service`
 	MigrationSystemNamespace = "migration-system"
 	TrueString               = "true"
 
+	LogsDir = "/var/log/pf9"
+
 	EventMessageConvertingDisk                    = "Converting disk"
 	EventMessageWaitingForCutOverStart            = "Waiting for VM Cutover start time"
 	EventMessageCopyingChangedBlocksWithIteration = "Copying changed blocks"

--- a/v2v-helper/pkg/utils/nbdutils.go
+++ b/v2v-helper/pkg/utils/nbdutils.go
@@ -1,6 +1,12 @@
 package utils
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/platform9/vjailbreak/v2v-helper/pkg/constants"
+)
 
 func ParseFraction(text string) (int, int, error) {
 	var numerator, denominator int
@@ -9,4 +15,23 @@ func ParseFraction(text string) (int, int, error) {
 		return 0, 0, err
 	}
 	return numerator, denominator, nil
+}
+
+func AddDebugOutputToFile(cmd *exec.Cmd) {
+	migrationName, err := GetMigrationObjectName()
+	if err == nil {
+		// Ensure logs directory exists
+		if err := os.MkdirAll(constants.LogsDir, 0755); err == nil {
+			// Create log file with the migration object name
+			logFilePath := fmt.Sprintf("%s/%s.log", constants.LogsDir, migrationName)
+			logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+			if err == nil {
+				PrintLog(fmt.Sprintf("Debug mode enabled. Command output will be logged to %s", logFilePath))
+
+				// Set stdout/stderr to only write to the log file, not to kubectl logs
+				cmd.Stdout = logFile
+				cmd.Stderr = logFile
+			}
+		}
+	}
 }

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -148,6 +147,7 @@ func (osclient *OpenStackClients) AttachVolumeToVM(volumeID string) error {
 			DeleteOnTermination: false,
 		}).Extract()
 		if err == nil || strings.Contains(err.Error(), "already attached") {
+			err = nil
 			break
 		}
 		time.Sleep(5 * time.Second) // Wait for 5 seconds before checking again
@@ -156,7 +156,7 @@ func (osclient *OpenStackClients) AttachVolumeToVM(volumeID string) error {
 		return fmt.Errorf("failed to attach volume to VM: %s", err)
 	}
 
-	log.Println("Waiting for volume attachment")
+	PrintLog("Waiting for volume attachment")
 	err = osclient.WaitForVolumeAttachment(volumeID)
 	if err != nil {
 		return fmt.Errorf("failed to wait for volume attachment: %s", err)
@@ -278,7 +278,7 @@ func (osclient *OpenStackClients) GetClosestFlavour(cpu int32, memory int32) (*f
 		return nil, fmt.Errorf("failed to extract all flavors: %s", err)
 	}
 
-	log.Println("Current requirements:", cpu, "CPUs and", memory, "MB of RAM")
+	PrintLog(fmt.Sprintf("Current requirements: %d CPUs and %d MB of RAM", cpu, memory))
 
 	bestFlavor := new(flavors.Flavor)
 	bestFlavor.VCPUs = constants.MaxCPU
@@ -293,10 +293,10 @@ func (osclient *OpenStackClients) GetClosestFlavour(cpu int32, memory int32) (*f
 	}
 
 	if bestFlavor.VCPUs != constants.MaxCPU {
-		log.Printf("The best flavor is:\nName: %s, ID: %s, RAM: %dMB, VCPUs: %d, Disk: %dGB\n",
-			bestFlavor.Name, bestFlavor.ID, bestFlavor.RAM, bestFlavor.VCPUs, bestFlavor.Disk)
+		PrintLog(fmt.Sprintf("The best flavor is:\nName: %s, ID: %s, RAM: %dMB, VCPUs: %d, Disk: %dGB\n",
+			bestFlavor.Name, bestFlavor.ID, bestFlavor.RAM, bestFlavor.VCPUs, bestFlavor.Disk))
 	} else {
-		log.Println("No suitable flavor found.")
+		PrintLog("No suitable flavor found.")
 		return nil, fmt.Errorf("no suitable flavor found for %d vCPUs and %d MB RAM", cpu, memory)
 	}
 
@@ -354,12 +354,11 @@ func (osclient *OpenStackClients) CreatePort(network *networks.Network, mac, ip,
 
 	for _, port := range portList {
 		if port.MACAddress == mac {
-			log.Printf("Port with MAC address %s already exists, ID: %s\n", mac, port.ID)
+			PrintLog(fmt.Sprintf("Port with MAC address %s already exists, ID: %s", mac, port.ID))
 			return &port, nil
 		}
 	}
-	log.Printf("Port with MAC address %s does not exist, creating new port\n", mac)
-	log.Println("Trying with same IP address: ", ip)
+	PrintLog(fmt.Sprintf("Port with MAC address %s does not exist, creating new port, trying with same IP address: %s", mac, ip))
 
 	// Check if subnet is valid to avoid panic.
 	if len(network.Subnets) == 0 {
@@ -378,7 +377,7 @@ func (osclient *OpenStackClients) CreatePort(network *networks.Network, mac, ip,
 	}).Extract()
 	if err != nil {
 		// return nil, err
-		log.Printf("Could Not Use IP: %s, using DHCP to create Port", ip)
+		PrintLog(fmt.Sprintf("Could Not Use IP: %s, using DHCP to create Port", ip))
 		port, err = ports.Create(osclient.NetworkingClient, ports.CreateOpts{
 			Name:       "port-" + vmname,
 			NetworkID:  network.ID,
@@ -388,7 +387,7 @@ func (osclient *OpenStackClients) CreatePort(network *networks.Network, mac, ip,
 			return nil, err
 		}
 	}
-	log.Println("Port created with ID: ", port.ID)
+	PrintLog(fmt.Sprintf("Port created with ID: %s", port.ID))
 	return port, nil
 }
 
@@ -450,9 +449,7 @@ func (osclient *OpenStackClients) CreateVM(flavor *flavors.Flavor, networkIDs, p
 		return nil, fmt.Errorf("failed to wait for server to become active: %s", err)
 	}
 
-	log.Println("Server created with ID: ", server.ID)
-
-	log.Println("Attaching Additional Disks")
+	PrintLog(fmt.Sprintf("Server created with ID: %s, Attaching Additional Disks", server.ID))
 
 	for _, disk := range append(vminfo.VMDisks[:bootableDiskIndex], vminfo.VMDisks[bootableDiskIndex+1:]...) {
 		_, err := volumeattach.Create(osclient.ComputeClient, server.ID, volumeattach.CreateOpts{

--- a/v2v-helper/reporter/reporter.go
+++ b/v2v-helper/reporter/reporter.go
@@ -5,11 +5,11 @@ package reporter
 import (
 	"context"
 	"fmt"
-	"log"
 	"math/rand"
 	"os"
 	"strings"
 
+	"github.com/platform9/vjailbreak/v2v-helper/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -90,7 +90,7 @@ func (r *Reporter) GetPod() error {
 func NewReporter() (*Reporter, error) {
 	r := &Reporter{}
 	if IsRunningInPod() {
-		log.Println("Running in pod")
+		utils.PrintLog("Running in pod")
 		if err := r.GetPodName(); err != nil {
 			return nil, err
 		}
@@ -104,7 +104,7 @@ func NewReporter() (*Reporter, error) {
 			return nil, err
 		}
 	} else {
-		log.Println("Not running in pod")
+		utils.PrintLog("Not running in pod")
 		os.Exit(1)
 	}
 	return r, nil
@@ -197,11 +197,11 @@ func (r *Reporter) UpdatePodEvents(ctx context.Context, ch <-chan string, ackCha
 					return
 				}
 				if err := r.UpdateProgress(msg); err != nil {
-					log.Println(err)
+					utils.PrintLog(err.Error())
 				}
 				if !strings.Contains(msg, "Progress:") {
 					if err := r.CreateKubernetesEvent(ctx, corev1.EventTypeNormal, "Migration", msg); err != nil {
-						log.Println(err)
+						utils.PrintLog(err.Error())
 					}
 				}
 				// Sending acknowledgment that the message has been processed


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #444
Fixes #396
Fixes #96
Fixes #111 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances migration debugging capabilities by implementing consistent logging utilities at '/var/log/pf9' and updating container image configurations. It refactors modules to use a unified PrintLog mechanism while changing image registry and pull policies to ensure correct controller versions, improving log consistency and configuration stability.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 5
</div>