### PR TITLE
Add check from nova side also for volume dettach 

### DIFF
--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -40,7 +40,7 @@ RUN dnf install -y \
     nbdkit \
     nbdkit-vddk-plugin \
     libnbd \
-    virt-v2v \
+    virt-v2v-2.7.13 \
     virtio-win && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -833,10 +833,6 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 		return errors.Wrap(err, "failed to live replicate disks")
 	}
 
-	// Sleep to simulate the detach taking time
-	migobj.logMessage("Sleeping for 30 seconds to simulate detach taking time")
-	time.Sleep(30 * time.Second)
-
 	// Convert the Boot Disk to raw format
 	err = migobj.ConvertVolumes(ctx, vminfo)
 	if err != nil {

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -123,7 +123,6 @@ func (migobj *Migrate) DetachVolume(disk vm.VMDisk) error {
 func (migobj *Migrate) DetachAllVolumes(vminfo vm.VMInfo) error {
 	openstackops := migobj.Openstackclients
 	for _, vmdisk := range vminfo.VMDisks {
-
 		if err := openstackops.DetachVolumeFromVM(vmdisk.OpenstackVol.ID); err != nil && !strings.Contains(err.Error(), "is not attached to volume") {
 			return errors.Wrap(err, "failed to detach volume from VM")
 		}
@@ -356,11 +355,6 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 	err = migobj.DetachAllVolumes(vminfo)
 	if err != nil {
 		return vminfo, errors.Wrap(err, "Failed to detach all volumes from VM")
-	}
-
-	err = migobj.DetachAllVolumes(vminfo)
-	if err != nil {
-		return vminfo, errors.Wrap(err, "Second dettach Failed to detach all volumes from VM")
 	}
 
 	log.Println("Stopping NBD server")
@@ -838,6 +832,10 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 		}
 		return errors.Wrap(err, "failed to live replicate disks")
 	}
+
+	// Sleep to simulate the detach taking time
+	migobj.logMessage("Sleeping for 30 seconds to simulate detach taking time")
+	time.Sleep(30 * time.Second)
 
 	// Convert the Boot Disk to raw format
 	err = migobj.ConvertVolumes(ctx, vminfo)

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -358,6 +358,11 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 		return vminfo, errors.Wrap(err, "Failed to detach all volumes from VM")
 	}
 
+	err = migobj.DetachAllVolumes(vminfo)
+	if err != nil {
+		return vminfo, errors.Wrap(err, "Second dettach Failed to detach all volumes from VM")
+	}
+
 	log.Println("Stopping NBD server")
 	for _, nbdserver := range nbdops {
 		err = nbdserver.StopNBDServer()

--- a/v2v-helper/pkg/constants/constants.go
+++ b/v2v-helper/pkg/constants/constants.go
@@ -17,7 +17,7 @@ systemctl enable --now serial-getty@ttyS0.service`
 	MaxRAM = 9999999
 
 	// Number of intervals to wait for the volume to become available
-	MaxIntervalCount = 12
+	MaxIntervalCount = 36
 
 	InspectOSCommand         = "inspect-os"
 	LSBootCommand            = "ls /boot"

--- a/v2v-helper/pkg/constants/constants.go
+++ b/v2v-helper/pkg/constants/constants.go
@@ -17,7 +17,7 @@ systemctl enable --now serial-getty@ttyS0.service`
 	MaxRAM = 9999999
 
 	// Number of intervals to wait for the volume to become available
-	MaxIntervalCount = 36
+	MaxIntervalCount = 60
 
 	InspectOSCommand         = "inspect-os"
 	LSBootCommand            = "ls /boot"

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -132,6 +132,30 @@ func (osclient *OpenStackClients) WaitForVolume(volumeID string) error {
 		if volume.Status == "available" && len(volume.Attachments) == 0 {
 			return nil
 		}
+
+		instanceID, err := GetCurrentInstanceUUID()
+		if err != nil {
+			return fmt.Errorf("failed to get instance ID: %s", err)
+		}
+
+		// Check if the volume is available from nova side as well
+		server, err := servers.Get(osclient.ComputeClient, instanceID).Extract()
+		if err != nil {
+			return fmt.Errorf("failed to get server: %s", err)
+		}
+
+		// get the attachments from the server
+		found := false
+		attachments := server.AttachedVolumes
+		for _, attachment := range attachments {
+			if attachment.ID == volumeID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil
+		}
 		time.Sleep(5 * time.Second) // Wait for 5 seconds before checking again
 	}
 	return fmt.Errorf("volume did not become available within %d seconds", constants.MaxIntervalCount*5)
@@ -142,6 +166,21 @@ func (osclient *OpenStackClients) AttachVolumeToVM(volumeID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get instance ID: %s", err)
 	}
+
+	// Log the volume status before attach
+	volume, err := volumes.Get(osclient.BlockStorageClient, volumeID).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to get volume: %s", err)
+	}
+	log.Printf("Volume status before attach: %s", volume.Status)
+
+	// Log the server status before attach
+	server, err := servers.Get(osclient.ComputeClient, instanceID).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to get server: %s", err)
+	}
+	log.Printf("Server status before attach: %s", server.AttachedVolumes)
+
 	for i := 0; i < constants.MaxIntervalCount; i++ {
 		_, err = volumeattach.Create(osclient.ComputeClient, instanceID, volumeattach.CreateOpts{
 			VolumeID:            volumeID,
@@ -161,6 +200,20 @@ func (osclient *OpenStackClients) AttachVolumeToVM(volumeID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to wait for volume attachment: %s", err)
 	}
+
+	// Log the volume status after attach
+	volume, err = volumes.Get(osclient.BlockStorageClient, volumeID).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to get volume: %s", err)
+	}
+	log.Printf("Volume status after attach: %s", volume.Status)
+
+	// Log the server status after attach
+	server, err = servers.Get(osclient.ComputeClient, instanceID).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to get server: %s", err)
+	}
+	log.Printf("Volume attachments after attach: %s", server.AttachedVolumes)
 
 	return nil
 }
@@ -201,6 +254,21 @@ func (osclient *OpenStackClients) DetachVolumeFromVM(volumeID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get instance ID: %s", err)
 	}
+
+	// Log the volume status before detach from cinder and nova
+	volume, err := volumes.Get(osclient.BlockStorageClient, volumeID).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to get volume: %s", err)
+	}
+	log.Printf("Volume status before detach: %s", volume.Status)
+
+	server, err := servers.Get(osclient.ComputeClient, instanceID).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to get server: %s", err)
+	}
+	log.Println("Volume attachments before detach:", server.AttachedVolumes)
+	log.Println("Server before detach:", server)
+
 	for i := 0; i < constants.MaxIntervalCount; i++ {
 		err = volumeattach.Delete(osclient.ComputeClient, instanceID, volumeID).ExtractErr()
 		if err == nil {
@@ -211,6 +279,21 @@ func (osclient *OpenStackClients) DetachVolumeFromVM(volumeID string) error {
 	if err != nil && !strings.Contains(err.Error(), "is not attached") {
 		return fmt.Errorf("failed to detach volume from VM: %s", err)
 	}
+
+	// Log the volume status after detach from cinder and nova
+	volume, err = volumes.Get(osclient.BlockStorageClient, volumeID).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to get volume: %s", err)
+	}
+	log.Printf("Volume status after detach: %s", volume.Status)
+
+	server, err = servers.Get(osclient.ComputeClient, instanceID).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to get server: %s", err)
+	}
+	log.Println("Volume attachments after detach:", server.AttachedVolumes)
+	log.Printf("Server status after detach: %s", server)
+
 	return nil
 }
 

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -139,23 +139,43 @@ func (osclient *OpenStackClients) WaitForVolume(volumeID string) error {
 
 func (osclient *OpenStackClients) AttachVolumeToVM(volumeID string) error {
 	instanceID, err := GetCurrentInstanceUUID()
+
+	var attachSucceeded bool
+	var attachErr error
 	if err != nil {
 		return fmt.Errorf("failed to get instance ID: %s", err)
 	}
+
 	for i := 0; i < constants.MaxIntervalCount; i++ {
-		_, err = volumeattach.Create(osclient.ComputeClient, instanceID, volumeattach.CreateOpts{
+		_, attachErr = volumeattach.Create(osclient.ComputeClient, instanceID, volumeattach.CreateOpts{
 			VolumeID:            volumeID,
 			DeleteOnTermination: false,
 		}).Extract()
-		if err == nil || strings.Contains(err.Error(), "already attached") {
+
+		if attachErr == nil {
+			log.Println("Attach succeeded")
+			attachSucceeded = true
 			break
 		}
-		time.Sleep(5 * time.Second) // Wait for 5 seconds before checking again
+
+		if strings.Contains(attachErr.Error(), "already attached") {
+			log.Println("Volume already attached - checking if it's a leftover from earlier operation")
+			// Retry in case it's a stale attach state (from a previous run)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		// Any other error: retry
+		log.Printf("Attach attempt failed: %v, retrying to attach volume", attachErr)
+		time.Sleep(5 * time.Second)
 	}
-	if err != nil {
-		return fmt.Errorf("failed to attach volume to VM: %s", err)
+	if attachErr != nil {
+		return fmt.Errorf("failed to attach volume to VM: %s", attachErr)
 	}
 
+	if !attachSucceeded {
+		return fmt.Errorf("failed to attach volume to VM")
+	}
 	log.Println("Waiting for volume attachment")
 	err = osclient.WaitForVolumeAttachment(volumeID)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Previously, if a volume was still attached from a prior operation, the function would exit early when encountering "already attached". This led to cases where:

A DetachVolume call was still being processed.

A subsequent AttachVolumeToVM would assume attachment was complete, but in reality, it wasn't initiated by the current operation.

This caused timing issues where the attach logic would falsely succeed without guaranteeing the intended outcome. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances error handling and retry logic in volume attachment/detachment and migration processes. It replaces immediate error returns with logging and continuation, while implementing retry mechanisms for volume attachment when encountering stale states. These improvements eliminate unnecessary sleep delays, address timing issues, and update dependencies in the Dockerfile to improve the reliability of the migration workflow.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>