### PR TITLE
User should be able to delete migration when in pending or any stage

### DIFF
--- a/ui/src/pages/dashboard/MigrationsTable.tsx
+++ b/ui/src/pages/dashboard/MigrationsTable.tsx
@@ -89,20 +89,17 @@ const columns: GridColDef[] = [
         headerName: "Actions",
         flex: 1,
         renderCell: (params) => {
-            const phase = params.row?.status?.phase;
-            const isDisabled = !phase || phase === "Running" || phase === "Pending";
 
             return (
-                <Tooltip title={isDisabled ? "Cannot delete while migration is in progress" : "Delete migration"} >
+                <Tooltip title={"Delete migration"} >
                     <IconButton
                         onClick={(e) => {
                             e.stopPropagation();
                             params.row.onDelete(params.row.metadata?.name);
                         }}
-                        disabled={isDisabled}
                         size="small"
                         sx={{
-                            cursor: isDisabled ? 'not-allowed' : 'pointer',
+                            cursor: 'pointer',
                             position: 'relative'
                         }}
                     >
@@ -181,11 +178,6 @@ export default function MigrationsTable({
         onDelete: onDeleteMigration
     })) || [];
 
-    const isRowSelectable = (params) => {
-        const phase = params.row?.status?.phase;
-        return !(!phase || phase === "Running" || phase === "Pending");
-    };
-
     return (
         <DataGrid
             rows={migrationsWithActions}
@@ -200,7 +192,6 @@ export default function MigrationsTable({
             localeText={{ noRowsLabel: "No Migrations Available" }}
             getRowId={(row) => row.metadata?.name}
             checkboxSelection
-            isRowSelectable={isRowSelectable}
             onRowSelectionModelChange={handleSelectionChange}
             rowSelectionModel={selectedRows}
             slots={{


### PR DESCRIPTION
…of the migration

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #447  
 <div id='description'>
<h3>Summary by Bito</h3>
The pull request fixes a bug in the migration deletion workflow by modifying the deletion button's behavior and tooltip messaging. It also removes unnecessary code for row selection, simplifying the UI logic and allowing deletion in any migration state.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>