### PR TITLE
disabled migration form submission on enter key when text inputs are …

### DIFF
--- a/ui/src/features/migration/MigrationOptions.tsx
+++ b/ui/src/features/migration/MigrationOptions.tsx
@@ -278,6 +278,8 @@ export default function MigrationOptions({
               <CustomTextField
                 label="Post Migration Script"
                 size="small"
+                multiline
+                rows={4}
                 value={params?.postMigrationScript || ""}
                 onChange={(e) =>
                   onChange("postMigrationScript")(String(e.target.value))
@@ -285,6 +287,7 @@ export default function MigrationOptions({
                 disabled={!selectedMigrationOptions.postMigrationScript}
                 error={!!errors["postMigrationScript"]}
                 required={selectedMigrationOptions.postMigrationScript}
+                placeholder="Enter your post-migration script here..."
               />
             </Fields>
 

--- a/ui/src/features/migration/MigrationOptionsAlt.tsx
+++ b/ui/src/features/migration/MigrationOptionsAlt.tsx
@@ -267,6 +267,8 @@ export default function MigrationOptionsAlt({
               <CustomTextField
                 label="Post Migration Script"
                 size="small"
+                multiline
+                rows={4}
                 value={params?.postMigrationScript || ""}
                 onChange={(e) =>
                   onChange("postMigrationScript")(String(e.target.value))
@@ -274,6 +276,7 @@ export default function MigrationOptionsAlt({
                 disabled={!selectedMigrationOptions.postMigrationScript}
                 error={!!errors["postMigrationScript"]}
                 required={selectedMigrationOptions.postMigrationScript}
+                placeholder="Enter your post-migration script here..."
               />
             </Fields>
 

--- a/ui/src/hooks/ui/useKeyboardSubmit.ts
+++ b/ui/src/hooks/ui/useKeyboardSubmit.ts
@@ -23,8 +23,23 @@ export function useKeyboardSubmit({
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === "Enter" && !isSubmitDisabled) {
-        event.preventDefault()
-        onSubmit()
+        // Get the currently focused element
+        const activeElement = document.activeElement as HTMLElement
+
+        // Check if the user is focused on an input element where Enter should work normally
+        const isInInputField =
+          activeElement &&
+          (activeElement.tagName === "INPUT" ||
+            activeElement.tagName === "TEXTAREA" ||
+            activeElement.isContentEditable ||
+            activeElement.closest('[role="textbox"]') ||
+            activeElement.closest(".MuiInputBase-input") ||
+            activeElement.closest('[contenteditable="true"]'))
+
+        if (!isInInputField) {
+          event.preventDefault()
+          onSubmit()
+        }
       } else if (event.key === "Escape") {
         event.preventDefault()
         onClose()


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances migration form components by adding multiline support and placeholder guidance to post-migration script input fields. It refines keyboard event handling to prevent accidental form submissions when pressing Enter in text inputs, creating a more intuitive user experience with clear guidance.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>