### PR TITLE
Backend Premptively fail if a mac is found in a port in openstack 

### DIFF
--- a/v2v-helper/main.go
+++ b/v2v-helper/main.go
@@ -111,10 +111,10 @@ func main() {
 	for _, mac := range vminfo.Mac {
 		macExists, err := openstackclients.MacExistsInPort(mac)
 		if err != nil {
-			handleError(fmt.Sprintf("Failed to check if mac exists in any port in openstack: %v", err))
+			handleError(fmt.Sprintf("Failed to migrate VM: Failed to check if mac exists in any port in openstack: %v", err))
 		}
 		if macExists {
-			handleError(fmt.Sprintf("Mac %s already exists in openstack", mac))
+			handleError(fmt.Sprintf("Failed to migrate VM: Mac %s already exists in openstack", mac))
 		}
 	}
 

--- a/v2v-helper/main.go
+++ b/v2v-helper/main.go
@@ -102,6 +102,22 @@ func main() {
 		handleError(fmt.Sprintf("Failed to get source VM: %v", err))
 	}
 
+	// Get VM Info
+	vminfo, err := vmops.GetVMInfo(migrationparams.OpenstackOSType)
+	if err != nil {
+		handleError(fmt.Sprintf("Failed to get VM info: %v", err))
+	}
+	// Before starting the migration check if mac does not exist in any port in openstack
+	for _, mac := range vminfo.Mac {
+		macExists, err := openstackclients.MacExistsInPort(mac)
+		if err != nil {
+			handleError(fmt.Sprintf("Failed to check if mac exists in any port in openstack: %v", err))
+		}
+		if macExists {
+			handleError(fmt.Sprintf("Mac %s already exists in openstack", mac))
+		}
+	}
+
 	migrationobj := migrate.Migrate{
 		URL:              vCenterURL,
 		UserName:         vCenterUserName,

--- a/v2v-helper/main.go
+++ b/v2v-helper/main.go
@@ -111,10 +111,10 @@ func main() {
 	for _, mac := range vminfo.Mac {
 		macExists, err := openstackclients.MacExistsInPort(mac)
 		if err != nil {
-			handleError(fmt.Sprintf("Failed to migrate VM: Failed to check if mac exists in any port in openstack: %v", err))
+			handleError(fmt.Sprintf("failed to migrate VM: Failed to check if mac exists in any port in openstack: %v", err))
 		}
 		if macExists {
-			handleError(fmt.Sprintf("Failed to migrate VM: Mac %s already exists in openstack", mac))
+			handleError(fmt.Sprintf("failed to migrate VM: Mac %s already exists in openstack", mac))
 		}
 	}
 
@@ -150,7 +150,7 @@ func main() {
 	}
 
 	if err := migrationobj.MigrateVM(ctx); err != nil {
-		msg := fmt.Sprintf("Failed to migrate VM: %v", err)
+		msg := fmt.Sprintf("failed to migrate VM: %v", err)
 
 		// Try to power on the VM if migration failed
 		powerOnErr := vmops.VMPowerOn()

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -473,3 +473,20 @@ func (osclient *OpenStackClients) WaitUntilVMActive(vmID string) (bool, error) {
 	}
 	return true, nil
 }
+
+func (osclient *OpenStackClients) MacExistsInPort(mac string) (bool, error) {
+	allPages, err := ports.List(osclient.NetworkingClient, ports.ListOpts{
+		MACAddress: mac,
+	}).AllPages()
+	if err != nil {
+		return false, fmt.Errorf("failed to list ports: %s", err)
+	}
+	allPorts, err := ports.ExtractPorts(allPages)
+	if err != nil {
+		return false, fmt.Errorf("failed to extract all ports: %s", err)
+	}
+	if len(allPorts) > 0 {
+		return true, nil
+	}
+	return false, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #445 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR implements pre-migration validations to prevent conflicts by checking for duplicate MAC addresses in Openstack. It adds logic to retrieve VM details, iterate over MAC addresses with improved error handling, and introduces a new function to verify MAC existence. These changes ensure VMs with conflicting MACs fail early, improving migration reliability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>