### PR TITLE
Increase timeout for vm status to become active

### DIFF
--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -467,7 +467,7 @@ func (osclient *OpenStackClients) CreateVM(flavor *flavors.Flavor, networkIDs, p
 		return nil, fmt.Errorf("failed to create server: %s", err)
 	}
 
-	err = servers.WaitForStatus(osclient.ComputeClient, server.ID, "ACTIVE", 60)
+	err = servers.WaitForStatus(osclient.ComputeClient, server.ID, "ACTIVE", 360)
 	if err != nil {
 		return nil, fmt.Errorf("failed to wait for server to become active: %s", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR extends the timeout duration for server activation in OpenStack operations, preventing premature timeouts while waiting for VMs to become active. The change improves system reliability by ensuring adequate wait time for server readiness, addressing a specific issue with VM activation timing.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>