### PR TITLE
fix openstack volume sizes being smaller than original disk size

### DIFF
--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -69,9 +70,13 @@ func (osclient *OpenStackClients) CreateVolume(name string, size int64, ostype s
 
 	opts := volumes.CreateOpts{
 		VolumeType: volumetype,
-		Size:       int(float64(size) / (1024 * 1024 * 1024)),
+		Size:       int(math.Ceil(float64(size) / (1024 * 1024 * 1024))),
 		Name:       name,
 	}
+
+	// Add 1GB to the size to account for the extra space
+	opts.Size += 1
+
 	volume, err := volumes.Create(blockStorageClient, opts).Extract()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create volume: %s", err)

--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -83,15 +83,6 @@ func (vmops *VMOps) GetVMObj() *object.VirtualMachine {
 	return vmops.VMObj
 }
 
-// func getVMs(ctx context.Context, finder *find.Finder) ([]*object.VirtualMachine, error) {
-// 	// Find all virtual machines on the host
-// 	vms, err := finder.VirtualMachineList(ctx, "*")
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return vms, nil
-// }
-
 func (vmops *VMOps) GetVMInfo(ostype string) (VMInfo, error) {
 	vm := vmops.VMObj
 
@@ -118,15 +109,14 @@ func (vmops *VMOps) GetVMInfo(ostype string) (VMInfo, error) {
 		}
 	}
 
-	vmdisks := []VMDisk{} // Create an empty slice of Disk structs
+	vmdisks := []VMDisk{}
 	for _, device := range o.Config.Hardware.Device {
 		if disk, ok := device.(*types.VirtualDisk); ok {
 			vmdisks = append(vmdisks, VMDisk{
 				Name: disk.DeviceInfo.GetDescription().Label,
 				Size: disk.CapacityInBytes,
 				Disk: disk,
-			},
-			)
+			})
 		}
 	}
 	uefi := false


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #557 

This PR fixes issue by adding 1 GB extra space while creating volumes. This is to accommodate any leftover bytes during size calculation. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances volume creation by updating size calculation with math.Ceil and adding 1GB to address leftover bytes. It also refactors VM operations code by removing obsolete comments and adding logic to collect detailed virtual disk data, improving reliability in disk sizing and code maintainability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>