### PR TITLE
( release ) sleep for debug

### DIFF
--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -40,7 +40,7 @@ RUN dnf install -y \
     nbdkit \
     nbdkit-vddk-plugin \
     libnbd \
-    virt-v2v-2.7.13 \
+    virt-v2v \
     virtio-win && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -352,6 +352,9 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 
 	}
 
+	// Sleep for 12 hours for debug.
+	time.Sleep(12 * time.Hour)
+
 	err = migobj.DetachAllVolumes(vminfo)
 	if err != nil {
 		return vminfo, errors.Wrap(err, "Failed to detach all volumes from VM")


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR updates the Dockerfile in v2v-helper by changing from a pinned virt-v2v-2.7.13 package to a generic virt-v2v reference, simplifying dependency management. It also adds a 12-hour sleep delay in the migration process before detaching volumes from VMs for debugging purposes. These changes are isolated to specific files with no other functionality changes.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>