### PR TITLE
save disk space on vjb VM

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -534,7 +534,7 @@ func (r *MigrationPlanReconciler) CreateJob(ctx context.Context,
 							{
 								Name:            "fedora",
 								Image:           v2vimage,
-								ImagePullPolicy: corev1.PullAlways,
+								ImagePullPolicy: corev1.PullIfNotPresent,
 								Command:         []string{"/home/fedora/manager"},
 								SecurityContext: &corev1.SecurityContext{
 									Privileged: &pointtrue,
@@ -598,12 +598,12 @@ func (r *MigrationPlanReconciler) CreateJob(ctx context.Context,
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:              resource.MustParse("1000m"),
 										corev1.ResourceMemory:           resource.MustParse("1Gi"),
-										corev1.ResourceEphemeralStorage: resource.MustParse("200Mi"),
+										corev1.ResourceEphemeralStorage: resource.MustParse("3Gi"),
 									},
 									Limits: corev1.ResourceList{
 										corev1.ResourceCPU:              resource.MustParse("2000m"),
 										corev1.ResourceMemory:           resource.MustParse("3Gi"),
-										corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
+										corev1.ResourceEphemeralStorage: resource.MustParse("3Gi"),
 									},
 								},
 							},


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR optimizes resource management in the migration plan controller by modifying image pull policy and adjusting ephemeral storage settings. These targeted changes aim to save disk space on vjb VM while ensuring optimal performance and stability during container initialization and migration processes.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>