### PR TITLE
make delete migration-controller-manager pod work

### DIFF
--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -1672,6 +1672,13 @@ spec:
         - /manager
         image: quay.io/platform9/vjailbreak-controller:v0.1.13
         imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - sleep 5
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1699,7 +1706,7 @@ spec:
         runAsGroup: 0
         runAsUser: 0
       serviceAccountName: migration-controller-manager
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 30
       volumes:
       - hostPath:
           path: /var/lib/rancher/k3s/server

--- a/k8s/migration/config/manager/manager.yaml
+++ b/k8s/migration/config/manager/manager.yaml
@@ -80,6 +80,10 @@ spec:
           requests:
             cpu: 200m
             memory: 256Mi
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 5"]
         volumeMounts:
         - mountPath: /etc/pf9/k3s
           name: master-token
@@ -95,4 +99,4 @@ spec:
         hostPath:                                                                 
           path: /home/ubuntu                                                      
           type: Directory                                                         
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 30


### PR DESCRIPTION
**What this PR does / why we need it**:
If we want to trigger force reconciliation of controller pods, right now, we need to scale down the deployment to 0 replicas and then scale up to 1 for it to work (this was due to a bug which caused new pod to never go into Running). This is tedious and time consuming. This PR resolves that bug

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances Kubernetes manager configuration by implementing a preStop lifecycle hook and adjusting termination grace periods to fix migration-controller-manager pod deletion issues. These changes eliminate the need for manual scaling to force reconciliation, creating a more streamlined pod lifecycle and resolving critical shutdown and startup bugs.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>