### PR TITLE
checking latest version of virt-v2v (release)

### DIFF
--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -40,7 +40,7 @@ RUN dnf install -y \
     nbdkit \
     nbdkit-vddk-plugin \
     libnbd \
-    virt-v2v-2.7.13 \
+    virt-v2v \
     virtio-win && \
     dnf clean all && \
     rm -rf /var/cache/dnf

--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -23,7 +23,7 @@ COPY manager manager
 
 # Stage 2: Runtime environment
 # Using same Fedora version for consistency and required runtime dependencies
-FROM fedora:42
+FROM fedora:43
 
 # Add virtio-win repository for Windows drivers
 # Required for VM migration and conversion support


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR updates the Dockerfile in v2v-helper directory by replacing version-specific virt-v2v-2.7.13 with a generic virt-v2v reference and upgrading from fedora:42 to fedora:43. These changes improve dependency management, enhance consistency in runtime dependencies, and simplify future maintenance by using the most recent version of virt-v2v during builds.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>