### PR TITLE
Add alpine docker image with rsync,coreutils in quay 

### DIFF
--- a/image_builder/configs/daemonset.yaml
+++ b/image_builder/configs/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
       hostNetwork: true
       initContainers:
         - name: fix-perms
-          image: alpine:3.22.0
+          image: quay.io/platform9/vjailbreak:alpine
           securityContext:
             privileged: true
             runAsUser: 0
@@ -37,7 +37,7 @@ spec:
               mountPath: /home/ubuntu/virtio-win
       containers:
         - name: sync-container
-          image: alpine:3.22.0
+          image: quay.io/platform9/vjailbreak:alpine
           securityContext:
             privileged: true
             runAsUser: 0

--- a/image_builder/configs/daemonset.yaml
+++ b/image_builder/configs/daemonset.yaml
@@ -57,7 +57,6 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              apk add --no-cache rsync coreutils grep
               IS_MASTER=$(grep -E '^export IS_MASTER=' /etc/pf9/k3s.env | cut -d'=' -f2)
               MASTER_IP=$(grep -E '^export MASTER_IP=' /etc/pf9/k3s.env | cut -d'=' -f2)
               if [ "$IS_MASTER" = "true" ]; then

--- a/image_builder/scripts/download_images.sh
+++ b/image_builder/scripts/download_images.sh
@@ -26,7 +26,8 @@ v2v_helper="quay.io/platform9/vjailbreak-v2v-helper:$TAG"
 controller="quay.io/platform9/vjailbreak-controller:$TAG"
 ui="quay.io/platform9/vjailbreak-ui:$TAG"
 vpwned="quay.io/platform9/vjailbreak-vpwned:$TAG"
-alpine="docker.io/library/alpine:3.22.0"
+# TODO(suhas): Create a seperate repository for alpine image in quay
+alpine="quay.io/platform9/vjailbreak:alpine"
 
 # Download and export images
 images=(


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request updates image references to use a custom Alpine image from quay.io instead of docker.io in both deployment configurations and the download script. The changes streamline image sourcing across the codebase while removing some explicit package installations and adding a TODO for repository creation.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>