### PR TITLE
upgraded fedora version to fetch latest version of virt-v2v

### DIFF
--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -23,7 +23,7 @@ COPY manager manager
 
 # Stage 2: Runtime environment
 # Using same Fedora version for consistency and required runtime dependencies
-FROM fedora:42
+FROM fedora:43
 
 # Add virtio-win repository for Windows drivers
 # Required for VM migration and conversion support


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrades the Fedora base image used in the v2v-helper Dockerfile from Fedora 42 to Fedora 43.
The upgrade is required because the migration failures observed with virt-v2v version 2.8 (specifically with CentOS VMs) were resolved after moving to Fedora 43.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #592  
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR updates the Fedora base image in the v2v-helper Dockerfile from version 42 to 43. The change addresses migration failures previously experienced with virt-v2v, enhancing runtime compatibility and stabilizing the VM migration environment.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>