### PR TITLE
Use our assets library to build v2v helper

### DIFF
--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -29,6 +29,8 @@ FROM fedora:42
 # Required for VM migration and conversion support
 # This provides Windows VirtIO drivers needed during VM conversion
 ADD https://fedorapeople.org/groups/virt/virtio-win/virtio-win.repo /etc/yum.repos.d/virtio-win.repo
+WORKDIR /tmp
+RUN curl -L -o virt-v2v-2.7.13-1.fc42.x86_64.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/main/assets/rpms/virt-v2v-2.7.13-1.fc42.x86_64.rpm
 
 # Install runtime dependencies:
 # - nbdkit: Network Block Device toolkit for accessing disk images
@@ -40,8 +42,9 @@ RUN dnf install -y \
     nbdkit \
     nbdkit-vddk-plugin \
     libnbd \
-    virt-v2v \
-    virtio-win && \
+    virtio-win 
+    
+RUN dnf install -y /tmp/virt-v2v-2.7.13-1.fc42.x86_64.rpm && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR uses the assets in the assets directory to install and version lock virt-v2v to 2.7.13 as that is the most tested version with vJailbreak.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #594 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR updates the v2v helper Dockerfile to use the assets library for package installation, streamlining the dependency process. It adds instructions to download the virt-v2v RPM and replaces old dependencies with direct installation commands, enhancing VM migration support and build reliability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>