### PR TITLE
Change the base ubuntu image for vJailbreak qcow

### DIFF
--- a/image_builder/vjailbreak-image.pkr.hcl
+++ b/image_builder/vjailbreak-image.pkr.hcl
@@ -11,7 +11,7 @@ source "qemu" "vjailbreak-image" {
   disk_image           = true
   skip_compaction      = true
   iso_url              = "vjailbreak-image.qcow2"
-  iso_checksum         = "sha256:69f55e8ba127c77b7fea66de7d4c9b60a1889e62a82fe6c39bcd2375aac24953"
+  iso_checksum         = "sha256:e0514d0ee287ca7fec7670e41ba67304f57eded5f4151f87734d7d3cc0a0d60a"
   iso_target_extension = "qcow2"
   output_directory     = "vjailbreak_qcow2"
   vm_name              = "vjailbreak-image.qcow2"

--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -1,30 +1,3 @@
-# Stage 1: Build environment
-# Using Fedora 42 which includes Go 1.24 required by our go.mod
-FROM quay.io/platform9/vjailbreak-v2v-helper:v0.1.12 AS builder
-
-# Build arguments for multi-platform support and versioning
-ARG TARGETOS
-ARG TARGETARCH
-ARG RELEASE_VERSION
-ENV RELEASE_VERSION=$RELEASE_VERSION
-
-
-# Set up build workspace
-WORKDIR /workspace
-
-# Copy pre-built binary from local build
-# Note: The binary is built by 'make -C v2v-helper build' before docker build
-# This is part of the VM migration toolchain for converting between different platforms
-COPY manager manager
-
-# Stage 2: Runtime environment
-# Using same Fedora version for consistency and required runtime dependencies
 FROM quay.io/platform9/vjailbreak-v2v-helper:v0.1.12
-
-# Add virtio-win repository for Windows drivers
-# Required for VM migration and conversion support
-# This provides Windows VirtIO drivers needed during VM conversion
-ADD https://fedorapeople.org/groups/virt/virtio-win/virtio-win.repo /etc/yum.repos.d/virtio-win.repo
-
-# Copy the binary from builder stage to the runtime environment
-COPY --from=builder /workspace/manager /home/fedora/manager
+COPY manager /home/fedora/manager
+RUN chmod +x /home/fedora/manager && chown fedora:fedora /home/fedora/manager

--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -23,30 +23,7 @@ COPY manager manager
 
 # Stage 2: Runtime environment
 # Using same Fedora version for consistency and required runtime dependencies
-FROM fedora:42
-
-# Add virtio-win repository for Windows drivers
-# Required for VM migration and conversion support
-# This provides Windows VirtIO drivers needed during VM conversion
-ADD https://fedorapeople.org/groups/virt/virtio-win/virtio-win.repo /etc/yum.repos.d/virtio-win.repo
-WORKDIR /tmp
-RUN curl -L -o virt-v2v-2.7.13-1.fc42.x86_64.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/main/assets/rpms/virt-v2v-2.7.13-1.fc42.x86_64.rpm
-
-# Install runtime dependencies:
-# - nbdkit: Network Block Device toolkit for accessing disk images
-# - nbdkit-vddk-plugin: VMware VDDK plugin for accessing VMware disks
-# - libnbd: Network Block Device client library
-# - virt-v2v: Convert VMs between platforms (e.g., VMware to OpenStack)
-# - virtio-win: VirtIO drivers for Windows guests
-RUN dnf install -y \
-    nbdkit \
-    nbdkit-vddk-plugin \
-    libnbd \
-    virtio-win 
-    
-RUN dnf install -y /tmp/virt-v2v-2.7.13-1.fc42.x86_64.rpm && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
+FROM quay.io/platform9/vjailbreak-v2v-helper:v0.1.12
 
 # Copy the binary from builder stage to the runtime environment
 COPY --from=builder /workspace/manager /home/fedora/manager

--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build environment
 # Using Fedora 42 which includes Go 1.24 required by our go.mod
-FROM fedora:43 AS builder
+FROM fedora:42 AS builder
 
 # Build arguments for multi-platform support and versioning
 ARG TARGETOS
@@ -23,12 +23,14 @@ COPY manager manager
 
 # Stage 2: Runtime environment
 # Using same Fedora version for consistency and required runtime dependencies
-FROM fedora:43
+FROM fedora:42
 
 # Add virtio-win repository for Windows drivers
 # Required for VM migration and conversion support
 # This provides Windows VirtIO drivers needed during VM conversion
 ADD https://fedorapeople.org/groups/virt/virtio-win/virtio-win.repo /etc/yum.repos.d/virtio-win.repo
+WORKDIR /tmp
+RUN curl -L -o virt-v2v-2.7.13-1.fc42.x86_64.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/main/assets/rpms/virt-v2v-2.7.13-1.fc42.x86_64.rpm
 
 # Install runtime dependencies:
 # - nbdkit: Network Block Device toolkit for accessing disk images
@@ -40,8 +42,9 @@ RUN dnf install -y \
     nbdkit \
     nbdkit-vddk-plugin \
     libnbd \
-    virt-v2v \
-    virtio-win && \
+    virtio-win 
+    
+RUN dnf install -y /tmp/virt-v2v-2.7.13-1.fc42.x86_64.rpm && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 

--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -23,7 +23,7 @@ COPY manager manager
 
 # Stage 2: Runtime environment
 # Using same Fedora version for consistency and required runtime dependencies
-FROM fedora:41
+FROM fedora:43
 
 # Add virtio-win repository for Windows drivers
 # Required for VM migration and conversion support

--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -1,8 +1,49 @@
-FROM quay.io/platform9/vjailbreak-v2v-helper:v0.1.12 AS builder
+# Stage 1: Build environment
+# Using Fedora 42 which includes Go 1.24 required by our go.mod
+FROM fedora:43 AS builder
+
+# Build arguments for multi-platform support and versioning
+ARG TARGETOS
+ARG TARGETARCH
+ARG RELEASE_VERSION
+ENV RELEASE_VERSION=$RELEASE_VERSION
+
+# Install build dependencies
+# - golang: Required for building the application (Go 1.24.1 from Fedora 42)
+# - libnbd-devel: Development files for NBD (Network Block Device) support
+RUN dnf install -y golang libnbd-devel
+
+# Set up build workspace
 WORKDIR /workspace
+
+# Copy pre-built binary from local build
+# Note: The binary is built by 'make -C v2v-helper build' before docker build
+# This is part of the VM migration toolchain for converting between different platforms
 COPY manager manager
 
-FROM quay.io/platform9/vjailbreak-v2v-helper:v0.1.12
+# Stage 2: Runtime environment
+# Using same Fedora version for consistency and required runtime dependencies
+FROM fedora:43
+
+# Add virtio-win repository for Windows drivers
+# Required for VM migration and conversion support
+# This provides Windows VirtIO drivers needed during VM conversion
 ADD https://fedorapeople.org/groups/virt/virtio-win/virtio-win.repo /etc/yum.repos.d/virtio-win.repo
+
+# Install runtime dependencies:
+# - nbdkit: Network Block Device toolkit for accessing disk images
+# - nbdkit-vddk-plugin: VMware VDDK plugin for accessing VMware disks
+# - libnbd: Network Block Device client library
+# - virt-v2v: Convert VMs between platforms (e.g., VMware to OpenStack)
+# - virtio-win: VirtIO drivers for Windows guests
+RUN dnf install -y \
+    nbdkit \
+    nbdkit-vddk-plugin \
+    libnbd \
+    virt-v2v \
+    virtio-win && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+# Copy the binary from builder stage to the runtime environment
 COPY --from=builder /workspace/manager /home/fedora/manager
-RUN chmod +x /home/fedora/manager

--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -23,7 +23,7 @@ COPY manager manager
 
 # Stage 2: Runtime environment
 # Using same Fedora version for consistency and required runtime dependencies
-FROM fedora:43
+FROM fedora:41
 
 # Add virtio-win repository for Windows drivers
 # Required for VM migration and conversion support

--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -23,7 +23,27 @@ COPY manager manager
 
 # Stage 2: Runtime environment
 # Using same Fedora version for consistency and required runtime dependencies
-FROM quay.io/platform9/vjailbreak-v2v-helper:v0.1.12
+FROM fedora:43
+
+# Add virtio-win repository for Windows drivers
+# Required for VM migration and conversion support
+# This provides Windows VirtIO drivers needed during VM conversion
+ADD https://fedorapeople.org/groups/virt/virtio-win/virtio-win.repo /etc/yum.repos.d/virtio-win.repo
+
+# Install runtime dependencies:
+# - nbdkit: Network Block Device toolkit for accessing disk images
+# - nbdkit-vddk-plugin: VMware VDDK plugin for accessing VMware disks
+# - libnbd: Network Block Device client library
+# - virt-v2v: Convert VMs between platforms (e.g., VMware to OpenStack)
+# - virtio-win: VirtIO drivers for Windows guests
+RUN dnf install -y \
+    nbdkit \
+    nbdkit-vddk-plugin \
+    libnbd \
+    virt-v2v \
+    virtio-win && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 # Copy the binary from builder stage to the runtime environment
 COPY --from=builder /workspace/manager /home/fedora/manager

--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build environment
 # Using Fedora 42 which includes Go 1.24 required by our go.mod
-FROM fedora:43 AS builder
+FROM quay.io/platform9/vjailbreak-v2v-helper:v0.1.12 AS builder
 
 # Build arguments for multi-platform support and versioning
 ARG TARGETOS
@@ -8,10 +8,6 @@ ARG TARGETARCH
 ARG RELEASE_VERSION
 ENV RELEASE_VERSION=$RELEASE_VERSION
 
-# Install build dependencies
-# - golang: Required for building the application (Go 1.24.1 from Fedora 42)
-# - libnbd-devel: Development files for NBD (Network Block Device) support
-RUN dnf install -y golang libnbd-devel
 
 # Set up build workspace
 WORKDIR /workspace
@@ -23,27 +19,12 @@ COPY manager manager
 
 # Stage 2: Runtime environment
 # Using same Fedora version for consistency and required runtime dependencies
-FROM fedora:43
+FROM quay.io/platform9/vjailbreak-v2v-helper:v0.1.12
 
 # Add virtio-win repository for Windows drivers
 # Required for VM migration and conversion support
 # This provides Windows VirtIO drivers needed during VM conversion
 ADD https://fedorapeople.org/groups/virt/virtio-win/virtio-win.repo /etc/yum.repos.d/virtio-win.repo
-
-# Install runtime dependencies:
-# - nbdkit: Network Block Device toolkit for accessing disk images
-# - nbdkit-vddk-plugin: VMware VDDK plugin for accessing VMware disks
-# - libnbd: Network Block Device client library
-# - virt-v2v: Convert VMs between platforms (e.g., VMware to OpenStack)
-# - virtio-win: VirtIO drivers for Windows guests
-RUN dnf install -y \
-    nbdkit \
-    nbdkit-vddk-plugin \
-    libnbd \
-    virt-v2v \
-    virtio-win && \
-    dnf clean all && \
-    rm -rf /var/cache/dnf
 
 # Copy the binary from builder stage to the runtime environment
 COPY --from=builder /workspace/manager /home/fedora/manager

--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -1,3 +1,8 @@
+FROM quay.io/platform9/vjailbreak-v2v-helper:v0.1.12 AS builder
+WORKDIR /workspace
+COPY manager manager
+
 FROM quay.io/platform9/vjailbreak-v2v-helper:v0.1.12
-COPY manager /home/fedora/manager
-RUN chmod +x /home/fedora/manager && chown fedora:fedora /home/fedora/manager
+ADD https://fedorapeople.org/groups/virt/virtio-win/virtio-win.repo /etc/yum.repos.d/virtio-win.repo
+COPY --from=builder /workspace/manager /home/fedora/manager
+RUN chmod +x /home/fedora/manager

--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build environment
 # Using Fedora 42 which includes Go 1.24 required by our go.mod
-FROM fedora:42 AS builder
+FROM fedora:43 AS builder
 
 # Build arguments for multi-platform support and versioning
 ARG TARGETOS

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -172,7 +172,7 @@ func ConvertDisk(ctx context.Context, xmlFile, path, ostype, virtiowindriver str
 	os.Setenv("LIBGUESTFS_BACKEND", "direct")
 
 	// Step 3: Prepare virt-v2v args
-	args := []string{"--firstboot", "/home/fedora/scripts/user_firstboot.sh"}
+	args := []string{"-v", "--firstboot", "/home/fedora/scripts/user_firstboot.sh"}
 	for _, script := range firstbootscripts {
 		args = append(args, "--firstboot", fmt.Sprintf("/home/fedora/%s.sh", script))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR updates the v2v-helper Dockerfile by replacing the Fedora base image with a newer version, adding build arguments for multi-platform builds, and implementing a multi-stage build process. It refreshes the ISO checksum in the image builder file, removes unnecessary repository additions, and enhances logging in virtv2vops.go with a '-v' flag for improved verbosity. These changes enhance image integrity and streamline container build workflows.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>