### PR TITLE
change from cloud-ctl to pcdctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ VERSION = $(RELEASE_VER)-$(GIT_SHA)
 
 export REPO ?= platform9
 export TAG ?= $(VERSION)
-export UI_IMG ?= ${REPO}/vjailbreak-ui:${TAG}
-export V2V_IMG ?= ${REPO}/v2v-helper:${TAG}
-export CONTROLLER_IMG ?= ${REPO}/vjailbreak-controller:${TAG}
-export VPWNED_IMG ?= ${REPO}/vjailbreak-vpwned:${TAG}
+export UI_IMG ?= ${REGISTRY}/${REPO}/vjailbreak-ui:${TAG}
+export V2V_IMG ?= ${REGISTRY}/${REPO}/v2v-helper:${TAG}
+export CONTROLLER_IMG ?= ${REGISTRY}/${REPO}/vjailbreak-controller:${TAG}
+export VPWNED_IMG ?= ${REGISTRY}/${REPO}/vjailbreak-vpwned:${TAG}
 export RELEASE_VERSION ?= $(VERSION)
 export KUBECONFIG ?= ~/.kube/config
 export CONTAINER_TOOL ?= docker


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
The pull request updates image variable definitions in the Makefile to include the REGISTRY prefix, supporting migration from cloud-ctl to pcdctl. These modifications streamline configuration and improve consistency in container deployments while aligning with the new tool transition.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>