### PR TITLE
accept os_family correctly and override if present

### DIFF
--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -764,8 +764,8 @@ spec:
               osFamily:
                 description: OSFamily is the OS type of the virtual machine
                 enum:
-                - windows
-                - linux
+                - windowsGuest
+                - linuxGuest
                 type: string
               source:
                 description: Source is the source details for the virtual machine

--- a/k8s/migration/api/v1alpha1/migrationtemplate_types.go
+++ b/k8s/migration/api/v1alpha1/migrationtemplate_types.go
@@ -35,7 +35,7 @@ type MigrationTemplateDestination struct {
 // MigrationTemplateSpec defines the desired state of MigrationTemplate including source/destination environments and mappings
 type MigrationTemplateSpec struct {
 	// OSFamily is the OS type of the virtual machine
-	// +kubebuilder:validation:Enum=windows;linux
+	// +kubebuilder:validation:Enum=windowsGuest;linuxGuest
 	OSFamily string `json:"osFamily,omitempty"`
 	// VirtioWinDriver is the driver to be used for the virtual machine
 	VirtioWinDriver string `json:"virtioWinDriver,omitempty"`

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationtemplates.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationtemplates.yaml
@@ -63,8 +63,8 @@ spec:
               osFamily:
                 description: OSFamily is the OS type of the virtual machine
                 enum:
-                - windows
-                - linux
+                - windowsGuest
+                - linuxGuest
                 type: string
               source:
                 description: Source is the source details for the virtual machine

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -826,6 +826,10 @@ func (r *MigrationPlanReconciler) CreateMigrationConfigMap(ctx context.Context,
 
 		configMap.Data["OS_FAMILY"] = vmMachine.Spec.VMInfo.OSFamily
 
+		if migrationtemplate.Spec.OSFamily != "" {
+			configMap.Data["OS_FAMILY"] = migrationtemplate.Spec.OSFamily
+		}
+
 		err = r.createResource(ctx, migrationobj, configMap)
 		if err != nil {
 			r.ctxlog.Error(err, fmt.Sprintf("Failed to create ConfigMap '%s'", configMapName))

--- a/ui/src/features/migration/constants.ts
+++ b/ui/src/features/migration/constants.ts
@@ -8,8 +8,8 @@ export enum CUTOVER_TYPES {
 
 export enum OS_TYPES {
   "AUTO_DETECT" = "default",
-  "WINDOWS" = "windows",
-  "LINUX" = "linux",
+  "WINDOWS" = "windowsGuest",
+  "LINUX" = "linuxGuest",
 }
 
 export const DATA_COPY_OPTIONS = [


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances the migration plan controller by prioritizing the OS family configuration from migrationtemplate.Spec.OSFamily over vmMachine.Spec.VMInfo when available. The implementation adds conditional logic to ensure proper OS configuration during ConfigMap creation and includes appropriate error logging, improving overall system reliability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>