### PR TITLE
support migration without a cluster on pcd

### DIFF
--- a/k8s/migration/pkg/constants/constants.go
+++ b/k8s/migration/pkg/constants/constants.go
@@ -152,6 +152,9 @@ const (
 
 	// StartCutOverNo is the value for start cut over no
 	StartCutOverNo = "no"
+
+	// PCDClusterNameNoCluster is the name of the PCD cluster when there is no cluster
+	PCDClusterNameNoCluster = "No Cluster (migration without cluster)"
 )
 
 // CloudInitScript contains the cloud-init script for VM initialization

--- a/k8s/migration/pkg/constants/constants.go
+++ b/k8s/migration/pkg/constants/constants.go
@@ -154,7 +154,7 @@ const (
 	StartCutOverNo = "no"
 
 	// PCDClusterNameNoCluster is the name of the PCD cluster when there is no cluster
-	PCDClusterNameNoCluster = "No Cluster (migration without cluster)"
+	PCDClusterNameNoCluster = "NONE"
 )
 
 // CloudInitScript contains the cloud-init script for VM initialization

--- a/k8s/migration/pkg/utils/pcdutils.go
+++ b/k8s/migration/pkg/utils/pcdutils.go
@@ -110,6 +110,7 @@ func CreatePCDClusterFromResmgrCluster(ctx context.Context, k8sClient client.Cli
 	return nil
 }
 
+// CreateEntryForNoPCDCluster creates a PCDCluster for no cluster
 func CreateEntryForNoPCDCluster(ctx context.Context, k8sClient client.Client, openstackCreds *vjailbreakv1alpha1.OpenstackCreds) error {
 	pcdCluster := vjailbreakv1alpha1.PCDCluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/k8s/migration/pkg/utils/pcdutils.go
+++ b/k8s/migration/pkg/utils/pcdutils.go
@@ -122,7 +122,7 @@ func CreateEntryForNoPCDCluster(ctx context.Context, k8sClient client.Client, op
 			},
 		},
 		Spec: vjailbreakv1alpha1.PCDClusterSpec{
-			ClusterName:                   fmt.Sprintf("%s-%s", openstackCreds.Name, constants.PCDClusterNameNoCluster),
+			ClusterName:                   fmt.Sprintf("%s - %s", openstackCreds.Name, constants.PCDClusterNameNoCluster),
 			Description:                   "",
 			Hosts:                         []string{},
 			VMHighAvailability:            false,
@@ -312,7 +312,7 @@ func DeleteStalePCDClusters(ctx context.Context, k8sClient client.Client, openst
 	}
 	upstreamClusterNames := []string{}
 	for _, cluster := range upstreamClusterList {
-		upstreamClusterNames = append(upstreamClusterNames, cluster.Name, fmt.Sprintf("%s-%s", openstackCreds.Name, constants.PCDClusterNameNoCluster))
+		upstreamClusterNames = append(upstreamClusterNames, cluster.Name, fmt.Sprintf("%s - %s", openstackCreds.Name, constants.PCDClusterNameNoCluster))
 	}
 
 	downstreamClusterList, err := filterPCDClustersOnOpenstackCreds(ctx, k8sClient, openstackCreds)

--- a/k8s/migration/pkg/utils/pcdutils.go
+++ b/k8s/migration/pkg/utils/pcdutils.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
@@ -121,7 +122,7 @@ func CreateEntryForNoPCDCluster(ctx context.Context, k8sClient client.Client, op
 			},
 		},
 		Spec: vjailbreakv1alpha1.PCDClusterSpec{
-			ClusterName:                   constants.PCDClusterNameNoCluster,
+			ClusterName:                   fmt.Sprintf("%s-%s", openstackCreds.Name, constants.PCDClusterNameNoCluster),
 			Description:                   "",
 			Hosts:                         []string{},
 			VMHighAvailability:            false,
@@ -311,7 +312,7 @@ func DeleteStalePCDClusters(ctx context.Context, k8sClient client.Client, openst
 	}
 	upstreamClusterNames := []string{}
 	for _, cluster := range upstreamClusterList {
-		upstreamClusterNames = append(upstreamClusterNames, cluster.Name, constants.PCDClusterNameNoCluster)
+		upstreamClusterNames = append(upstreamClusterNames, cluster.Name, fmt.Sprintf("%s-%s", openstackCreds.Name, constants.PCDClusterNameNoCluster))
 	}
 
 	downstreamClusterList, err := filterPCDClustersOnOpenstackCreds(ctx, k8sClient, openstackCreds)

--- a/k8s/migration/pkg/utils/pcdutils.go
+++ b/k8s/migration/pkg/utils/pcdutils.go
@@ -43,6 +43,11 @@ func SyncPCDInfo(ctx context.Context, k8sClient client.Client, openstackCreds vj
 	if err != nil {
 		return errors.Wrap(err, "failed to list clusters")
 	}
+	err = CreateEntryForNoPCDCluster(ctx, k8sClient, &openstackCreds)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return errors.Wrap(err, "failed to create dummy PCD cluster")
+	}
+
 	for _, cluster := range clusterList {
 		err := CreatePCDClusterFromResmgrCluster(ctx, k8sClient, cluster, &openstackCreds)
 		if err != nil {
@@ -100,6 +105,35 @@ func CreatePCDClusterFromResmgrCluster(ctx context.Context, k8sClient client.Cli
 		return errors.Wrap(err, "failed to generate PCD cluster")
 	}
 	if err := k8sClient.Create(ctx, pcdCluster); err != nil {
+		return errors.Wrap(err, "failed to create PCD cluster")
+	}
+	return nil
+}
+
+func CreateEntryForNoPCDCluster(ctx context.Context, k8sClient client.Client, openstackCreds *vjailbreakv1alpha1.OpenstackCreds) error {
+	pcdCluster := vjailbreakv1alpha1.PCDCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      openstackCreds.Name,
+			Namespace: constants.NamespaceMigrationSystem,
+			Labels: map[string]string{
+				constants.OpenstackCredsLabel: openstackCreds.Name,
+			},
+		},
+		Spec: vjailbreakv1alpha1.PCDClusterSpec{
+			ClusterName:                   constants.PCDClusterNameNoCluster,
+			Description:                   "",
+			Hosts:                         []string{},
+			VMHighAvailability:            false,
+			EnableAutoResourceRebalancing: false,
+			RebalancingFrequencyMins:      0,
+		},
+		Status: vjailbreakv1alpha1.PCDClusterStatus{
+			AggregateID: 0,
+			CreatedAt:   "",
+			UpdatedAt:   "",
+		},
+	}
+	if err := k8sClient.Create(ctx, &pcdCluster); err != nil {
 		return errors.Wrap(err, "failed to create PCD cluster")
 	}
 	return nil
@@ -276,7 +310,7 @@ func DeleteStalePCDClusters(ctx context.Context, k8sClient client.Client, openst
 	}
 	upstreamClusterNames := []string{}
 	for _, cluster := range upstreamClusterList {
-		upstreamClusterNames = append(upstreamClusterNames, cluster.Name)
+		upstreamClusterNames = append(upstreamClusterNames, cluster.Name, constants.PCDClusterNameNoCluster)
 	}
 
 	downstreamClusterList, err := filterPCDClustersOnOpenstackCreds(ctx, k8sClient, openstackCreds)

--- a/v2v-helper/pkg/constants/constants.go
+++ b/v2v-helper/pkg/constants/constants.go
@@ -45,5 +45,5 @@ systemctl enable --now serial-getty@ttyS0.service`
 	OSFamilyWindows = "windowsguest"
 	OSFamilyLinux   = "linuxguest"
 
-	PCDClusterNameNoCluster = "No Cluster (migration without cluster)"
+	PCDClusterNameNoCluster = "NONE"
 )

--- a/v2v-helper/pkg/constants/constants.go
+++ b/v2v-helper/pkg/constants/constants.go
@@ -44,4 +44,6 @@ systemctl enable --now serial-getty@ttyS0.service`
 
 	OSFamilyWindows = "windowsguest"
 	OSFamilyLinux   = "linuxguest"
+
+	PCDClusterNameNoCluster = "No Cluster (migration without cluster)"
 )

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -453,7 +453,7 @@ func (osclient *OpenStackClients) CreateVM(flavor *flavors.Flavor, networkIDs, p
 		FlavorRef: flavor.ID,
 		Networks:  openstacknws,
 	}
-	if availabilityZone != "" {
+	if availabilityZone != "" && availabilityZone != constants.PCDClusterNameNoCluster {
 		// for PCD, this will be set to cluster name
 		serverCreateOpts.AvailabilityZone = availabilityZone
 	}

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -453,7 +453,7 @@ func (osclient *OpenStackClients) CreateVM(flavor *flavors.Flavor, networkIDs, p
 		FlavorRef: flavor.ID,
 		Networks:  openstacknws,
 	}
-	if availabilityZone != "" && availabilityZone != constants.PCDClusterNameNoCluster {
+	if availabilityZone != "" && strings.Contains(availabilityZone, constants.PCDClusterNameNoCluster) {
 		// for PCD, this will be set to cluster name
 		serverCreateOpts.AvailabilityZone = availabilityZone
 	}

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -453,7 +453,7 @@ func (osclient *OpenStackClients) CreateVM(flavor *flavors.Flavor, networkIDs, p
 		FlavorRef: flavor.ID,
 		Networks:  openstacknws,
 	}
-	if availabilityZone != "" && strings.Contains(availabilityZone, constants.PCDClusterNameNoCluster) {
+	if availabilityZone != "" && !strings.Contains(availabilityZone, constants.PCDClusterNameNoCluster) {
 		// for PCD, this will be set to cluster name
 		serverCreateOpts.AvailabilityZone = availabilityZone
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #609 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR implements support for clusterless migration on PCD by adding new constants and utilities for handling scenarios without a cluster. It introduces a function to create dummy clusters when needed, refines conditional logic in cluster management and openstack ops modules, and standardizes naming conventions across modules to address issue #609.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>