### PR TITLE
fix part-to-dev input

### DIFF
--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -287,14 +287,14 @@ func CheckForLVM(disks []vm.VMDisk) (string, error) {
 	command := "inspect-os"
 	osPath, err := RunCommandInGuestAllVolumes(disks, command, false)
 	if err != nil {
-		return "", fmt.Errorf("failed to run command (%s): %v: %s\n", command, err, strings.TrimSpace(osPath))
+		return "", fmt.Errorf("failed to run command (%s): %v: %s", command, err, strings.TrimSpace(osPath))
 	}
 
 	// Get the lvs list
 	command = "lvs"
 	lvsStr, err := RunCommandInGuestAllVolumes(disks, command, false)
 	if err != nil {
-		return "", fmt.Errorf("failed to run command (%s): %v: %s\n", command, err, strings.TrimSpace(lvsStr))
+		return "", fmt.Errorf("failed to run command (%s): %v: %s", command, err, strings.TrimSpace(lvsStr))
 	}
 
 	lvs := strings.Split(string(lvsStr), "\n")
@@ -340,7 +340,7 @@ func GetBootableVolumeIndex(disks []vm.VMDisk) (int, error) {
 		return -1, fmt.Errorf("failed to run command (%s): %v: %s", command, err, strings.TrimSpace(partitionsStr))
 	}
 
-	partitions := strings.Split(string(partitionsStr), "\n")
+	partitions := strings.Split(strings.TrimSpace(partitionsStr), "\n")
 	for _, partition := range partitions {
 		command := "part-to-dev"
 		device, err := RunCommandInGuestAllVolumes(disks, command, false, strings.TrimSpace(partition))


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
fixes #613 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR improves error handling in virtv2v operations by fixing newline formatting in 'inspect-os' and 'lvs' commands and enhancing partition string parsing with proper trimming. These changes deliver cleaner error reporting and more consistent command output handling, directly addressing issue #613.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>