### PR TITLE
Fix RC file parsing to support special characters in OpenStack credentials.

### DIFF
--- a/ui/src/components/forms/OpenstackRCFileUpload.tsx
+++ b/ui/src/components/forms/OpenstackRCFileUpload.tsx
@@ -72,7 +72,6 @@ const OpenstackRCFileUploader = forwardRef<OpenstackRCFileUploaderRef, Openstack
         const parsedFields = parseFields(content)
         const isValid = validateFields(parsedFields)
         if (isValid) {
-          console.log("Sending parsedFields to backend:", parsedFields);
           onChange(parsedFields)
         }
       } catch {
@@ -87,18 +86,20 @@ const OpenstackRCFileUploader = forwardRef<OpenstackRCFileUploaderRef, Openstack
 
   const parseFields = (content: string) => {
    
+    // Remove 'export' keywords from each line
     const cleanedContent = content.replace(/^export\s+/gm, "");
     const parsedFields: Record<string, string> = {};
     const lines = cleanedContent.split('\n');
-  
+    // Parse each line as key=value, handling special cases:
     for (const line of lines) {
       const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith('#')) continue;
-      const eqIdx = trimmed.indexOf('=');
+      if (!trimmed || trimmed.startsWith('#')) continue; // Skip empty lines and lines starting with '#' (treated as comments)
+      const eqIdx = trimmed.indexOf('='); // Only process lines containing '='
       if (eqIdx === -1) continue;
       const key = trimmed.slice(0, eqIdx).trim();
       let value = trimmed.slice(eqIdx + 1).trim();
   
+      // Remove surrounding quotes from values, if present
       if (
         (value.startsWith('"') && value.endsWith('"')) ||
         (value.startsWith("'") && value.endsWith("'"))


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the OpenStack RC file parsing logic to correctly handle passwords containing the # (hash) character. With this change, passwords containing # are now accepted and validated without error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #524 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes incorrect parsing of OpenStack RC files containing special characters by implementing a custom line-by-line parser instead of using dotenv. It removes unnecessary debug logging, enhances the parser to handle special characters like '#' in credentials, and improves error handling by clearing previous errors. The changes include clearer comments and better processing of export keywords and key-value pairs for more reliable RC file parsing.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>