### PR TITLE
configmap for current vjailbreak version (release)

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -264,6 +264,12 @@ jobs:
           input: ./ui/deploy/ui.yaml
           output: ./image_builder/deploy/01ui.yaml
 
+      - name: Substitue image tags in manifests
+        uses: danielr1996/envsubst-action@1.0.0
+        with:
+          input: ./image_builder/configs/version-config.yaml
+          output: ./image_builder/deploy/version-config.yaml
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -341,3 +347,4 @@ jobs:
           path: |
             image_builder/deploy/00controller.yaml
             image_builder/deploy/01ui.yaml
+            image_builder/deploy/version-config.yaml

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,9 @@ vjail-controller-only:
 generate-manifests: vjail-controller ui
 	rm -rf image_builder/deploy && mkdir image_builder/deploy
 	envsubst < ui/deploy/ui.yaml > image_builder/deploy/01ui.yaml
+	envsubst < image_builder/configs/version-config.yaml > image_builder/deploy/version-config.yaml
 	make -C k8s/migration/ build-installer && cp k8s/migration/dist/install.yaml image_builder/deploy/00controller.yaml
-
+	
 .PHONY: build-vpwned
 build-vpwned:
 	make -C pkg/vpwned docker-build docker-push

--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -3288,7 +3288,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: quay.io/platform9/vjailbreak-controller:v0.1.14
+        image: quay.io/platform9/vjailbreak-controller:v0.1.15
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -3360,7 +3360,7 @@ spec:
         app: vpwned-sdk
     spec:
       containers:
-      - image: quay.io/platform9/vjailbreak-vpwned:v0.1.14
+      - image: quay.io/platform9/vjailbreak-vpwned:v0.1.15
         imagePullPolicy: IfNotPresent
         name: vpwned
         ports:

--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -3288,7 +3288,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: platform9/vjailbreak-controller:v0.1.13
+        image: quay.io/platform9/vjailbreak-controller:v0.1.14
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -3360,7 +3360,7 @@ spec:
         app: vpwned-sdk
     spec:
       containers:
-      - image: platform9/vjailbreak-vpwned:v0.1.13
+      - image: quay.io/platform9/vjailbreak-vpwned:v0.1.14
         imagePullPolicy: IfNotPresent
         name: vpwned
         ports:

--- a/image_builder/configs/version-config.yaml
+++ b/image_builder/configs/version-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: version-config
+  namespace: migration-system
+data:
+  version: ${TAG}
+  upgradeAvailable: "false"
+  upgradeVersion: ""

--- a/image_builder/vjailbreak-image.pkr.hcl
+++ b/image_builder/vjailbreak-image.pkr.hcl
@@ -59,6 +59,11 @@ build {
   }
 
   provisioner "file" {
+    source      = "${path.root}/configs/version-config.yaml"
+    destination = "/tmp/version-config.yaml"
+  }
+
+  provisioner "file" {
     source      = "${path.root}/configs/rsyncd.conf"
     destination = "/tmp/rsyncd.conf"
   }
@@ -88,6 +93,7 @@ build {
     "sudo mv /tmp/yamls /etc/pf9/yamls",
     "sudo mv /tmp/rsyncd.conf /etc/pf9/rsyncd.conf",
     "sudo mv /tmp/daemonset.yaml /etc/pf9/yamls/daemonset.yaml",
+    "sudo mv /tmp/version-config.yaml /etc/pf9/yamls/version-config.yaml",
     "sudo mv /tmp/env /etc/pf9/env",
     "sudo chmod +x /etc/pf9/install.sh",
     "sudo chown root:root /etc/pf9/k3s.env",

--- a/image_builder/vjailbreak-image.pkr.hcl
+++ b/image_builder/vjailbreak-image.pkr.hcl
@@ -88,7 +88,6 @@ build {
     "sudo mv /tmp/yamls /etc/pf9/yamls",
     "sudo mv /tmp/rsyncd.conf /etc/pf9/rsyncd.conf",
     "sudo mv /tmp/daemonset.yaml /etc/pf9/yamls/daemonset.yaml",
-    "sudo mv /tmp/version-config.yaml /etc/pf9/yamls/version-config.yaml",
     "sudo mv /tmp/env /etc/pf9/env",
     "sudo chmod +x /etc/pf9/install.sh",
     "sudo chown root:root /etc/pf9/k3s.env",

--- a/image_builder/vjailbreak-image.pkr.hcl
+++ b/image_builder/vjailbreak-image.pkr.hcl
@@ -59,11 +59,6 @@ build {
   }
 
   provisioner "file" {
-    source      = "${path.root}/configs/version-config.yaml"
-    destination = "/tmp/version-config.yaml"
-  }
-
-  provisioner "file" {
     source      = "${path.root}/configs/rsyncd.conf"
     destination = "/tmp/rsyncd.conf"
   }

--- a/k8s/migration/config/addons/kustomization.yaml
+++ b/k8s/migration/config/addons/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: vpwned
   newName: quay.io/platform9/vjailbreak-vpwned
-  newTag: v0.1.14
+  newTag: v0.1.15

--- a/k8s/migration/config/addons/kustomization.yaml
+++ b/k8s/migration/config/addons/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: vpwned
-  newName: platform9/vjailbreak-vpwned
-  newTag: v0.1.13
+  newName: quay.io/platform9/vjailbreak-vpwned
+  newTag: v0.1.14

--- a/k8s/migration/config/manager/kustomization.yaml
+++ b/k8s/migration/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: platform9/vjailbreak-controller
-  newTag: v0.1.13
+  newName: quay.io/platform9/vjailbreak-controller
+  newTag: v0.1.14

--- a/k8s/migration/config/manager/kustomization.yaml
+++ b/k8s/migration/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/platform9/vjailbreak-controller
-  newTag: v0.1.14
+  newTag: v0.1.15


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 

**Testing Done**
<img width="1440" alt="Screenshot 2025-06-26 at 6 07 00 PM" src="https://github.com/user-attachments/assets/12728bf6-3934-44fa-9151-f53af9fd4e6c" />


 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR introduces a ConfigMap-based version configuration feature by updating the image builder configuration and removing the version-config.yaml file move command. Changes include modifications to the Makefile while maintaining the overall file structure. YAML and kustomization files have been updated with current image tags to streamline manifest generation and improve deployment consistency.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>