### PR TITLE
( release ) improve logging in v2v-helper while running guestfish commands on the volumes 

### DIFF
--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -19,6 +19,7 @@ import (
 	"unicode"
 
 	"github.com/platform9/vjailbreak/v2v-helper/pkg/constants"
+	"github.com/platform9/vjailbreak/v2v-helper/pkg/utils"
 	"github.com/platform9/vjailbreak/v2v-helper/vm"
 )
 
@@ -270,9 +271,10 @@ func RunCommandInGuest(path string, command string, write bool) (string, error) 
 		"-a",
 		path,
 		"-i")
-	cmd.Stdin = strings.NewReader(command)
-	log.Printf("Executing %s", cmd.String()+" "+command)
-	out, err := cmd.Output()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	out, err := utils.RunAndLogCommand(cmd)
 	if err != nil {
 		return "", fmt.Errorf("failed to run command (%s): %v: %s", command, err, strings.TrimSpace(string(out)))
 	}
@@ -326,7 +328,7 @@ func RunCommandInGuestAllVolumes(disks []vm.VMDisk, command string, write bool, 
 	os.Setenv("LIBGUESTFS_BACKEND", "direct")
 	cmd := prepareGuestfishCommand(disks, command, write, args...)
 	log.Printf("Executing %s", cmd.String())
-	out, err := cmd.CombinedOutput()
+	out, err := utils.RunAndLogCommand(cmd)
 	if err != nil {
 		return "", fmt.Errorf("failed to run command (%s): %v: %s", command, err, strings.TrimSpace(string(out)))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #641 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances logging and error handling in v2v-helper and virtv2v modules by introducing a new RunAndLogCommand utility function. The implementation standardizes command execution logging, particularly for guestfish commands in virtv2vops.go, resulting in improved diagnostics and more robust error reporting for external command execution.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>