### PR TITLE
added a common library to avoid cyclic dependency

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -1,0 +1,11 @@
+module github.com/platform9/vjailbreak/common
+
+go 1.24.0
+
+require k8s.io/apimachinery v0.33.2
+
+require (
+	github.com/go-logr/logr v1.4.2 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
+)

--- a/common/go.sum
+++ b/common/go.sum
@@ -1,0 +1,8 @@
+github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
+github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+k8s.io/apimachinery v0.33.2 h1:IHFVhqg59mb8PJWTLi8m1mAoepkUNYmptHsV+Z1m5jY=
+k8s.io/apimachinery v0.33.2/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
+k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
+k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
+k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
+k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// ConvertToK8sName converts a name to be Kubernetes-compatible
+func ConvertToK8sName(name string) (string, error) {
+	// Convert to lowercase
+	name = strings.ToLower(name)
+	// Replace separators with hyphens
+	re := regexp.MustCompile(`[_\s]`)
+	name = re.ReplaceAllString(name, "-")
+	// Remove all characters that are not lowercase alphanumeric, hyphens, or periods
+	re = regexp.MustCompile(`[^a-z0-9\-.]`)
+	name = re.ReplaceAllString(name, "")
+	// Remove leading and trailing hyphens
+	name = strings.Trim(name, "-")
+	// Truncate to 242 characters, as we prepend v2v-helper- to the name
+	if len(name) > 242 {
+		name = name[:242]
+	}
+	nameerrors := validation.IsQualifiedName(name)
+	if len(nameerrors) == 0 {
+		return name, nil
+	}
+	return name, fmt.Errorf("name '%s' is not a valid K8s name: %v", name, nameerrors)
+}


### PR DESCRIPTION
## What this PR does / why we need it

This PR introduces a new Go module within the vjailbreak monorepo.
Previously, the k8s/migration and v2v-helper packages had circular import dependencies, which caused build and dependency resolution issues. To address this, a separate module has been created to decouple these components and eliminate the cyclic imports.

## Which issue(s) this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #

## Special notes for your reviewer

## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces a new common library module to resolve cyclic dependency issues in the monorepo. It sets up module configuration files (go.mod and go.sum) and adds a utility function for converting strings to Kubernetes-compatible names, ultimately improving build reliability and decoupling interdependent packages.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>