### PR TITLE
fix condition for triggering vm migrations (release)

### DIFF
--- a/k8s/migration/internal/controller/clustermigration_controller.go
+++ b/k8s/migration/internal/controller/clustermigration_controller.go
@@ -135,7 +135,7 @@ func (r *ClusterMigrationReconciler) reconcileNormal(ctx context.Context, scope 
 	}
 
 	// count successful esxiMigrations, we want to trigger vm migrations
-	// only if more than one esxi migration is successful
+	// only if one or more esxi migrations are successful
 	successfulESXiMigrations, err := countSuccessfulESXIMigrations(ctx, scope)
 	if err != nil {
 		log.Error(err, "Failed to count successful ESXi migrations")
@@ -214,7 +214,7 @@ func (r *ClusterMigrationReconciler) reconcileNormal(ctx context.Context, scope 
 			log.Info("Requeuing ClusterMigration for further processing", "requeueAfter", "1m")
 			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
-		
+
 		log.Info("ESXIMigration is in another state, updating ClusterMigration status to pending", "esxiName", esxi, "esxiPhase", esxiMigration.Status.Phase)
 		err = r.UpdateClusterMigrationStatus(ctx, scope, vjailbreakv1alpha1.ClusterMigrationPhasePending, esxiMigration.Status.Message, esxi)
 		if err != nil {

--- a/k8s/migration/internal/controller/clustermigration_controller.go
+++ b/k8s/migration/internal/controller/clustermigration_controller.go
@@ -143,7 +143,7 @@ func (r *ClusterMigrationReconciler) reconcileNormal(ctx context.Context, scope 
 	}
 
 	log.Info("Counted successful ESXi migrations", "count", successfulESXiMigrations)
-	if successfulESXiMigrations > 1 {
+	if successfulESXiMigrations >= 1 {
 		err = handleVMMigrations(ctx, scope)
 		if err != nil {
 			log.Error(err, "Failed to handle VM migrations")

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -576,6 +576,10 @@ func GetAllVMs(ctx context.Context, k3sclient client.Client, vmwcreds *vjailbrea
 			fmt.Printf("VM properties not available for vm (%s), skipping this VM\n", vm.Name())
 			continue
 		}
+		// exclude vCLS VMs
+		if strings.Contains(vmProps.Config.Name, "vCLS-") {
+			continue
+		}
 		var datastores []string
 		var networks []string
 		var disks []string

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -577,7 +577,7 @@ func GetAllVMs(ctx context.Context, k3sclient client.Client, vmwcreds *vjailbrea
 			continue
 		}
 		// exclude vCLS VMs
-		if strings.Contains(vmProps.Config.Name, "vCLS-") {
+		if strings.HasPrefix(vmProps.Config.Name, "vCLS-") {
 			continue
 		}
 		var datastores []string


### PR DESCRIPTION
## What this PR does / why we need it

## Which issue(s) this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #

## Special notes for your reviewer

## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes a logic error in the Kubernetes migration controller by modifying the conditional check to ensure that even a single successful ESXi migration triggers the VM migration handling function. It also adds an exclusion check for vCLS VMs in credential utilities to prevent unnecessary processing, implementing stricter prefix matching and improving the reliability of the overall migration workflow.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>