### PR TITLE
Backport: vPwned: fix condition trigger for vm migrations

### DIFF
--- a/k8s/migration/internal/controller/clustermigration_controller.go
+++ b/k8s/migration/internal/controller/clustermigration_controller.go
@@ -135,7 +135,7 @@ func (r *ClusterMigrationReconciler) reconcileNormal(ctx context.Context, scope 
 	}
 
 	// count successful esxiMigrations, we want to trigger vm migrations
-	// only if more than one esxi migration is successful
+	// only if one or more esxi migrations are successful
 	successfulESXiMigrations, err := countSuccessfulESXIMigrations(ctx, scope)
 	if err != nil {
 		log.Error(err, "Failed to count successful ESXi migrations")

--- a/k8s/migration/internal/controller/clustermigration_controller.go
+++ b/k8s/migration/internal/controller/clustermigration_controller.go
@@ -143,7 +143,7 @@ func (r *ClusterMigrationReconciler) reconcileNormal(ctx context.Context, scope 
 	}
 
 	log.Info("Counted successful ESXi migrations", "count", successfulESXiMigrations)
-	if successfulESXiMigrations > 1 {
+	if successfulESXiMigrations >= 1 {
 		err = handleVMMigrations(ctx, scope)
 		if err != nil {
 			log.Error(err, "Failed to handle VM migrations")

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -924,7 +924,7 @@ func GetAllVMs(ctx context.Context, k3sclient client.Client, vmwcreds *vjailbrea
 		}
 
 		// exclude vCLS VMs
-		if strings.Contains(vmProps.Config.Name, "vCLS-") {
+		if strings.HasPrefix(vmProps.Config.Name, "vCLS-") {
 			continue
 		}
 

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -923,6 +923,11 @@ func GetAllVMs(ctx context.Context, k3sclient client.Client, vmwcreds *vjailbrea
 			}
 		}
 
+		// exclude vCLS VMs
+		if strings.Contains(vmProps.Config.Name, "vCLS-") {
+			continue
+		}
+
 		vminfo = append(vminfo, vjailbreakv1alpha1.VMInfo{
 			Name:              vmProps.Config.Name,
 			Datastores:        datastores,


### PR DESCRIPTION
## What this PR does / why we need it

## Which issue(s) this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #

## Special notes for your reviewer

## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR modifies the cluster migration controller to trigger VM migrations when at least one ESXi migration succeeds, rather than requiring more than one. It also fixes an issue by replacing a generic string check with a specific prefix check in credential utilities to properly exclude vCLS VMs, enhancing overall migration reliability and efficiency.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>