### PR TITLE
add kubernetes dashboard by default to grafana

### DIFF
--- a/k8s/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
+++ b/k8s/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
@@ -24679,497 +24679,552 @@ items:
 - apiVersion: v1
   data:
     k8s-overview.json: |-
-      {
-        "__inputs": [
-          {
-            "name": "DS_PROMETHEUS",
-            "label": "Prometheus",
-            "description": "",
-            "type": "datasource",
-            "pluginId": "prometheus",
-            "pluginName": "Prometheus"
-          }
-        ],
-        "__requires": [
-          {
-            "type": "panel",
-            "id": "bargauge",
-            "name": "Bar gauge",
-            "version": ""
-          },
-          {
-            "type": "grafana",
-            "id": "grafana",
-            "name": "Grafana",
-            "version": "7.5.11"
-          },
-          {
-            "type": "panel",
-            "id": "graph",
-            "name": "Graph",
-            "version": ""
-          },
-          {
-            "type": "datasource",
-            "id": "prometheus",
-            "name": "Prometheus",
-            "version": "1.0.0"
-          },
-          {
-            "type": "panel",
-            "id": "table",
-            "name": "Table",
-            "version": ""
-          }
-        ],
+        {
         "annotations": {
-          "list": [
+            "list": [
             {
-              "$$hashKey": "object:247",
-              "builtIn": 1,
-              "datasource": "-- Grafana --",
-              "enable": true,
-              "hide": true,
-              "iconColor": "rgba(0, 211, 255, 1)",
-              "name": "Annotations & Alerts",
-              "target": {
+                "$$hashKey": "object:247",
+                "builtIn": 1,
+                "datasource": {
+                "type": "datasource",
+                "uid": "grafana"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
                 "limit": 100,
                 "matchAny": false,
                 "tags": [],
                 "type": "dashboard"
-              },
-              "type": "dashboard"
+                },
+                "type": "dashboard"
             }
-          ]
+            ]
         },
-        "description": "【 resource overview 】2025.01.25 detail ，kubernetes Node information details ！ outflow K8S Node resource overview 、 Network bandwidth per second 、Pod Resource details K8S Network overview ， Optimizing important metrics display 。https://github.com/starsliao/Prometheus",
+        "description": "【English version】2025.01.25 Updates，kubernetesComprehensive display of resources！Includes K8S Overall Resource Overview、Microservices Resource Details、Pod Resource Details andK8SNetwork Bandwidth，Optimization metrics。https://grafana.com/orgs/starsliao/dashboards",
         "editable": true,
+        "fiscalYearStartMonth": 0,
         "gnetId": 15661,
         "graphTooltip": 0,
-        "id": null,
-        "iteration": 1633873748245,
+        "id": 30,
         "links": [
-          {
+            {
             "icon": "bolt",
             "tags": [],
             "targetBlank": true,
             "title": "Update",
-            "tooltip": " Update current dashboard ",
+            "tooltip": "See more dashboards",
             "type": "link",
-            "url": "https://grafana.com/dashboards/13105"
-          },
-          {
+            "url": "https://grafana.com/orgs/starsliao/dashboards"
+            },
+            {
             "$$hashKey": "object:831",
             "icon": "question",
             "tags": [
-              "node_exporter"
+                "node_exporter"
             ],
             "targetBlank": true,
             "title": "GitHub",
-            "tooltip": " Overall memory usage  ",
+            "tooltip": "View more dashboards",
             "type": "link",
-            "url": "https://github.com/starsliao/Prometheus"
-          },
-          {
-            "$$hashKey": "object:1091",
-            "asDropdown": true,
-            "icon": "external link",
-            "tags": [],
-            "targetBlank": true,
-            "type": "dashboards"
-          }
+            "url": "https://github.com/starsliao"
+            }
         ],
+        "liveNow": false,
         "panels": [
-          {
+            {
             "collapsed": false,
-            "datasource": "${datasource}",
+            "datasource": {
+                "type": "prometheus",
+                "uid": "WAYOn0FGz"
+            },
             "gridPos": {
-              "h": 1,
-              "w": 24,
-              "x": 0,
-              "y": 0
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
             },
             "id": 54,
             "panels": [],
-            "title": " Node Storage Information ： Number of cores used :【$Node】",
+            "title": "Node Resource Overview：Selected Nodes:【$Node】",
             "type": "row"
-          },
-          {
-            "cacheTimeout": null,
-            "datasource": "${datasource}",
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
             "fieldConfig": {
-              "defaults": {
+                "defaults": {
                 "decimals": 1,
                 "mappings": [],
                 "max": 1,
                 "min": 0,
                 "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
+                    "mode": "absolute",
+                    "steps": [
                     {
-                      "color": "rgba(50, 172, 45, 0.97)",
-                      "value": null
+                        "color": "green",
+                        "value": null
                     },
                     {
-                      "color": "rgba(237, 129, 40, 0.89)",
-                      "value": 0.8
+                        "color": "orange",
+                        "value": 0.8
                     },
                     {
-                      "color": "rgba(245, 54, 54, 0.9)",
-                      "value": 0.99
+                        "color": "red",
+                        "value": 0.9
                     }
-                  ]
+                    ]
                 },
                 "unit": "percentunit"
-              },
-              "overrides": []
+                },
+                "overrides": []
             },
             "gridPos": {
-              "h": 4,
-              "w": 4,
-              "x": 0,
-              "y": 1
+                "h": 4,
+                "w": 4,
+                "x": 0,
+                "y": 1
             },
             "id": 44,
-            "links": [],
             "options": {
-              "displayMode": "basic",
-              "orientation": "vertical",
-              "reduceOptions": {
+                "displayMode": "basic",
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "vertical",
+                "reduceOptions": {
                 "calcs": [
-                  "last"
+                    "last"
                 ],
                 "fields": "",
                 "values": false
-              },
-              "showUnfilled": true,
-              "text": {}
+                },
+                "showUnfilled": false,
+                "sizing": "auto",
+                "text": {},
+                "valueMode": "color"
             },
-            "pluginVersion": "7.5.11",
+            "pluginVersion": "11.2.0",
             "targets": [
-              {
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
                 "exemplar": true,
                 "expr": "sum(container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})",
+                "format": "time_series",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": " Memory Limit Rate ",
+                "legendFormat": "Memory Utilization",
                 "refId": "C"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
                 "exemplar": true,
                 "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})",
+                "format": "time_series",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": " Total memory usage ",
+                "legendFormat": "Memory Request Rate",
                 "refId": "A"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
                 "exemplar": true,
                 "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})",
+                "format": "time_series",
                 "hide": false,
                 "instant": true,
-                "interval": "10s",
+                "interval": "",
                 "intervalFactor": 1,
-                "legendFormat": " Total Memory Demand ",
+                "legendFormat": "Memory Limit Rate",
                 "refId": "B",
                 "step": 10
-              }
+                }
             ],
-            "title": " Overall core usage ",
+            "title": "Node Memory Ratio",
             "type": "bargauge"
-          },
-          {
-            "cacheTimeout": null,
-            "datasource": "${datasource}",
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
             "fieldConfig": {
-              "defaults": {
+                "defaults": {
                 "decimals": 1,
                 "mappings": [],
                 "max": 1,
                 "min": 0,
                 "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
+                    "mode": "absolute",
+                    "steps": [
                     {
-                      "color": "rgba(50, 172, 45, 0.97)",
-                      "value": null
+                        "color": "green",
+                        "value": null
                     },
                     {
-                      "color": "rgba(237, 129, 40, 0.89)",
-                      "value": 0.8
+                        "color": "orange",
+                        "value": 0.7
                     },
                     {
-                      "color": "rgba(245, 54, 54, 0.9)",
-                      "value": 0.99
+                        "color": "red",
+                        "value": 0.9
                     }
-                  ]
+                    ]
                 },
                 "unit": "percentunit"
-              },
-              "overrides": []
+                },
+                "overrides": []
             },
             "gridPos": {
-              "h": 4,
-              "w": 4,
-              "x": 4,
-              "y": 1
+                "h": 4,
+                "w": 4,
+                "x": 4,
+                "y": 1
             },
             "id": 45,
-            "links": [],
             "options": {
-              "displayMode": "basic",
-              "orientation": "vertical",
-              "reduceOptions": {
+                "displayMode": "basic",
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "vertical",
+                "reduceOptions": {
                 "calcs": [
-                  "lastNotNull"
+                    "last"
                 ],
                 "fields": "",
                 "values": false
-              },
-              "showUnfilled": true,
-              "text": {}
+                },
+                "showUnfilled": false,
+                "sizing": "auto",
+                "text": {},
+                "valueMode": "color"
             },
-            "pluginVersion": "7.5.11",
+            "pluginVersion": "11.2.0",
             "targets": [
-              {
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
                 "exemplar": true,
                 "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}[2m])) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})",
+                "format": "time_series",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": "CPU Request Rate ",
+                "legendFormat": "CPU Utilization Rate",
                 "refId": "C"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
                 "exemplar": true,
                 "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})",
+                "format": "time_series",
                 "instant": true,
                 "interval": "",
-                "legendFormat": "CPU total memory ",
+                "legendFormat": "CPU Request Rate",
                 "refId": "A"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
                 "exemplar": true,
                 "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})",
+                "format": "time_series",
                 "instant": true,
                 "interval": "",
-                "legendFormat": "CPU Nodes ",
+                "legendFormat": "CPU Limit Rate",
                 "refId": "B"
-              }
+                }
             ],
-            "title": " container CPU proportion ",
+            "title": "Node CPU Ratio",
             "type": "bargauge"
-          },
-          {
-            "datasource": "${datasource}",
-            "description": " Memory Request Rate ， container POD core ， container POD disk ",
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "description": "Number of cluster nodes，Nodes POD Number of，NodesPODUpper Limit",
             "fieldConfig": {
-              "defaults": {
+                "defaults": {
                 "mappings": [],
-                "max": 1000,
+                "max": 100,
                 "min": 1,
                 "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
+                    "mode": "absolute",
+                    "steps": [
                     {
-                      "color": "green",
-                      "value": null
+                        "color": "green",
+                        "value": null
                     },
                     {
-                      "color": "#EAB839",
-                      "value": 1000
+                        "color": "orange",
+                        "value": 1000
                     },
                     {
-                      "color": "red",
-                      "value": 2000
+                        "color": "red",
+                        "value": 2000
                     }
-                  ]
+                    ]
                 },
                 "unit": "none"
-              },
-              "overrides": []
+                },
+                "overrides": []
             },
             "gridPos": {
-              "h": 4,
-              "w": 3,
-              "x": 8,
-              "y": 1
+                "h": 4,
+                "w": 3,
+                "x": 8,
+                "y": 1
             },
             "id": 74,
             "options": {
-              "displayMode": "basic",
-              "orientation": "vertical",
-              "reduceOptions": {
+                "displayMode": "basic",
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "vertical",
+                "reduceOptions": {
                 "calcs": [
-                  "last"
+                    "last"
                 ],
                 "fields": "",
                 "values": false
-              },
-              "showUnfilled": true,
-              "text": {}
+                },
+                "showUnfilled": false,
+                "sizing": "auto",
+                "text": {},
+                "valueMode": "color"
             },
-            "pluginVersion": "7.5.11",
+            "pluginVersion": "11.2.0",
             "targets": [
-              {
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "expr": "count(kube_node_info{origin_prometheus=~\"$origin_prometheus\"})",
                 "instant": true,
                 "interval": "",
-                "legendFormat": " Total Cores ",
+                "legendFormat": "Number of nodes",
                 "refId": "A"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "expr": "count(kube_pod_info{origin_prometheus=~\"$origin_prometheus\",created_by_kind!~\"<none>|Job\",node=~\"^$Node$\"})",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": "Pod core ",
+                "legendFormat": "Pod Number of nodes",
                 "refId": "B"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "exemplar": true,
                 "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"pods\", unit=\"integer\",node=~\"^$Node$\"})",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": " disk Pod",
+                "legendFormat": "Upper limit Pod",
                 "refId": "C"
-              }
+                }
             ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": " microservice Pod",
+            "title": "Nodes with Pod",
             "type": "bargauge"
-          },
-          {
-            "datasource": "${datasource}",
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
             "fieldConfig": {
-              "defaults": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
                 "custom": {
-                  "align": "center",
-                  "displayMode": "auto",
-                  "filterable": false
+                    "align": "center",
+                    "cellOptions": {
+                    "type": "color-text"
+                    },
+                    "filterable": false,
+                    "inspect": false
                 },
                 "mappings": [],
                 "noValue": "0",
                 "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
+                    "mode": "absolute",
+                    "steps": [
                     {
-                      "color": "green",
-                      "value": null
+                        "color": "green",
+                        "value": null
                     },
                     {
-                      "color": "red",
-                      "value": 80
+                        "color": "red",
+                        "value": 80
                     }
-                  ]
-                }
-              },
-              "overrides": [
+                    ]
+                },
+                "unit": "none"
+                },
+                "overrides": [
                 {
-                  "matcher": {
+                    "matcher": {
                     "id": "byName",
-                    "options": " use "
-                  },
-                  "properties": [
+                    "options": "Space"
+                    },
+                    "properties": [
                     {
-                      "id": "custom.width",
-                      "value": 8
+                        "id": "custom.width",
+                        "value": 59
                     }
-                  ]
+                    ]
                 },
                 {
-                  "matcher": {
+                    "matcher": {
                     "id": "byName",
                     "options": "Pod"
-                  },
-                  "properties": [
+                    },
+                    "properties": [
                     {
-                      "id": "custom.width",
-                      "value": 21
+                        "id": "custom.width",
+                        "value": 21
                     }
-                  ]
+                    ]
                 },
                 {
-                  "matcher": {
+                    "matcher": {
                     "id": "byName",
                     "options": "SVC"
-                  },
-                  "properties": [
+                    },
+                    "properties": [
                     {
-                      "id": "custom.width",
-                      "value": 7
+                        "id": "custom.width",
+                        "value": 7
                     }
-                  ]
+                    ]
                 },
                 {
-                  "matcher": {
+                    "matcher": {
                     "id": "byName",
-                    "options": " usage "
-                  },
-                  "properties": [
+                    "options": "Microservices"
+                    },
+                    "properties": [
                     {
-                      "id": "custom.width",
-                      "value": 4
+                        "id": "custom.width",
+                        "value": 4
                     }
-                  ]
+                    ]
                 },
                 {
-                  "matcher": {
+                    "matcher": {
                     "id": "byName",
-                    "options": " memory "
-                  },
-                  "properties": [
+                    "options": "Configuration"
+                    },
+                    "properties": [
                     {
-                      "id": "custom.width",
-                      "value": 16
+                        "id": "custom.width",
+                        "value": 16
                     }
-                  ]
+                    ]
                 },
                 {
-                  "matcher": {
+                    "matcher": {
                     "id": "byName",
-                    "options": " request "
-                  },
-                  "properties": [
+                    "options": "Passwords"
+                    },
+                    "properties": [
                     {
-                      "id": "custom.width",
-                      "value": 33
+                        "id": "custom.width",
+                        "value": 33
                     }
-                  ]
+                    ]
                 }
-              ]
+                ]
             },
             "gridPos": {
-              "h": 8,
-              "w": 5,
-              "x": 11,
-              "y": 1
+                "h": 8,
+                "w": 5,
+                "x": 11,
+                "y": 1
             },
             "id": 51,
             "options": {
-              "showHeader": true,
-              "sortBy": [
+                "cellHeight": "sm",
+                "footer": {
+                "countRows": false,
+                "fields": "",
+                "reducer": [
+                    "sum"
+                ],
+                "show": true
+                },
+                "showHeader": true,
+                "sortBy": [
                 {
-                  "desc": true,
-                  "displayName": " use "
+                    "desc": true,
+                    "displayName": "Microservices"
                 }
-              ]
+                ]
             },
-            "pluginVersion": "7.5.11",
+            "pluginVersion": "11.2.0",
             "targets": [
-              {
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
                 "expr": "count(kube_pod_info{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\"}) by (namespace)",
                 "format": "table",
                 "instant": true,
                 "interval": "",
                 "legendFormat": "",
                 "refId": "A"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
                 "expr": "count(kube_service_info{origin_prometheus=~\"$origin_prometheus\"}) by(namespace)",
                 "format": "table",
                 "hide": false,
@@ -25177,17 +25232,27 @@ items:
                 "interval": "",
                 "legendFormat": "",
                 "refId": "C"
-              },
-              {
-                "expr": "count(count(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\"}) by(container,namespace))by(namespace)",
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "count by (namespace)({__name__=~\"kube_deployment_metadata_generation|kube_daemonset_metadata_generation|kube_statefulset_metadata_generation\",origin_prometheus=~\"$origin_prometheus\"})",
                 "format": "table",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": "",
+                "legendFormat": "__auto",
                 "refId": "D"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
                 "expr": "count(kube_configmap_info{origin_prometheus=~\"$origin_prometheus\"}) by(namespace)",
                 "format": "table",
                 "hide": false,
@@ -25195,8 +25260,13 @@ items:
                 "interval": "",
                 "legendFormat": "configmap",
                 "refId": "B"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
                 "expr": "count(kube_secret_info{origin_prometheus=~\"$origin_prometheus\"}) by(namespace)",
                 "format": "table",
                 "hide": false,
@@ -25204,29 +25274,29 @@ items:
                 "interval": "",
                 "legendFormat": "secret",
                 "refId": "E"
-              }
+                }
             ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": " average memory ",
+            "title": "Namespace Resource Statistics",
             "transformations": [
-              {
+                {
                 "id": "seriesToColumns",
                 "options": {
-                  "byField": "namespace"
+                    "byField": "namespace"
                 }
-              },
-              {
+                },
+                {
                 "id": "organize",
                 "options": {
-                  "excludeByName": {
+                    "excludeByName": {
+                    "Time": true,
                     "Time 1": true,
                     "Time 2": true,
                     "Time 3": true,
                     "Time 4": true,
                     "Time 5": true
-                  },
-                  "indexByName": {
+                    },
+                    "includeByName": {},
+                    "indexByName": {
                     "Time 1": 2,
                     "Time 2": 4,
                     "Time 3": 6,
@@ -25234,872 +25304,1931 @@ items:
                     "Value #C": 5,
                     "Value #D": 1,
                     "namespace": 0
-                  },
-                  "renameByName": {
+                    },
+                    "renameByName": {
                     "Time 1": "",
                     "Time 2": "",
                     "Value #A": "Pod",
-                    "Value #B": " memory ",
+                    "Value #B": "Configuration",
                     "Value #C": "SVC",
-                    "Value #D": " usage ",
-                    "Value #E": " request ",
-                    "namespace": " use "
-                  }
+                    "Value #D": "Microservices",
+                    "Value #E": "Passwords",
+                    "namespace": "Spaces"
+                    }
                 }
-              }
+                }
             ],
             "type": "table"
-          },
-          {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "decimals": 2,
-            "editable": true,
-            "error": false,
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
             "fieldConfig": {
-              "defaults": {
-                "links": []
-              },
-              "overrides": []
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "series",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 30,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineStyle": {
+                    "fill": "solid"
+                    },
+                    "lineWidth": 2,
+                    "pointSize": 4,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green",
+                        "value": null
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "binbps"
+                },
+                "overrides": []
             },
-            "fill": 1,
-            "fillGradient": 0,
-            "grid": {},
             "gridPos": {
-              "h": 8,
-              "w": 8,
-              "x": 16,
-              "y": 1
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 1
             },
-            "height": "200px",
-            "hiddenSeries": false,
             "id": 32,
-            "isNew": true,
-            "legend": {
-              "alignAsTable": false,
-              "avg": true,
-              "current": true,
-              "max": false,
-              "min": false,
-              "rightSide": false,
-              "show": false,
-              "sideWidth": 200,
-              "sort": "current",
-              "sortDesc": true,
-              "total": false,
-              "values": true
-            },
-            "lines": true,
-            "linewidth": 2,
-            "links": [],
-            "nullPointMode": "null",
             "options": {
-              "alertThreshold": true
+                "legend": {
+                "calcs": [
+                    "max"
+                ],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true,
+                "width": 200
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
             },
-            "percentage": false,
-            "pluginVersion": "7.5.11",
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
+            "pluginVersion": "10.4.1",
             "targets": [
-              {
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
                 "exemplar": true,
-                "expr": "sum (rate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m]))*8",
+                "expr": "sum (irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m]))*8",
                 "format": "time_series",
                 "interval": "",
                 "intervalFactor": 1,
-                "legendFormat": " inflow ",
+                "legendFormat": "Receive",
                 "metric": "network",
+                "range": true,
                 "refId": "A",
                 "step": 10
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
                 "exemplar": true,
-                "expr": "sum (rate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m]))*8",
+                "expr": "sum (irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m]))*8",
                 "instant": false,
                 "interval": "",
                 "intervalFactor": 1,
-                "legendFormat": " status ",
+                "legendFormat": "Send",
                 "metric": "network",
                 "refId": "B",
                 "step": 10
-              }
+                }
             ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "$NameSpace： selected nodes （ Associating nodes and namespaces ）",
-            "tooltip": {
-              "msResolution": false,
-              "shared": true,
-              "sort": 0,
-              "value_type": "cumulative"
+            "title": "$NameSpace：Network Overview（Associable nodes and namespaces）",
+            "type": "timeseries"
             },
-            "type": "graph",
-            "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
             },
-            "yaxes": [
-              {
-                "$$hashKey": "object:750",
-                "format": "binbps",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "$$hashKey": "object:751",
-                "format": "Bps",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": false
-              }
-            ],
-            "yaxis": {
-              "align": false,
-              "alignLevel": null
-            }
-          },
-          {
-            "datasource": "${datasource}",
             "fieldConfig": {
-              "defaults": {
+                "defaults": {
                 "decimals": 1,
                 "mappings": [],
-                "max": 1000000000000,
+                "max": 2000000000000,
                 "min": 1,
                 "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
+                    "mode": "absolute",
+                    "steps": [
                     {
-                      "color": "green",
-                      "value": null
+                        "color": "green",
+                        "value": null
                     },
                     {
-                      "color": "#EAB839",
-                      "value": 800000000000
+                        "color": "orange",
+                        "value": 100000000000
                     },
                     {
-                      "color": "red",
-                      "value": 1000000000000
+                        "color": "red",
+                        "value": 2000000000000
                     }
-                  ]
+                    ]
                 },
                 "unit": "bytes"
-              },
-              "overrides": []
+                },
+                "overrides": []
             },
             "gridPos": {
-              "h": 4,
-              "w": 4,
-              "x": 0,
-              "y": 5
+                "h": 4,
+                "w": 4,
+                "x": 0,
+                "y": 5
             },
             "id": 71,
             "options": {
-              "displayMode": "basic",
-              "orientation": "vertical",
-              "reduceOptions": {
+                "displayMode": "basic",
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "vertical",
+                "reduceOptions": {
                 "calcs": [
-                  "lastNotNull"
+                    "last"
                 ],
                 "fields": "",
                 "values": false
-              },
-              "showUnfilled": true,
-              "text": {}
+                },
+                "showUnfilled": false,
+                "sizing": "auto",
+                "text": {},
+                "valueMode": "color"
             },
-            "pluginVersion": "7.5.11",
+            "pluginVersion": "11.2.0",
             "targets": [
-              {
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "exemplar": true,
                 "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})",
                 "instant": true,
                 "interval": "",
-                "legendFormat": " Requests ",
+                "legendFormat": "Total Memory",
                 "refId": "A"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "exemplar": true,
                 "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"})",
                 "instant": true,
                 "interval": "",
-                "legendFormat": " Nodes ",
+                "legendFormat": "Usage",
                 "refId": "C"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "exemplar": true,
                 "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})",
                 "instant": true,
                 "interval": "",
-                "legendFormat": " total disk ",
+                "legendFormat": "Requests",
                 "refId": "D"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "exemplar": true,
                 "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})",
                 "instant": true,
                 "interval": "",
-                "legendFormat": " limit rate ",
+                "legendFormat": "Limits",
                 "refId": "B"
-              }
+                }
             ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": " Resource comprehensive display ",
+            "title": "Node Memory Information",
             "type": "bargauge"
-          },
-          {
-            "datasource": "${datasource}",
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
             "fieldConfig": {
-              "defaults": {
+                "defaults": {
                 "decimals": 1,
                 "mappings": [],
                 "max": 500,
                 "min": 1,
                 "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
+                    "mode": "absolute",
+                    "steps": [
                     {
-                      "color": "green",
-                      "value": null
+                        "color": "green",
+                        "value": null
                     },
                     {
-                      "color": "#EAB839",
-                      "value": 500
+                        "color": "#EAB839",
+                        "value": 500
                     },
                     {
-                      "color": "red",
-                      "value": 1000
+                        "color": "red",
+                        "value": 1000
                     }
-                  ]
+                    ]
                 },
-                "unit": "locale"
-              },
-              "overrides": []
+                "unit": "none"
+                },
+                "overrides": []
             },
             "gridPos": {
-              "h": 4,
-              "w": 4,
-              "x": 4,
-              "y": 5
+                "h": 4,
+                "w": 4,
+                "x": 4,
+                "y": 5
             },
             "id": 72,
             "options": {
-              "displayMode": "basic",
-              "orientation": "vertical",
-              "reduceOptions": {
+                "displayMode": "basic",
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "vertical",
+                "reduceOptions": {
                 "calcs": [
-                  "last"
+                    "last"
                 ],
                 "fields": "",
                 "values": false
-              },
-              "showUnfilled": true,
-              "text": {}
+                },
+                "showUnfilled": false,
+                "sizing": "auto",
+                "text": {},
+                "valueMode": "color"
             },
-            "pluginVersion": "7.5.11",
+            "pluginVersion": "11.2.0",
             "targets": [
-              {
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "exemplar": true,
                 "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})",
                 "instant": true,
                 "interval": "",
-                "legendFormat": " usage ",
+                "legendFormat": "Total Cores",
                 "refId": "A"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "exemplar": true,
                 "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",id=\"/\",node=~\"^$Node$\"}[2m]))",
                 "instant": true,
                 "interval": "",
-                "legendFormat": " Nodes ",
+                "legendFormat": "Usage",
                 "refId": "C"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "exemplar": true,
                 "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})",
                 "instant": true,
                 "interval": "",
-                "legendFormat": " total disk ",
+                "legendFormat": "Requests",
                 "refId": "D"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "exemplar": true,
                 "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})",
                 "instant": true,
                 "interval": "",
-                "legendFormat": " limit rate ",
+                "legendFormat": "Limit",
                 "refId": "B"
-              }
+                }
             ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": " container CPU node ",
+            "title": "Node CPU Number of cores",
             "type": "bargauge"
-          },
-          {
-            "datasource": "${datasource}",
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
             "fieldConfig": {
-              "defaults": {
-                "decimals": 2,
+                "defaults": {
+                "decimals": 1,
                 "mappings": [],
                 "max": 8000000000000,
                 "min": 1,
                 "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
+                    "mode": "absolute",
+                    "steps": [
                     {
-                      "color": "green",
-                      "value": null
+                        "color": "green",
+                        "value": null
                     },
                     {
-                      "color": "#EAB839",
-                      "value": 5000000000000
+                        "color": "#EAB839",
+                        "value": 5000000000000
                     },
                     {
-                      "color": "red",
-                      "value": 10000000000000
+                        "color": "red",
+                        "value": 10000000000000
                     }
-                  ]
+                    ]
                 },
                 "unit": "bytes"
-              },
-              "overrides": [
+                },
+                "overrides": [
                 {
-                  "matcher": {
+                    "matcher": {
                     "id": "byName",
-                    "options": " Request Rate "
-                  },
-                  "properties": [
+                    "options": "Utilization"
+                    },
+                    "properties": [
                     {
-                      "id": "unit",
-                      "value": "percentunit"
+                        "id": "unit",
+                        "value": "percentunit"
                     },
                     {
-                      "id": "max",
-                      "value": 1
+                        "id": "max"
                     },
                     {
-                      "id": "min",
-                      "value": 0
+                        "id": "min",
+                        "value": 0
                     },
                     {
-                      "id": "thresholds",
-                      "value": {
+                        "id": "thresholds",
+                        "value": {
                         "mode": "percentage",
                         "steps": [
-                          {
+                            {
                             "color": "green",
                             "value": null
-                          },
-                          {
+                            },
+                            {
                             "color": "orange",
                             "value": 80
-                          },
-                          {
+                            },
+                            {
                             "color": "red",
                             "value": 90
-                          }
+                            }
                         ]
-                      }
+                        }
                     }
-                  ]
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Total"
+                    },
+                    "properties": [
+                    {
+                        "id": "decimals",
+                        "value": 0
+                    }
+                    ]
                 }
-              ]
+                ]
             },
             "gridPos": {
-              "h": 4,
-              "w": 3,
-              "x": 8,
-              "y": 5
+                "h": 4,
+                "w": 3,
+                "x": 8,
+                "y": 5
             },
             "id": 73,
             "options": {
-              "displayMode": "basic",
-              "orientation": "vertical",
-              "reduceOptions": {
+                "displayMode": "basic",
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "vertical",
+                "reduceOptions": {
                 "calcs": [
-                  "lastNotNull"
+                    "last"
                 ],
                 "fields": "",
                 "values": false
-              },
-              "showUnfilled": true,
-              "text": {}
+                },
+                "showUnfilled": false,
+                "sizing": "auto",
+                "text": {},
+                "valueMode": "color"
             },
-            "pluginVersion": "7.5.11",
+            "pluginVersion": "11.2.0",
             "targets": [
-              {
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "expr": "sum (container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"}) / sum (container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})",
                 "instant": true,
                 "interval": "",
-                "legendFormat": " Request Rate ",
+                "legendFormat": "Utilization Rate",
                 "refId": "C"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "expr": "sum (container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})",
                 "instant": true,
                 "interval": "",
-                "legendFormat": " Nodes ",
+                "legendFormat": "Usage",
                 "refId": "A"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "expr": "sum (container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})",
                 "instant": true,
                 "interval": "",
-                "legendFormat": " name ",
+                "legendFormat": "Total",
                 "refId": "B"
-              }
+                }
             ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": " Node memory ratio ",
+            "title": "Node Storage Information",
             "type": "bargauge"
-          },
-          {
-            "datasource": "${datasource}",
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
             "fieldConfig": {
-              "defaults": {
+                "defaults": {
                 "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "center",
-                  "displayMode": "auto",
-                  "filterable": false
+                    "mode": "palette-classic"
                 },
                 "mappings": [],
                 "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
+                    "mode": "absolute",
+                    "steps": [
                     {
-                      "color": "green",
-                      "value": null
+                        "color": "green",
+                        "value": null
                     },
                     {
-                      "color": "red",
-                      "value": 80
+                        "color": "red",
+                        "value": 80
                     }
-                  ]
+                    ]
                 }
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Pod"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 51
-                    }
-                  ]
                 },
+                "overrides": [
                 {
-                  "matcher": {
-                    "id": "byName",
-                    "options": " include "
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 51
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "CPU limit ( number )"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 63
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "CPU total "
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 54
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "CPU total "
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 58
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": " memory request "
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 78
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": " Total Memory "
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 76
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": " Network bandwidth "
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 83
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": " English version "
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 85
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": " container name "
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 84
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": " config %"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 92
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": " Memory Usage %"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 63
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": " Network bandwidth %"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 59
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "CPU limit %"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 81
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "CPU max %"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 77
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "CPU total %"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 59
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": " English version %"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 72
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
+                    "matcher": {
                     "id": "byRegexp",
-                    "options": ".*%"
-                  },
-                  "properties": [
-                    {
-                      "id": "unit",
-                      "value": "percentunit"
+                    "options": "/Anomaly.*/"
                     },
+                    "properties": [
                     {
-                      "id": "thresholds",
-                      "value": {
-                        "mode": "percentage",
-                        "steps": [
-                          {
-                            "color": "green",
-                            "value": null
-                          },
-                          {
-                            "color": "orange",
-                            "value": 80
-                          },
-                          {
-                            "color": "red",
-                            "value": 90
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "id": "custom.displayMode",
-                      "value": "color-background"
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byRegexp",
-                    "options": "( memory request | Total Memory | Memory Usage | Network bandwidth | English version | container name )"
-                  },
-                  "properties": [
-                    {
-                      "id": "unit",
-                      "value": "bytes"
-                    },
-                    {
-                      "id": "decimals",
-                      "value": 2
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": " container "
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 96
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": " memory request %"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 67
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": " Memory Usage "
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 75
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "CPU max "
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 58
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byRegexp",
-                    "options": "(CPU total | Total Memory | container name |Pod disk )"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.displayMode",
-                      "value": "color-background"
-                    },
-                    {
-                      "id": "thresholds",
-                      "value": {
-                        "mode": "absolute",
-                        "steps": [
-                          {
-                            "color": "blue",
-                            "value": null
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "Pod disk "
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 54
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byRegexp",
-                    "options": "CPU limit \\( number \\)$| memory request $| English version $"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.displayMode",
-                      "value": "color-text"
-                    },
-                    {
-                      "id": "color",
-                      "value": {
-                        "fixedColor": "orange",
+                        "id": "color",
+                        "value": {
+                        "fixedColor": "red",
                         "mode": "fixed"
-                      }
+                        }
                     }
-                  ]
+                    ]
                 }
-              ]
+                ]
             },
             "gridPos": {
-              "h": 8,
-              "w": 24,
-              "x": 0,
-              "y": 9
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 9
+            },
+            "id": 88,
+            "maxPerRow": 2,
+            "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                "calcs": [
+                    "last"
+                ],
+                "fields": "",
+                "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+            },
+            "pluginVersion": "11.2.0",
+            "repeat": "origin_prometheus",
+            "repeatDirection": "v",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "count({__name__=~\"kube_deployment_metadata_generation|kube_daemonset_metadata_generation|kube_statefulset_metadata_generation\",origin_prometheus=~\"$origin_prometheus\"})",
+                "hide": false,
+                "instant": true,
+                "legendFormat": "Workload",
+                "range": false,
+                "refId": "F"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "count(kube_pod_info{origin_prometheus=~\"$origin_prometheus\"})",
+                "hide": false,
+                "instant": true,
+                "legendFormat": "Total Pod",
+                "range": false,
+                "refId": "E"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "count by(key,origin_prometheus)(kube_node_spec_taint{origin_prometheus=~\"$origin_prometheus\",key=~\"node.kubernetes.io.*\"})",
+                "format": "time_series",
+                "hide": false,
+                "instant": true,
+                "legendFormat": "{{key}}",
+                "range": false,
+                "refId": "D"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "count by(origin_prometheus)(kube_node_info{origin_prometheus=~\"$origin_prometheus\"})",
+                "hide": false,
+                "instant": true,
+                "legendFormat": "Total Nodes",
+                "range": false,
+                "refId": "C"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "count by(origin_prometheus)(kube_node_info{origin_prometheus=~\"$origin_prometheus\"}) - count by(origin_prometheus)(kube_node_spec_taint{origin_prometheus=~\"$origin_prometheus\",key!~\"node.kubernetes.io.*\"})",
+                "hide": false,
+                "instant": true,
+                "legendFormat": "Normal Node",
+                "range": false,
+                "refId": "B"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "count by(key,origin_prometheus)(kube_node_spec_taint{origin_prometheus=~\"$origin_prometheus\",key!~\"node.kubernetes.io.*\"})",
+                "hide": false,
+                "instant": true,
+                "legendFormat": "{{key}}",
+                "range": false,
+                "refId": "A"
+                }
+            ],
+            "transformations": [
+                {
+                "id": "renameByRegex",
+                "options": {
+                    "regex": "(node.kubernetes.io/)(.*)",
+                    "renamePattern": "Abnormal:$2"
+                }
+                }
+            ],
+            "type": "stat"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 15,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green",
+                        "value": null
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "bytes"
+                },
+                "overrides": [
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Total Memory"
+                    },
+                    "properties": [
+                    {
+                        "id": "color",
+                        "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                        }
+                    },
+                    {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                    }
+                    ]
+                }
+                ]
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 8,
+                "x": 0,
+                "y": 11
+            },
+            "id": 79,
+            "options": {
+                "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": false
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": true,
+                "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})",
+                "instant": false,
+                "interval": "",
+                "legendFormat": "Total Memory",
+                "refId": "A"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": true,
+                "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"})",
+                "instant": false,
+                "interval": "",
+                "legendFormat": "Usage",
+                "refId": "C"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})",
+                "hide": true,
+                "instant": false,
+                "interval": "",
+                "legendFormat": "Requests",
+                "refId": "D"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})",
+                "hide": true,
+                "instant": false,
+                "interval": "",
+                "legendFormat": "Limit",
+                "refId": "B"
+                }
+            ],
+            "title": "Memory Usage【$Node】",
+            "type": "timeseries"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 15,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green",
+                        "value": null
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "none"
+                },
+                "overrides": [
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Total Cores"
+                    },
+                    "properties": [
+                    {
+                        "id": "color",
+                        "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                        }
+                    },
+                    {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                    }
+                    ]
+                }
+                ]
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 8,
+                "x": 8,
+                "y": 11
+            },
+            "id": 80,
+            "options": {
+                "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": false
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": true,
+                "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})",
+                "instant": false,
+                "interval": "",
+                "legendFormat": "Total Cores",
+                "refId": "A"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": true,
+                "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",id=\"/\",node=~\"^$Node$\"}[2m]))",
+                "instant": false,
+                "interval": "",
+                "legendFormat": "Usage",
+                "refId": "C"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})",
+                "hide": true,
+                "instant": false,
+                "interval": "",
+                "legendFormat": "Requests",
+                "refId": "D"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})",
+                "hide": true,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "Limit",
+                "refId": "B"
+                }
+            ],
+            "title": "CPU Used Cores【$Node】",
+            "type": "timeseries"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "description": "Number of Cluster Nodes，Nodes POD Number of，Nodes POD Upper Limit",
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "series",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 15,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green",
+                        "value": null
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "none"
+                },
+                "overrides": [
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Upper Limit Pod"
+                    },
+                    "properties": [
+                    {
+                        "id": "color",
+                        "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                        }
+                    },
+                    {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Number of nodes"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.axisPlacement",
+                        "value": "right"
+                    },
+                    {
+                        "id": "custom.drawStyle",
+                        "value": "points"
+                    },
+                    {
+                        "id": "color",
+                        "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                        }
+                    },
+                    {
+                        "id": "custom.pointSize",
+                        "value": 3
+                    }
+                    ]
+                }
+                ]
+            },
+            "gridPos": {
+                "h": 5,
+                "w": 8,
+                "x": 16,
+                "y": 11
+            },
+            "id": 81,
+            "options": {
+                "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": true,
+                "expr": "count(kube_node_info{origin_prometheus=~\"$origin_prometheus\"})",
+                "hide": false,
+                "instant": false,
+                "interval": "",
+                "legendFormat": "Number of nodes",
+                "refId": "A"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": true,
+                "expr": "count(kube_pod_info{origin_prometheus=~\"$origin_prometheus\",created_by_kind!~\"<none>|Job\",node=~\"^$Node$\"})",
+                "hide": false,
+                "instant": false,
+                "interval": "",
+                "legendFormat": "Pod Number",
+                "refId": "B"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": true,
+                "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"pods\", unit=\"integer\",node=~\"^$Node$\"})",
+                "hide": false,
+                "instant": false,
+                "interval": "",
+                "legendFormat": "Upper Limit Pod",
+                "refId": "C"
+                }
+            ],
+            "title": "Pod Number and nodes【$Node】",
+            "type": "timeseries"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green",
+                        "value": null
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "percent"
+                },
+                "overrides": [
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": "/Total number of cores.*/"
+                    },
+                    "properties": [
+                    {
+                        "id": "color",
+                        "value": {
+                        "fixedColor": "#C4162A",
+                        "mode": "fixed"
+                        }
+                    }
+                    ]
+                }
+                ]
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 0,
+                "y": 16
+            },
+            "id": 75,
+            "options": {
+                "legend": {
+                "calcs": [
+                    "mean",
+                    "lastNotNull",
+                    "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": false
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": true,
+                "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}[2m]))by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})by (node)*100",
+                "format": "time_series",
+                "hide": false,
+                "instant": false,
+                "interval": "",
+                "legendFormat": "{{node}}",
+                "refId": "I"
+                }
+            ],
+            "title": "$Node：Nodes CPU Breakdown",
+            "type": "timeseries"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green",
+                        "value": null
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "percent"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 8,
+                "y": 16
+            },
+            "id": 76,
+            "options": {
+                "legend": {
+                "calcs": [
+                    "mean",
+                    "lastNotNull",
+                    "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": false
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": true,
+                "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})by (node)*100",
+                "format": "time_series",
+                "hide": false,
+                "instant": false,
+                "interval": "",
+                "legendFormat": "{{node}}",
+                "refId": "I"
+                }
+            ],
+            "title": "$Node：Node Memory Breakdown",
+            "type": "timeseries"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "series",
+                    "axisLabel": "←Inflow/Outflow→",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green",
+                        "value": null
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "binbps"
+                },
+                "overrides": [
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": "/Inflow.*/"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.transform",
+                        "value": "negative-Y"
+                    }
+                    ]
+                }
+                ]
+            },
+            "gridPos": {
+                "h": 6,
+                "w": 8,
+                "x": 16,
+                "y": 16
+            },
+            "id": 78,
+            "options": {
+                "legend": {
+                "calcs": [
+                    "mean",
+                    "lastNotNull",
+                    "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": false
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": true,
+                "expr": "sum (irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\"}[2m]))by (node) *8",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Inflow:{{node}}",
+                "metric": "network",
+                "refId": "A",
+                "step": 10
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": true,
+                "expr": "sum (irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\"}[2m]))by (node) *8",
+                "instant": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Outflows:{{node}}",
+                "metric": "network",
+                "refId": "B",
+                "step": 10
+                }
+            ],
+            "title": "$Node：Node Network Overview",
+            "type": "timeseries"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "thresholds"
+                },
+                "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                    "type": "auto"
+                    },
+                    "filterable": false,
+                    "inspect": false
+                },
+                "mappings": [],
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green",
+                        "value": null
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                }
+                },
+                "overrides": [
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "CPU Limitations"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 76
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Memory Usage"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 71
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Memory Limits"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 74
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Disk Usage"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 74
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": ".*%"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.cellOptions",
+                        "value": {
+                        "mode": "gradient",
+                        "type": "color-background"
+                        }
+                    },
+                    {
+                        "id": "color",
+                        "value": {
+                        "mode": "continuous-GrYlRd"
+                        }
+                    },
+                    {
+                        "id": "custom.width",
+                        "value": 85
+                    },
+                    {
+                        "id": "unit",
+                        "value": "percentunit"
+                    },
+                    {
+                        "id": "decimals",
+                        "value": 0
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": "(Memory Usage|Total Memory|Memory Request|Memory Limit|Disk Usage|Disk Total)"
+                    },
+                    "properties": [
+                    {
+                        "id": "unit",
+                        "value": "bytes"
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Nodes"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 96
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Memory Requests"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 76
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "CPU Requests"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 75
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": "(CPUTotal|MemoryTotal|DiskTotal|PodLimit)"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.cellOptions",
+                        "value": {
+                        "mode": "gradient",
+                        "type": "color-background"
+                        }
+                    },
+                    {
+                        "id": "thresholds",
+                        "value": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                            "color": "blue",
+                            "value": null
+                            }
+                        ]
+                        }
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "PodCap"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 66
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": "CPU Core Usage$|Memory Usage$|Disk Usage$|Pod Number of"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.cellOptions",
+                        "value": {
+                        "type": "color-text"
+                        }
+                    },
+                    {
+                        "id": "color",
+                        "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                        }
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": "/.*Total/"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.cellOptions",
+                        "value": {
+                        "mode": "gradient",
+                        "type": "color-background"
+                        }
+                    },
+                    {
+                        "id": "custom.cellOptions",
+                        "value": {
+                        "mode": "gradient",
+                        "type": "color-background"
+                        }
+                    },
+                    {
+                        "id": "color",
+                        "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                        }
+                    },
+                    {
+                        "id": "decimals",
+                        "value": 0
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Pod Number of"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 58
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "CPUTotal Cores"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 69
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Total Memory"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 75
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Total Disk"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 74
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "CPU Core Usage"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 74
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Memory Usage%"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 102
+                    }
+                    ]
+                }
+                ]
+            },
+            "gridPos": {
+                "h": 11,
+                "w": 24,
+                "x": 0,
+                "y": 22
             },
             "id": 52,
             "options": {
-              "showHeader": true,
-              "sortBy": [
+                "cellHeight": "sm",
+                "footer": {
+                "countRows": false,
+                "enablePagination": true,
+                "fields": "",
+                "reducer": [
+                    "sum"
+                ],
+                "show": false
+                },
+                "showHeader": true,
+                "sortBy": [
                 {
-                  "desc": true,
-                  "displayName": " English version %"
+                    "desc": true,
+                    "displayName": "Memory Usage%"
                 }
-              ]
+                ]
             },
-            "pluginVersion": "7.5.11",
+            "pluginVersion": "11.2.0",
             "targets": [
-              {
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "count(kube_pod_info{origin_prometheus=~\"$origin_prometheus\",created_by_kind!~\"<none>|Job\",node=~\"^$Node$\"}) by (node)",
                 "format": "table",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": "pod core ",
+                "legendFormat": "pod Number",
                 "refId": "A"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "kube_node_status_condition{origin_prometheus=~\"$origin_prometheus\",status=\"true\",node=~\"^$Node$\"}  == 1",
                 "format": "table",
+                "hide": true,
                 "instant": true,
                 "interval": "",
-                "legendFormat": " include ",
+                "legendFormat": "Status",
                 "refId": "B"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}[2m])) by (node)",
                 "format": "table",
                 "hide": false,
@@ -26107,9 +27236,13 @@ items:
                 "interval": "",
                 "legendFormat": "",
                 "refId": "I"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"} - 0",
                 "format": "table",
                 "hide": false,
@@ -26117,9 +27250,13 @@ items:
                 "interval": "",
                 "legendFormat": "",
                 "refId": "C"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"}) by (node)",
                 "format": "table",
                 "hide": false,
@@ -26127,9 +27264,13 @@ items:
                 "interval": "",
                 "legendFormat": "",
                 "refId": "E"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"}) by (node)",
                 "format": "table",
                 "hide": false,
@@ -26137,9 +27278,13 @@ items:
                 "interval": "",
                 "legendFormat": "",
                 "refId": "F"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}) by (node)",
                 "format": "table",
                 "hide": false,
@@ -26147,9 +27292,13 @@ items:
                 "interval": "",
                 "legendFormat": "",
                 "refId": "J"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"}) by (node) - 0",
                 "format": "table",
                 "hide": false,
@@ -26157,9 +27306,13 @@ items:
                 "interval": "",
                 "legendFormat": "",
                 "refId": "D"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"}) by (node)",
                 "format": "table",
                 "hide": false,
@@ -26167,9 +27320,13 @@ items:
                 "interval": "",
                 "legendFormat": "",
                 "refId": "G"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"}) by (node)",
                 "format": "table",
                 "hide": false,
@@ -26177,8 +27334,13 @@ items:
                 "interval": "",
                 "legendFormat": "",
                 "refId": "H"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum (container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"}) by (node)",
                 "format": "table",
                 "hide": false,
@@ -26186,9 +27348,13 @@ items:
                 "interval": "",
                 "legendFormat": "",
                 "refId": "K"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum (container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"}) by (node)",
                 "format": "table",
                 "hide": false,
@@ -26196,99 +27362,130 @@ items:
                 "interval": "",
                 "legendFormat": "",
                 "refId": "L"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})by (node)",
                 "format": "table",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": " memory request %",
+                "legendFormat": "Memory Usage%",
                 "refId": "M"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})by (node)",
                 "format": "table",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": " Memory Usage %",
+                "legendFormat": "Memory Requests%",
                 "refId": "N"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})by (node)",
                 "format": "table",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": " Network bandwidth %",
+                "legendFormat": "Memory Limit%",
                 "refId": "O"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}[2m]))by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})by (node)",
                 "format": "table",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": "CPU limit %",
+                "legendFormat": "CPU Usage%",
                 "refId": "P"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})by (node)",
                 "format": "table",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": "CPU max %",
+                "legendFormat": "CPU Requests%",
                 "refId": "Q"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})by (node)",
                 "format": "table",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": " Network bandwidth %",
+                "legendFormat": "Memory Limit%",
                 "refId": "R"
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum (container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})by (node) / sum (container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})by (node)",
                 "format": "table",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": " English version %",
+                "legendFormat": "Disk Usage%",
                 "refId": "S"
-              },
-              {
-                "exemplar": true,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
                 "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"pods\", unit=\"integer\",node=~\"^$Node$\"})by (node)",
                 "format": "table",
                 "hide": false,
                 "instant": true,
                 "interval": "",
-                "legendFormat": "Pod disk ",
+                "legendFormat": "PodCaps",
                 "refId": "T"
-              }
+                }
             ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "$Node： Node memory details ",
+            "title": "$Node：Node Information Detail",
             "transformations": [
-              {
+                {
                 "id": "merge",
                 "options": {}
-              },
-              {
+                },
+                {
                 "id": "organize",
                 "options": {
-                  "excludeByName": {
+                    "excludeByName": {
                     "Time": true,
                     "Time 1": true,
                     "Time 10": true,
@@ -26322,7 +27519,7 @@ items:
                     "app_kubernetes_io_version 1": true,
                     "app_kubernetes_io_version 2": true,
                     "app_kubernetes_io_version 3": true,
-                    "condition": false,
+                    "condition": true,
                     "instance": true,
                     "instance 1": true,
                     "instance 2": true,
@@ -26346,780 +27543,2668 @@ items:
                     "resource": true,
                     "status": true,
                     "unit": true
-                  },
-                  "indexByName": {
-                    "Time": 26,
-                    "Value #A": 3,
-                    "Value #B": 6,
-                    "Value #C": 7,
-                    "Value #D": 14,
-                    "Value #E": 10,
-                    "Value #F": 12,
-                    "Value #G": 17,
+                    },
+                    "includeByName": {},
+                    "indexByName": {
+                    "Time": 22,
+                    "Value #A": 2,
+                    "Value #C": 6,
+                    "Value #D": 8,
+                    "Value #E": 16,
+                    "Value #F": 17,
+                    "Value #G": 18,
                     "Value #H": 19,
-                    "Value #I": 8,
-                    "Value #J": 15,
-                    "Value #K": 22,
-                    "Value #L": 21,
-                    "Value #M": 16,
-                    "Value #N": 18,
-                    "Value #O": 20,
-                    "Value #P": 9,
-                    "Value #Q": 11,
-                    "Value #R": 13,
-                    "Value #S": 23,
-                    "Value #T": 2,
-                    "__name__": 4,
-                    "app_kubernetes_io_name": 27,
-                    "app_kubernetes_io_version": 28,
-                    "condition": 1,
-                    "instance": 29,
-                    "job": 30,
-                    "k8s_namespace": 31,
-                    "k8s_sname": 32,
+                    "Value #I": 7,
+                    "Value #J": 9,
+                    "Value #K": 11,
+                    "Value #L": 10,
+                    "Value #M": 4,
+                    "Value #N": 13,
+                    "Value #O": 15,
+                    "Value #P": 3,
+                    "Value #Q": 12,
+                    "Value #R": 14,
+                    "Value #S": 5,
+                    "Value #T": 1,
+                    "instance": 23,
+                    "job": 24,
                     "node": 0,
-                    "origin_prometheus": 33,
-                    "resource": 24,
-                    "status": 5,
-                    "unit": 25
-                  },
-                  "renameByName": {
-                    "Value #A": "Pod",
-                    "Value #C": "CPU total ",
-                    "Value #D": " Total Memory ",
-                    "Value #E": "CPU max ",
-                    "Value #F": "CPU total ",
-                    "Value #G": " Memory Usage ",
-                    "Value #H": " Network bandwidth ",
-                    "Value #I": "CPU limit ( number )",
-                    "Value #J": " memory request ",
-                    "Value #K": " English version ",
-                    "Value #L": " container name ",
-                    "Value #M": " memory request %",
-                    "Value #N": " Memory Usage %",
-                    "Value #O": " Network bandwidth %",
-                    "Value #P": "CPU limit %",
-                    "Value #Q": "CPU max %",
-                    "Value #R": "CPU total %",
-                    "Value #S": " English version %",
-                    "Value #T": "Pod disk ",
-                    "condition": " include ",
-                    "node": " container "
-                  }
+                    "origin_prometheus": 25,
+                    "resource": 20,
+                    "unit": 21
+                    },
+                    "renameByName": {
+                    "Value #A": "Pod Number of",
+                    "Value #C": "CPU Total Cores",
+                    "Value #D": "Total Memory",
+                    "Value #E": "CPU Requests",
+                    "Value #F": "CPU Limit",
+                    "Value #G": "Memory Requests",
+                    "Value #H": "Memory Limit",
+                    "Value #I": "CPU Core Usage",
+                    "Value #J": "Memory Usage",
+                    "Value #K": "Disk Usage",
+                    "Value #L": "Disk Total",
+                    "Value #M": "Memory Usage%",
+                    "Value #N": "Memory Requests%",
+                    "Value #O": "Memory Limit%",
+                    "Value #P": "CPU Usage%",
+                    "Value #Q": "CPU Requests%",
+                    "Value #R": "CPU Limit%",
+                    "Value #S": "Disk Usage%",
+                    "Value #T": "Pod Limit",
+                    "condition": "Status",
+                    "node": "Node"
+                    }
                 }
-              },
-              {
+                },
+                {
                 "id": "filterFieldsByName",
                 "options": {}
-              }
+                }
             ],
             "type": "table"
-          },
-          {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
             "fieldConfig": {
-              "defaults": {},
-              "overrides": []
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                    "type": "color-background"
+                    },
+                    "inspect": false
+                },
+                "decimals": 0,
+                "links": [],
+                "mappings": [
+                    {
+                    "options": {
+                        "0": {
+                        "color": "red",
+                        "index": 0
+                        }
+                    },
+                    "type": "value"
+                    },
+                    {
+                    "options": {
+                        "match": "null",
+                        "result": {
+                        "color": "red",
+                        "index": 1
+                        }
+                    },
+                    "type": "special"
+                    }
+                ],
+                "noValue": "0",
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green"
+                    }
+                    ]
+                },
+                "unit": "bytes"
+                },
+                "overrides": [
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Utilization"
+                    },
+                    "properties": [
+                    {
+                        "id": "unit",
+                        "value": "percent"
+                    },
+                    {
+                        "id": "custom.width",
+                        "value": 54
+                    },
+                    {
+                        "id": "color",
+                        "value": {
+                        "fixedColor": "purple",
+                        "mode": "fixed"
+                        }
+                    },
+                    {
+                        "id": "decimals"
+                    },
+                    {
+                        "id": "mappings",
+                        "value": [
+                        {
+                            "options": {
+                            "from": 75,
+                            "result": {
+                                "color": "semi-dark-red",
+                                "index": 0
+                            },
+                            "to": 110
+                            },
+                            "type": "range"
+                        }
+                        ]
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Mounts Pod Number of"
+                    },
+                    "properties": [
+                    {
+                        "id": "unit",
+                        "value": "none"
+                    },
+                    {
+                        "id": "custom.width",
+                        "value": 59
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Namespace"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 58
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "PVC"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 94
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Usage"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 57
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Total"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 54
+                    }
+                    ]
+                }
+                ]
             },
-            "fill": 0,
-            "fillGradient": 0,
             "gridPos": {
-              "h": 10,
-              "w": 8,
-              "x": 0,
-              "y": 17
+                "h": 8,
+                "w": 6,
+                "x": 0,
+                "y": 33
             },
-            "hiddenSeries": false,
-            "id": 75,
-            "legend": {
-              "alignAsTable": true,
-              "avg": true,
-              "current": true,
-              "max": true,
-              "min": false,
-              "rightSide": false,
-              "show": true,
-              "total": false,
-              "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": "null",
+            "id": 92,
             "options": {
-              "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.11",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [
-              {
-                "$$hashKey": "object:2068",
-                "alias": "/ usage .*/",
-                "color": "#C4162A"
-              }
-            ],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-              {
-                "exemplar": true,
-                "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}[2m]))by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})by (node)*100",
-                "format": "time_series",
-                "hide": false,
-                "instant": false,
-                "interval": "",
-                "legendFormat": "{{node}}",
-                "refId": "I"
-              }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "$Node： container CPU receive ",
-            "tooltip": {
-              "shared": true,
-              "sort": 2,
-              "value_type": "individual"
-            },
-            "transformations": [],
-            "type": "graph",
-            "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-            },
-            "yaxes": [
-              {
-                "$$hashKey": "object:1711",
-                "format": "percent",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "$$hashKey": "object:1712",
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              }
-            ],
-            "yaxis": {
-              "align": false,
-              "alignLevel": null
-            }
-          },
-          {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "fieldConfig": {
-              "defaults": {},
-              "overrides": []
-            },
-            "fill": 0,
-            "fillGradient": 0,
-            "gridPos": {
-              "h": 10,
-              "w": 8,
-              "x": 8,
-              "y": 17
-            },
-            "hiddenSeries": false,
-            "id": 76,
-            "legend": {
-              "alignAsTable": true,
-              "avg": true,
-              "current": true,
-              "max": true,
-              "min": false,
-              "rightSide": false,
-              "show": true,
-              "sort": "current",
-              "sortDesc": true,
-              "total": false,
-              "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "nullPointMode": "null",
-            "options": {
-              "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.11",
-            "pointradius": 2,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-              {
-                "exemplar": true,
-                "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})by (node)*100",
-                "format": "time_series",
-                "hide": false,
-                "instant": false,
-                "interval": "",
-                "legendFormat": "{{node}}",
-                "refId": "I"
-              }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "$Node： Node Memory Information ",
-            "tooltip": {
-              "shared": true,
-              "sort": 2,
-              "value_type": "individual"
-            },
-            "transformations": [],
-            "type": "graph",
-            "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-            },
-            "yaxes": [
-              {
-                "$$hashKey": "object:1711",
-                "format": "percent",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "$$hashKey": "object:1712",
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
+                "cellHeight": "sm",
+                "footer": {
+                "countRows": false,
+                "fields": "",
+                "reducer": [
+                    "sum"
+                ],
                 "show": false
-              }
-            ],
-            "yaxis": {
-              "align": false,
-              "alignLevel": null
-            }
-          },
-          {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "${datasource}",
-            "decimals": 2,
-            "editable": true,
-            "error": false,
-            "fieldConfig": {
-              "defaults": {
-                "links": []
-              },
-              "overrides": []
+                },
+                "showHeader": true,
+                "sortBy": [
+                {
+                    "desc": true,
+                    "displayName": "Usage Rate"
+                }
+                ]
             },
-            "fill": 0,
-            "fillGradient": 0,
-            "grid": {},
-            "gridPos": {
-              "h": 10,
-              "w": 8,
-              "x": 16,
-              "y": 17
-            },
-            "height": "200px",
-            "hiddenSeries": false,
-            "id": 78,
-            "isNew": true,
-            "legend": {
-              "alignAsTable": true,
-              "avg": true,
-              "current": true,
-              "max": true,
-              "min": false,
-              "rightSide": false,
-              "show": true,
-              "sideWidth": null,
-              "total": false,
-              "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "links": [],
-            "nullPointMode": "null",
-            "options": {
-              "alertThreshold": true
-            },
-            "percentage": false,
-            "pluginVersion": "7.5.11",
-            "pointradius": 5,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "stack": false,
-            "steppedLine": false,
+            "pluginVersion": "10.4.1",
             "targets": [
-              {
-                "exemplar": true,
-                "expr": "sum (irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\"}[2m]))by (node) *8",
-                "format": "time_series",
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{origin_prometheus=~\"$origin_prometheus\"})",
+                "format": "table",
+                "instant": true,
                 "interval": "",
                 "intervalFactor": 1,
-                "legendFormat": " update :{{node}}",
-                "metric": "network",
+                "legendFormat": "{{namespace}}:{{ persistentvolumeclaim }}",
+                "metric": "container_memory_usage:sort_desc",
+                "range": false,
                 "refId": "A",
                 "step": 10
-              },
-              {
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "min by (namespace,persistentvolumeclaim) (kubelet_volume_stats_available_bytes{origin_prometheus=~\"$origin_prometheus\"}) + max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{origin_prometheus=~\"$origin_prometheus\"})",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "__auto",
+                "metric": "container_memory_usage:sort_desc",
+                "range": false,
+                "refId": "B",
+                "step": 10
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{origin_prometheus=~\"$origin_prometheus\"}) /(min by (namespace,persistentvolumeclaim) (kubelet_volume_stats_available_bytes{origin_prometheus=~\"$origin_prometheus\"}) + max by (namespace,persistentvolumeclaim) (kubelet_volume_stats_used_bytes{origin_prometheus=~\"$origin_prometheus\"}))*100",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "{{namespace}}:{{ persistentvolumeclaim }}",
+                "metric": "container_memory_usage:sort_desc",
+                "range": false,
+                "refId": "C",
+                "step": 10
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "count by (namespace,persistentvolumeclaim)(kube_pod_spec_volumes_persistentvolumeclaims_info{origin_prometheus=~\"$origin_prometheus\"})",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "__auto",
+                "metric": "container_memory_usage:sort_desc",
+                "range": false,
+                "refId": "D",
+                "step": 10
+                }
+            ],
+            "title": "PVC Storage Usage",
+            "transformations": [
+                {
+                "id": "merge",
+                "options": {}
+                },
+                {
+                "id": "organize",
+                "options": {
+                    "excludeByName": {
+                    "Time": true
+                    },
+                    "includeByName": {},
+                    "indexByName": {},
+                    "renameByName": {
+                    "Value #A": "Usage",
+                    "Value #B": "Total",
+                    "Value #C": "Usage Rate",
+                    "Value #D": "Mount Pod Number",
+                    "namespace": "Namespaces",
+                    "persistentvolumeclaim": "PVC"
+                    }
+                }
+                }
+            ],
+            "type": "table"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green"
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 9,
+                "x": 6,
+                "y": 33
+            },
+            "id": 86,
+            "options": {
+                "legend": {
+                "calcs": [
+                    "last",
+                    "max"
+                ],
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true,
+                "sortBy": "Max",
+                "sortDesc": true
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
                 "exemplar": true,
-                "expr": "sum (irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\"}[2m]))by (node) *8",
+                "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container !=\"\",container!=\"POD\"}[2m])) by (namespace)>0.5",
+                "hide": false,
                 "instant": false,
                 "interval": "",
                 "intervalFactor": 1,
-                "legendFormat": " restart :{{node}}",
-                "metric": "network",
+                "legendFormat": "{{ namespace }}",
+                "metric": "container_cpu",
+                "refId": "A",
+                "step": 10
+                }
+            ],
+            "title": "Namespaces CPU Usage kernel(>0.5)",
+            "type": "timeseries"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "decimals": 0,
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green"
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 9,
+                "x": 15,
+                "y": 33
+            },
+            "id": 85,
+            "options": {
+                "legend": {
+                "calcs": [
+                    "last",
+                    "max"
+                ],
+                "displayMode": "table",
+                "placement": "right",
+                "showLegend": true,
+                "sortBy": "Max",
+                "sortDesc": true
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": true,
+                "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container !=\"\",container!=\"POD\"}) by (namespace) > 1*1024*1024*1024",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "{{namespace} {{ pod }}",
+                "metric": "container_memory_usage:sort_desc",
+                "range": true,
+                "refId": "A",
+                "step": 10
+                }
+            ],
+            "title": "Namespaces WSS Memory Usage (>1G)",
+            "type": "timeseries"
+            },
+            {
+            "collapsed": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "WAYOn0FGz"
+            },
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 41
+            },
+            "id": 49,
+            "panels": [],
+            "title": "Pod Resource Overview：SelectedPod:【$Pod】",
+            "type": "row"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "thresholds"
+                },
+                "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                    "type": "auto"
+                    },
+                    "filterable": false,
+                    "inspect": false
+                },
+                "displayName": "",
+                "mappings": [],
+                "max": 100,
+                "min": 0,
+                "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                    {
+                        "color": "green"
+                    },
+                    {
+                        "color": "#EAB839",
+                        "value": 80
+                    },
+                    {
+                        "color": "red",
+                        "value": 90
+                    }
+                    ]
+                },
+                "unit": "short"
+                },
+                "overrides": [
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Namespace"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 96
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Pod Name"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 207
+                    },
+                    {
+                        "id": "custom.align",
+                        "value": "right"
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Cores Used"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 71
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Reboot"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 38
+                    },
+                    {
+                        "id": "thresholds",
+                        "value": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                            "color": "green"
+                            },
+                            {
+                            "color": "#EAB839",
+                            "value": 1
+                            },
+                            {
+                            "color": "red",
+                            "value": 3
+                            }
+                        ]
+                        }
+                    },
+                    {
+                        "id": "custom.cellOptions",
+                        "value": {
+                        "mode": "gradient",
+                        "type": "color-background"
+                        }
+                    },
+                    {
+                        "id": "decimals"
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": ".*%"
+                    },
+                    "properties": [
+                    {
+                        "id": "unit",
+                        "value": "percentunit"
+                    },
+                    {
+                        "id": "custom.cellOptions",
+                        "value": {
+                        "type": "color-background"
+                        }
+                    },
+                    {
+                        "id": "color",
+                        "value": {
+                        "mode": "continuous-GrYlRd"
+                        }
+                    },
+                    {
+                        "id": "decimals",
+                        "value": 1
+                    },
+                    {
+                        "id": "custom.width",
+                        "value": 55
+                    },
+                    {
+                        "id": "min",
+                        "value": 0
+                    },
+                    {
+                        "id": "max",
+                        "value": 1
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": ".*Restrictions"
+                    },
+                    "properties": [
+                    {
+                        "id": "color",
+                        "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                        }
+                    },
+                    {
+                        "id": "custom.cellOptions",
+                        "value": {
+                        "mode": "gradient",
+                        "type": "color-background"
+                        }
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Nodes"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 100
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": "Cores in use$|WSS$|RSS$|Survival|Inflow|Outflow"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.cellOptions",
+                        "value": {
+                        "type": "color-text"
+                        }
+                    },
+                    {
+                        "id": "color",
+                        "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                        }
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Container Name"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 57
+                    },
+                    {
+                        "id": "custom.align",
+                        "value": "left"
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Survival"
+                    },
+                    "properties": [
+                    {
+                        "id": "unit",
+                        "value": "s"
+                    },
+                    {
+                        "id": "custom.width",
+                        "value": 80
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Used cores"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 62
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "CPU Limits"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 58
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Memory Limit"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 68
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Memory Requirements"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 88
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": "WSS$|RSS$|Memory Requirements$|Memory Limit$|Disk.*$"
+                    },
+                    "properties": [
+                    {
+                        "id": "unit",
+                        "value": "bytes"
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "WSS"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 81
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "RSS"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 74
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "CPU Requirements"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 72
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Disk Limitations"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 83
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "Disk Usage"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 72
+                    },
+                    {
+                        "id": "custom.cellOptions",
+                        "value": {
+                        "type": "color-background"
+                        }
+                    },
+                    {
+                        "id": "thresholds",
+                        "value": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                            "color": "green"
+                            },
+                            {
+                            "color": "orange",
+                            "value": 10737418240
+                            },
+                            {
+                            "color": "red",
+                            "value": 16106127360
+                            }
+                        ]
+                        }
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byName",
+                    "options": "WSS%"
+                    },
+                    "properties": [
+                    {
+                        "id": "custom.width",
+                        "value": 77
+                    }
+                    ]
+                },
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": "/Inflow|Streaming Out/"
+                    },
+                    "properties": [
+                    {
+                        "id": "unit",
+                        "value": "binbps"
+                    },
+                    {
+                        "id": "custom.width",
+                        "value": 80
+                    }
+                    ]
+                }
+                ]
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 42
+            },
+            "id": 47,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                "countRows": false,
+                "fields": "",
+                "reducer": [
+                    "sum"
+                ],
+                "show": false
+                },
+                "showHeader": true,
+                "sortBy": [
+                {
+                    "desc": true,
+                    "displayName": "WSS%"
+                }
+                ]
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (container, pod,node,namespace) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}/100000) by (container, pod,node,namespace)) ",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "A"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
+                "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (container, pod,node,namespace)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "CPUKernel Usage",
+                "refId": "Q"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
+                "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "B"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
+                "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                "format": "table",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "C"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "wss%",
+                "refId": "I"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
+                "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "wss",
+                "refId": "D"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "rss%",
+                "refId": "L"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
+                "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "rss",
+                "refId": "K"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "E"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "exemplar": false,
+                "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "F"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "sum(container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                "format": "table",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "J"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "kube_pod_container_status_restarts_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"} * on (pod) group_left(node) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "H"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "time() - kube_pod_created{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"} * on(pod) group_right kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\",container =~\"$Container\"}",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "__auto",
+                "refId": "R"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "sum(container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "S"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "sum(sum(irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\",container =~\"$Container\"}) by(pod) *8",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "__auto",
+                "refId": "T"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "sum(sum(irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\",container =~\"$Container\"}) by(pod) *8",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "__auto",
+                "refId": "U"
+                }
+            ],
+            "title": "$Node：Pod Resource Detail(Associable Nodes)",
+            "transformations": [
+                {
+                "id": "merge",
+                "options": {}
+                },
+                {
+                "id": "organize",
+                "options": {
+                    "excludeByName": {
+                    "Time": true,
+                    "Time 1": true,
+                    "Time 10": true,
+                    "Time 11": true,
+                    "Time 12": true,
+                    "Time 13": true,
+                    "Time 2": true,
+                    "Time 3": true,
+                    "Time 4": true,
+                    "Time 5": true,
+                    "Time 6": true,
+                    "Time 7": true,
+                    "Time 8": true,
+                    "Time 9": true,
+                    "Value #G": false,
+                    "__name__": true,
+                    "app_kubernetes_io_name": true,
+                    "app_kubernetes_io_name 1": true,
+                    "app_kubernetes_io_name 2": true,
+                    "app_kubernetes_io_version": true,
+                    "app_kubernetes_io_version 1": true,
+                    "app_kubernetes_io_version 2": true,
+                    "container 1": true,
+                    "container 10": true,
+                    "container 11": true,
+                    "container 12": true,
+                    "container 2": true,
+                    "container 3": true,
+                    "container 4": true,
+                    "container 5": true,
+                    "container 6": true,
+                    "container 7": true,
+                    "container 8": true,
+                    "container 9": true,
+                    "created_by_kind": true,
+                    "created_by_name": true,
+                    "host_ip": true,
+                    "instance": true,
+                    "instance 1": true,
+                    "instance 2": true,
+                    "job": true,
+                    "job 1": true,
+                    "job 2": true,
+                    "k8s_namespace": true,
+                    "k8s_namespace 1": true,
+                    "k8s_namespace 2": true,
+                    "k8s_sname": true,
+                    "k8s_sname 1": true,
+                    "k8s_sname 2": true,
+                    "namespace": false,
+                    "namespace 1": true,
+                    "namespace 10": true,
+                    "namespace 11": true,
+                    "namespace 12": false,
+                    "namespace 2": true,
+                    "namespace 3": true,
+                    "namespace 4": true,
+                    "namespace 5": true,
+                    "namespace 6": true,
+                    "namespace 7": true,
+                    "namespace 8": true,
+                    "namespace 9": true,
+                    "node 1": true,
+                    "node 10": true,
+                    "node 11": false,
+                    "node 12": true,
+                    "node 2": true,
+                    "node 3": true,
+                    "node 4": true,
+                    "node 5": true,
+                    "node 6": true,
+                    "node 7": true,
+                    "node 8": true,
+                    "node 9": true,
+                    "origin_prometheus": true,
+                    "origin_prometheus 1": true,
+                    "origin_prometheus 2": true,
+                    "phase": true,
+                    "pod_ip": true,
+                    "priority_class": true,
+                    "uid": true
+                    },
+                    "includeByName": {},
+                    "indexByName": {
+                    "Time": 21,
+                    "Value #A": 4,
+                    "Value #B": 16,
+                    "Value #C": 7,
+                    "Value #D": 10,
+                    "Value #E": 17,
+                    "Value #F": 9,
+                    "Value #G": 23,
+                    "Value #H": 14,
+                    "Value #I": 5,
+                    "Value #J": 13,
+                    "Value #K": 11,
+                    "Value #L": 6,
+                    "Value #M": 24,
+                    "Value #N": 25,
+                    "Value #O": 26,
+                    "Value #P": 27,
+                    "Value #Q": 8,
+                    "Value #R": 15,
+                    "Value #S": 12,
+                    "container": 2,
+                    "instance": 18,
+                    "ip": 28,
+                    "job": 19,
+                    "namespace": 1,
+                    "node": 0,
+                    "origin_prometheus": 20,
+                    "pod": 3,
+                    "uid": 22
+                    },
+                    "renameByName": {
+                    "Value #A": "CPU%",
+                    "Value #B": "CPU Requirements",
+                    "Value #C": "CPU Limitations",
+                    "Value #D": "WSS",
+                    "Value #E": "Memory Requirements",
+                    "Value #F": "Memory Limit",
+                    "Value #H": "Reboot",
+                    "Value #I": "WSS%",
+                    "Value #J": "Disk Usage",
+                    "Value #K": "RSS",
+                    "Value #L": "RSS%",
+                    "Value #M": "Heap Memory",
+                    "Value #N": "maxHeap",
+                    "Value #O": "Non-Heap",
+                    "Value #P": "maxNon-Heap",
+                    "Value #Q": "Using Cores",
+                    "Value #R": "Survival",
+                    "Value #S": "Disk Limit",
+                    "Value #T": "Inflow",
+                    "Value #U": "Streaming Out",
+                    "container": "Container Name",
+                    "instance": "",
+                    "ip": "POD IP",
+                    "namespace": "Namespace",
+                    "namespace 1": "",
+                    "namespace 12": "Namespace",
+                    "node": "Nodes",
+                    "node 1": "",
+                    "node 11": "Node",
+                    "pod": "Pod Name",
+                    "priority_class": ""
+                    }
+                }
+                },
+                {
+                "id": "filterFieldsByName",
+                "options": {
+                    "include": {
+                    "names": [
+                        "Node",
+                        "Namespace",
+                        "Container Name",
+                        "Pod Name",
+                        "CPU%",
+                        "WSS%",
+                        "RSS%",
+                        "CPU Restrictions",
+                        "Cores Used",
+                        "Memory Limit",
+                        "WSS",
+                        "RSS",
+                        "Disk Limit",
+                        "Disk Usage",
+                        "Reboot",
+                        "CPUDemand",
+                        "Memory Requirements",
+                        "Inflow",
+                        "Outflow",
+                        "Survival"
+                    ]
+                    }
+                }
+                }
+            ],
+            "type": "table"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green"
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "percent"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 0,
+                "y": 50
+            },
+            "id": 58,
+            "options": {
+                "legend": {
+                "calcs": [
+                    "mean",
+                    "lastNotNull",
+                    "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": true,
+                "expr": "max(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (container, pod) / (max(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}/100000) by (container, pod)) * 100",
+                "hide": false,
+                "instant": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "{{ pod }}",
+                "metric": "container_cpu",
+                "refId": "A",
+                "step": 10
+                }
+            ],
+            "title": "Pod Containers CPU Utilization (Maximum100%Associable Nodes)",
+            "type": "timeseries"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green"
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "percent"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 8,
+                "y": 50
+            },
+            "id": 27,
+            "options": {
+                "legend": {
+                "calcs": [
+                    "max",
+                    "last",
+                    "mean"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "max (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod)/ max(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod) * 100",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "WSS：{{ pod }}",
+                "metric": "container_memory_usage:sort_desc",
+                "range": true,
+                "refId": "A",
+                "step": 10
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "max (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod)/ max(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod) * 100",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "RSS：{{ pod }}",
+                "metric": "container_memory_usage:sort_desc",
+                "range": true,
                 "refId": "B",
                 "step": 10
-              }
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": true,
+                "expr": "(cass_jvm_heap{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}) / (cass_jvm_heap_max{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}) * 100",
+                "hide": true,
+                "instant": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Heap：{{ pod }}",
+                "metric": "container_memory_usage:sort_desc",
+                "refId": "C",
+                "step": 10
+                }
             ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeRegions": [],
-            "timeShift": null,
-            "title": "$Node： Overall resource overview ",
-            "tooltip": {
-              "msResolution": false,
-              "shared": true,
-              "sort": 2,
-              "value_type": "cumulative"
+            "title": "Pod Container Memory Usage (Associatable Nodes)",
+            "type": "timeseries"
             },
-            "type": "graph",
-            "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
             },
-            "yaxes": [
-              {
-                "$$hashKey": "object:750",
-                "format": "binbps",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "$$hashKey": "object:751",
-                "format": "Bps",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": false
-              }
-            ],
-            "yaxis": {
-              "align": false,
-              "alignLevel": null
-            }
-          },
-          {
-            "collapsed": true,
-            "datasource": "${datasource}",
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green"
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "binbps"
+                },
+                "overrides": []
+            },
             "gridPos": {
-              "h": 1,
-              "w": 24,
-              "x": 0,
-              "y": 27
+                "h": 9,
+                "w": 8,
+                "x": 16,
+                "y": 50
+            },
+            "id": 77,
+            "options": {
+                "legend": {
+                "calcs": [
+                    "max",
+                    "last",
+                    "mean"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "max(max(irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\",container =~\"$Container\"}) by(pod) *8",
+                "hide": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Inflow:{{ pod}}",
+                "metric": "network",
+                "range": true,
+                "refId": "A",
+                "step": 10
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "max(max(irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\",container =~\"$Container\"}) by(pod) *8",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Outflow:{{ pod}}",
+                "metric": "network",
+                "range": true,
+                "refId": "B",
+                "step": 10
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(sum(irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(pod) *8",
+                "hide": true,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "__auto",
+                "metric": "network",
+                "range": true,
+                "refId": "C",
+                "step": 10
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "expr": "sum(sum(irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(pod) *8",
+                "hide": true,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "__auto",
+                "metric": "network",
+                "range": true,
+                "refId": "D",
+                "step": 10
+                }
+            ],
+            "title": "Pod Network bandwidth per second (Associable Nodes)",
+            "type": "timeseries"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green"
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "none"
+                },
+                "overrides": [
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": "/Limit.*/"
+                    },
+                    "properties": [
+                    {
+                        "id": "color",
+                        "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                        }
+                    }
+                    ]
+                }
+                ]
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 0,
+                "y": 59
+            },
+            "id": 82,
+            "options": {
+                "legend": {
+                "calcs": [
+                    "max",
+                    "last",
+                    "mean"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true,
+                "sortBy": "Max",
+                "sortDesc": true
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": true,
+                "expr": "max(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (container, pod,node,namespace)",
+                "hide": false,
+                "instant": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "CPU Usage：{{ pod }}",
+                "metric": "container_cpu",
+                "refId": "A",
+                "step": 10
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": true,
+                "expr": "max(max(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)) by(container)",
+                "hide": false,
+                "instant": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "Pod CPU Limitations：{{ container}}",
+                "metric": "container_cpu",
+                "refId": "B",
+                "step": 10
+                }
+            ],
+            "title": "Pod Containers CPU Core Usage",
+            "type": "timeseries"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green"
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "bytes"
+                },
+                "overrides": [
+                {
+                    "matcher": {
+                    "id": "byRegexp",
+                    "options": "/.*Limitations/"
+                    },
+                    "properties": [
+                    {
+                        "id": "color",
+                        "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                        }
+                    }
+                    ]
+                }
+                ]
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 8,
+                "y": 59
+            },
+            "id": 84,
+            "options": {
+                "legend": {
+                "calcs": [
+                    "max",
+                    "last",
+                    "mean"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true,
+                "sortBy": "Max",
+                "sortDesc": true
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "max (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "WSS：{{ pod }}",
+                "metric": "container_memory_usage:sort_desc",
+                "range": true,
+                "refId": "A",
+                "step": 10
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "max(max(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)) by(container)",
+                "hide": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "PodMemory Limits：{{ container}}",
+                "metric": "container_memory_usage:sort_desc",
+                "range": true,
+                "refId": "B",
+                "step": 10
+                }
+            ],
+            "title": "Pod Containers WSS Memory Usage (Associable Nodes)",
+            "type": "timeseries"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+            },
+            "fieldConfig": {
+                "defaults": {
+                "color": {
+                    "mode": "palette-classic"
+                },
+                "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                    "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "spanNulls": false,
+                    "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                    "mode": "off"
+                    }
+                },
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                    {
+                        "color": "green"
+                    },
+                    {
+                        "color": "red",
+                        "value": 80
+                    }
+                    ]
+                },
+                "unit": "bytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 8,
+                "x": 16,
+                "y": 59
+            },
+            "id": 83,
+            "options": {
+                "legend": {
+                "calcs": [
+                    "lastNotNull",
+                    "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+                },
+                "tooltip": {
+                "mode": "multi",
+                "sort": "desc"
+                }
+            },
+            "pluginVersion": "10.4.1",
+            "targets": [
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "editorMode": "code",
+                "exemplar": true,
+                "expr": "max (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": "RSS：{{ pod }}",
+                "metric": "container_memory_usage:sort_desc",
+                "range": true,
+                "refId": "A",
+                "step": 10
+                }
+            ],
+            "title": "Pod Containers RSS Memory Usage (Associable Nodes)",
+            "type": "timeseries"
+            },
+            {
+            "collapsed": true,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "WAYOn0FGz"
+            },
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 68
             },
             "id": 61,
             "panels": [
-              {
-                "datasource": "${datasource}",
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "fieldConfig": {
-                  "defaults": {
+                    "defaults": {
                     "color": {
-                      "mode": "thresholds"
+                        "mode": "thresholds"
                     },
                     "custom": {
-                      "align": "center",
-                      "displayMode": "auto",
-                      "filterable": false
+                        "align": "center",
+                        "cellOptions": {
+                        "type": "auto"
+                        },
+                        "filterable": false,
+                        "inspect": false
                     },
                     "displayName": "",
                     "mappings": [],
                     "thresholds": {
-                      "mode": "percentage",
-                      "steps": [
+                        "mode": "percentage",
+                        "steps": [
                         {
-                          "color": "green",
-                          "value": null
-                        },
-                        {
-                          "color": "orange",
-                          "value": 70
-                        },
-                        {
-                          "color": "red",
-                          "value": 90
+                            "color": "green"
                         }
-                      ]
+                        ]
                     },
-                    "unit": "short"
-                  },
-                  "overrides": [
+                    "unit": "none"
+                    },
+                    "overrides": [
                     {
-                      "matcher": {
+                        "matcher": {
                         "id": "byRegexp",
-                        "options": ".*%.*"
-                      },
-                      "properties": [
+                        "options": ".*%"
+                        },
+                        "properties": [
                         {
-                          "id": "unit",
-                          "value": "percent"
+                            "id": "unit",
+                            "value": "percentunit"
                         },
                         {
-                          "id": "custom.displayMode",
-                          "value": "gradient-gauge"
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byRegexp",
-                        "options": " Requests .*"
-                      },
-                      "properties": [
+                            "id": "custom.cellOptions",
+                            "value": {
+                            "mode": "gradient",
+                            "type": "gauge",
+                            "valueDisplayMode": "color"
+                            }
+                        },
                         {
-                          "id": "unit",
-                          "value": "bytes"
+                            "id": "max",
+                            "value": 1
+                        },
+                        {
+                            "id": "min",
+                            "value": 0
+                        },
+                        {
+                            "id": "color",
+                            "value": {
+                            "mode": "continuous-GrYlRd"
+                            }
+                        },
+                        {
+                            "id": "decimals",
+                            "value": 0
                         }
-                      ]
+                        ]
                     },
                     {
-                      "matcher": {
+                        "matcher": {
+                        "id": "byRegexp",
+                        "options": ".*Memory Usage$|.*Memory Limits$|.*Memory Requirements$|.*Disk Usage$|.*Disk Limits$"
+                        },
+                        "properties": [
+                        {
+                            "id": "unit",
+                            "value": "bytes"
+                        }
+                        ]
+                    },
+                    {
+                        "matcher": {
                         "id": "byName",
-                        "options": " Number of cluster nodes "
-                      },
-                      "properties": [
-                        {
-                          "id": "unit",
-                          "value": "bytes"
+                        "options": "Namespace"
                         },
+                        "properties": [
                         {
-                          "id": "thresholds",
-                          "value": {
-                            "mode": "absolute",
-                            "steps": [
-                              {
-                                "color": "green",
-                                "value": null
-                              },
-                              {
-                                "color": "orange",
-                                "value": 10737418240
-                              },
-                              {
-                                "color": "red",
-                                "value": 16106127360
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "id": "custom.displayMode",
-                          "value": "color-background"
-                        },
-                        {
-                          "id": "custom.width",
-                          "value": 90
+                            "id": "custom.width",
+                            "value": 92
                         }
-                      ]
+                        ]
                     },
                     {
-                      "matcher": {
-                        "id": "byRegexp",
-                        "options": ".* total "
-                      },
-                      "properties": [
+                        "matcher": {
+                        "id": "byName",
+                        "options": "Container Name"
+                        },
+                        "properties": [
                         {
-                          "id": "color",
-                          "value": {
+                            "id": "custom.width",
+                            "value": 187
+                        }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                        "id": "byName",
+                        "options": "Total CPU Core Usage"
+                        },
+                        "properties": [
+                        {
+                            "id": "custom.width",
+                            "value": 100
+                        }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                        "id": "byName",
+                        "options": "Pod"
+                        },
+                        "properties": [
+                        {
+                            "id": "custom.width",
+                            "value": 44
+                        },
+                        {
+                            "id": "custom.cellOptions",
+                            "value": {
+                            "type": "color-background"
+                            }
+                        },
+                        {
+                            "id": "color",
+                            "value": {
                             "fixedColor": "blue",
                             "mode": "fixed"
-                          }
+                            }
+                        }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                        "id": "byName",
+                        "options": "Average CPU Usage%"
                         },
+                        "properties": [
                         {
-                          "id": "custom.displayMode",
-                          "value": "color-background"
+                            "id": "custom.width",
+                            "value": 116
                         }
-                      ]
+                        ]
                     },
                     {
-                      "matcher": {
+                        "matcher": {
                         "id": "byName",
-                        "options": " total CPU total "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 84
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " Total Disk Usage "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 77
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " Selected microservices (RSS) "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 119
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " Total memory limit "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 82
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " limit amount "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 69
+                        "options": "Average RSS Memory Usage%"
                         },
+                        "properties": [
                         {
-                          "id": "thresholds",
-                          "value": {
-                            "mode": "absolute",
-                            "steps": [
-                              {
-                                "color": "orange",
-                                "value": null
-                              },
-                              {
-                                "color": "green",
-                                "value": 2
-                              }
-                            ]
-                          }
+                            "id": "custom.width",
+                            "value": 141
+                        }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                        "id": "byName",
+                        "options": "Average WSS Memory Usage%"
                         },
+                        "properties": [
                         {
-                          "id": "custom.displayMode",
-                          "value": "color-background"
+                            "id": "custom.width",
+                            "value": 165
                         }
-                      ]
+                        ]
                     },
                     {
-                      "matcher": {
+                        "matcher": {
                         "id": "byName",
-                        "options": " Resource Details %(RSS)"
-                      },
-                      "properties": [
+                        "options": "Total CPU Limit"
+                        },
+                        "properties": [
                         {
-                          "id": "custom.width",
-                          "value": 112
+                            "id": "custom.width",
+                            "value": 86
                         }
-                      ]
+                        ]
                     },
                     {
-                      "matcher": {
+                        "matcher": {
                         "id": "byName",
-                        "options": " password CPU%( overall 100%)"
-                      },
-                      "properties": [
+                        "options": "Total Memory Limit"
+                        },
+                        "properties": [
                         {
-                          "id": "custom.width",
-                          "value": 150
+                            "id": "custom.width",
+                            "value": 86
                         }
-                      ]
+                        ]
                     },
                     {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " Node Network Overview "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 100
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " total CPU selected "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 82
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " Resource Details %(WSS)"
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 130
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " Selected microservices (WSS)"
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 120
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " average memory "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 79
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
+                        "matcher": {
                         "id": "byRegexp",
-                        "options": " Node Network Overview $| Selected microservices \\(WSS\\)$| Selected microservices \\(RSS\\) $"
-                      },
-                      "properties": [
+                        "options": "/.*Limit$/"
+                        },
+                        "properties": [
                         {
-                          "id": "color",
-                          "value": {
+                            "id": "color",
+                            "value": {
+                            "fixedColor": "blue",
+                            "mode": "fixed"
+                            }
+                        },
+                        {
+                            "id": "custom.cellOptions",
+                            "value": {
+                            "type": "color-background"
+                            }
+                        }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                        "id": "byRegexp",
+                        "options": "/.*Memory Usage$|.*Core Usage$/"
+                        },
+                        "properties": [
+                        {
+                            "id": "custom.cellOptions",
+                            "value": {
+                            "type": "color-text"
+                            }
+                        },
+                        {
+                            "id": "color",
+                            "value": {
                             "fixedColor": "orange",
                             "mode": "fixed"
-                          }
-                        },
-                        {
-                          "id": "custom.displayMode",
-                          "value": "color-text"
+                            }
                         }
-                      ]
+                        ]
                     },
                     {
-                      "matcher": {
+                        "matcher": {
                         "id": "byName",
-                        "options": " container number "
-                      },
-                      "properties": [
+                        "options": "Total RSS Memory Usage"
+                        },
+                        "properties": [
                         {
-                          "id": "custom.width",
-                          "value": 149
+                            "id": "custom.width",
+                            "value": 107
                         }
-                      ]
+                        ]
+                    },
+                    {
+                        "matcher": {
+                        "id": "byName",
+                        "options": "Total WSS Memory Usage"
+                        },
+                        "properties": [
+                        {
+                            "id": "custom.width",
+                            "value": 113
+                        }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                        "id": "byName",
+                        "options": "Average Disk Usage"
+                        },
+                        "properties": [
+                        {
+                            "id": "custom.width",
+                            "value": 96
+                        },
+                        {
+                            "id": "custom.cellOptions",
+                            "value": {
+                            "type": "color-background"
+                            }
+                        },
+                        {
+                            "id": "thresholds",
+                            "value": {
+                            "mode": "absolute",
+                            "steps": [
+                                {
+                                "color": "green"
+                                },
+                                {
+                                "color": "orange",
+                                "value": 10737418240
+                                },
+                                {
+                                "color": "red",
+                                "value": 16106127360
+                                }
+                            ]
+                            }
+                        }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                        "id": "byName",
+                        "options": "Average Disk Limit"
+                        },
+                        "properties": [
+                        {
+                            "id": "custom.width",
+                            "value": 96
+                        }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                        "id": "byName",
+                        "options": "Total CPU Demand"
+                        },
+                        "properties": [
+                        {
+                            "id": "custom.width",
+                            "value": 80
+                        }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                        "id": "byName",
+                        "options": "Total Memory Demand"
+                        },
+                        "properties": [
+                        {
+                            "id": "custom.width",
+                            "value": 80
+                        }
+                        ]
                     }
-                  ]
+                    ]
                 },
                 "gridPos": {
-                  "h": 8,
-                  "w": 24,
-                  "x": 0,
-                  "y": 2
+                    "h": 9,
+                    "w": 24,
+                    "x": 0,
+                    "y": 3
                 },
-                "id": 57,
+                "id": 87,
                 "options": {
-                  "showHeader": true,
-                  "sortBy": [
+                    "cellHeight": "sm",
+                    "footer": {
+                    "countRows": false,
+                    "enablePagination": true,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                    },
+                    "showHeader": true,
+                    "sortBy": [
                     {
-                      "desc": true,
-                      "displayName": " container number "
+                        "desc": true,
+                        "displayName": "Average WSS Memory Usage%"
                     }
-                  ]
+                    ]
                 },
-                "pluginVersion": "7.5.11",
+                "pluginVersion": "10.4.1",
                 "targets": [
-                  {
-                    "exemplar": true,
-                    "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}[2m])) by (container) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}/100000) by (container)) * 100",
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}[2m])) by (container) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}/100000) by (container))",
                     "format": "table",
                     "hide": false,
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
                     "refId": "A"
-                  },
-                  {
-                    "exemplar": true,
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
                     "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}[2m])) by (container)",
                     "format": "table",
                     "hide": false,
                     "instant": true,
                     "interval": "",
-                    "legendFormat": " Node Network Overview ",
+                    "legendFormat": "Total Cores Used",
                     "refId": "L"
-                  },
-                  {
-                    "exemplar": true,
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "exemplar": false,
                     "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
                     "format": "table",
                     "hide": false,
@@ -27127,26 +30212,41 @@ items:
                     "interval": "",
                     "legendFormat": "",
                     "refId": "B"
-                  },
-                  {
-                    "exemplar": true,
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "exemplar": false,
                     "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
                     "format": "table",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
                     "refId": "C"
-                  },
-                  {
-                    "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container) * 100",
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
                     "format": "table",
                     "hide": false,
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
                     "refId": "I"
-                  },
-                  {
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "exemplar": false,
                     "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
                     "format": "table",
                     "hide": false,
@@ -27154,37 +30254,57 @@ items:
                     "interval": "",
                     "legendFormat": "",
                     "refId": "D"
-                  },
-                  {
-                    "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container) * 100",
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
                     "format": "table",
                     "hide": false,
                     "instant": true,
                     "interval": "",
-                    "legendFormat": " Resource Details %(RSS)",
+                    "legendFormat": "Average Memory%(RSS)",
                     "refId": "H"
-                  },
-                  {
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "exemplar": false,
                     "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
                     "format": "table",
                     "hide": false,
                     "instant": true,
                     "interval": "",
-                    "legendFormat": " Selected microservices (RSS) ",
+                    "legendFormat": "Total Memory Usage (RSS) ",
                     "refId": "K"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "sum by(container) (kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"})",
                     "format": "table",
                     "hide": false,
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
                     "refId": "E"
-                  },
-                  {
-                    "exemplar": true,
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "exemplar": false,
                     "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
                     "format": "table",
                     "hide": false,
@@ -27192,37 +30312,61 @@ items:
                     "interval": "",
                     "legendFormat": "",
                     "refId": "F"
-                  },
-                  {
-                    "expr": "sum(container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "avg(container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
                     "format": "table",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
                     "refId": "J"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "count(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by(container,namespace) - 0",
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "count(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by(container,namespace)",
                     "format": "table",
                     "instant": true,
                     "interval": "",
                     "legendFormat": "",
                     "refId": "G"
-                  }
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "avg(container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "M"
+                    }
                 ],
-                "timeFrom": null,
-                "timeShift": null,
-                "title": " usage ( container number ) namespace ",
+                "title": "Microservices (Container Name) Resource Statistics",
                 "transformations": [
-                  {
+                    {
                     "id": "merge",
                     "options": {}
-                  },
-                  {
+                    },
+                    {
                     "id": "organize",
                     "options": {
-                      "excludeByName": {
+                        "excludeByName": {
                         "Time": true,
                         "Time 1": true,
                         "Time 10": true,
@@ -27236,124 +30380,145 @@ items:
                         "Time 7": true,
                         "Time 8": true,
                         "Time 9": true
-                      },
-                      "indexByName": {
-                        "Time 1": 2,
-                        "Time 10": 20,
-                        "Time 11": 22,
-                        "Time 12": 24,
-                        "Time 2": 4,
-                        "Time 3": 6,
-                        "Time 4": 8,
-                        "Time 5": 10,
-                        "Time 6": 12,
-                        "Time 7": 14,
-                        "Time 8": 16,
-                        "Time 9": 18,
+                        },
+                        "includeByName": {},
+                        "indexByName": {
+                        "Time": 15,
                         "Value #A": 3,
-                        "Value #B": 7,
-                        "Value #C": 9,
-                        "Value #D": 13,
-                        "Value #E": 19,
-                        "Value #F": 21,
-                        "Value #G": 25,
-                        "Value #H": 15,
-                        "Value #I": 11,
-                        "Value #J": 23,
-                        "Value #K": 17,
-                        "Value #L": 5,
+                        "Value #B": 13,
+                        "Value #C": 6,
+                        "Value #D": 9,
+                        "Value #E": 14,
+                        "Value #F": 8,
+                        "Value #G": 2,
+                        "Value #H": 5,
+                        "Value #I": 4,
+                        "Value #J": 12,
+                        "Value #K": 10,
+                        "Value #L": 7,
+                        "Value #M": 11,
                         "container": 1,
                         "namespace": 0
-                      },
-                      "renameByName": {
+                        },
+                        "renameByName": {
                         "Time 1": "",
-                        "Value #A": " password CPU%( overall 100%)",
-                        "Value #B": " total CPU selected ",
-                        "Value #C": " total CPU total ",
-                        "Value #D": " Selected microservices (WSS)",
-                        "Value #E": " Total memory limit ",
-                        "Value #F": " Total Disk Usage ",
-                        "Value #G": " limit amount ",
-                        "Value #H": " Resource Details %(RSS)",
-                        "Value #I": " Resource Details %(WSS)",
-                        "Value #J": " Number of cluster nodes ",
-                        "Value #K": " Selected microservices (RSS) ",
-                        "Value #L": " Node Network Overview ",
-                        "container": " container number ",
-                        "namespace": " average memory "
-                      }
+                        "Value #A": "Average CPU Usage%",
+                        "Value #B": "Total CPU Demand",
+                        "Value #C": "Total CPU Restrictions",
+                        "Value #D": "Total WSS Memory Usage",
+                        "Value #E": "Total Memory Requirements",
+                        "Value #F": "Total Memory Limit",
+                        "Value #G": "Pod",
+                        "Value #H": "Average RSS Memory Usage%",
+                        "Value #I": "Average WSS Memory Usage%",
+                        "Value #J": "Average Disk Usage",
+                        "Value #K": "Total RSS Memory Use",
+                        "Value #L": "Total CPU Core Usage",
+                        "Value #M": "Average Disk Limit",
+                        "container": "Container Name",
+                        "namespace": "Namespace"
+                        }
                     }
-                  },
-                  {
+                    },
+                    {
                     "id": "filterFieldsByName",
                     "options": {}
-                  }
+                    }
                 ],
                 "type": "table"
-              },
-              {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "datasource": "${datasource}",
-                "decimals": 3,
-                "editable": true,
-                "error": false,
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
                 "fieldConfig": {
-                  "defaults": {
-                    "links": []
-                  },
-                  "overrides": []
+                    "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                        "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                        "mode": "off"
+                        }
+                    },
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                        {
+                            "color": "green"
+                        },
+                        {
+                            "color": "red",
+                            "value": 80
+                        }
+                        ]
+                    },
+                    "unit": "percent"
+                    },
+                    "overrides": []
                 },
-                "fill": 0,
-                "fillGradient": 0,
-                "grid": {},
                 "gridPos": {
-                  "h": 9,
-                  "w": 8,
-                  "x": 0,
-                  "y": 10
+                    "h": 7,
+                    "w": 8,
+                    "x": 0,
+                    "y": 12
                 },
-                "height": "",
-                "hiddenSeries": false,
                 "id": 24,
-                "isNew": true,
-                "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "hideEmpty": false,
-                  "hideZero": false,
-                  "max": true,
-                  "min": true,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-                },
-                "lines": true,
-                "linewidth": 1,
-                "links": [],
-                "nullPointMode": "null",
                 "options": {
-                  "alertThreshold": true
+                    "legend": {
+                    "calcs": [
+                        "max",
+                        "last",
+                        "mean"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                    },
+                    "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                    }
                 },
-                "percentage": false,
-                "pluginVersion": "7.5.11",
-                "pointradius": 5,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
+                "pluginVersion": "10.4.1",
                 "targets": [
-                  {
-                    "expr": "sum(rate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}[2m])) by (container) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}/100000) by (container)) * 100",
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "exemplar": true,
+                    "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}[2m])) by (container) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}/100000) by (container)) * 100",
                     "hide": false,
                     "instant": false,
                     "interval": "",
@@ -27362,111 +30527,101 @@ items:
                     "metric": "container_cpu",
                     "refId": "A",
                     "step": 10
-                  }
+                    }
                 ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": " usage ( container number ) password CPU Request Rate ( overall 100%)",
-                "tooltip": {
-                  "msResolution": true,
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "cumulative"
+                "title": "Microservices (Container Name) Average CPU Usage (Maximum100%)",
+                "type": "timeseries"
                 },
-                "type": "graph",
-                "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": []
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
                 },
-                "yaxes": [
-                  {
-                    "$$hashKey": "object:5607",
-                    "format": "percent",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                  },
-                  {
-                    "$$hashKey": "object:5608",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": false
-                  }
-                ],
-                "yaxis": {
-                  "align": false,
-                  "alignLevel": null
-                }
-              },
-              {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "datasource": "${datasource}",
-                "decimals": 2,
-                "editable": true,
-                "error": false,
                 "fieldConfig": {
-                  "defaults": {
-                    "links": []
-                  },
-                  "overrides": []
+                    "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                        "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                        "mode": "off"
+                        }
+                    },
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                        {
+                            "color": "green"
+                        },
+                        {
+                            "color": "red",
+                            "value": 80
+                        }
+                        ]
+                    },
+                    "unit": "percent"
+                    },
+                    "overrides": []
                 },
-                "fill": 0,
-                "fillGradient": 0,
-                "grid": {},
                 "gridPos": {
-                  "h": 9,
-                  "w": 8,
-                  "x": 8,
-                  "y": 10
+                    "h": 7,
+                    "w": 8,
+                    "x": 8,
+                    "y": 12
                 },
-                "hiddenSeries": false,
-                "id": 59,
-                "isNew": true,
-                "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-                },
-                "lines": true,
-                "linewidth": 2,
-                "links": [],
-                "nullPointMode": "null",
+                "id": 89,
                 "options": {
-                  "alertThreshold": true
+                    "legend": {
+                    "calcs": [
+                        "max",
+                        "last",
+                        "mean"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                    },
+                    "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                    }
                 },
-                "percentage": false,
-                "pluginVersion": "7.5.11",
-                "pointradius": 5,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
+                "pluginVersion": "10.4.1",
                 "targets": [
-                  {
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
                     "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container) * 100",
                     "interval": "",
                     "intervalFactor": 1,
@@ -27474,8 +30629,12 @@ items:
                     "metric": "container_memory_usage:sort_desc",
                     "refId": "A",
                     "step": 10
-                  },
-                  {
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
                     "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container) * 100",
                     "interval": "",
                     "intervalFactor": 1,
@@ -27483,135 +30642,134 @@ items:
                     "metric": "container_memory_usage:sort_desc",
                     "refId": "B",
                     "step": 10
-                  }
+                    }
                 ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": " usage ( container number ) Microservice resource details ",
-                "tooltip": {
-                  "msResolution": false,
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "cumulative"
+                "title": "Microservice (Container Name) Average Memory Utilization",
+                "type": "timeseries"
                 },
-                "type": "graph",
-                "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": []
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
                 },
-                "yaxes": [
-                  {
-                    "$$hashKey": "object:5686",
-                    "format": "percent",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                  },
-                  {
-                    "$$hashKey": "object:5687",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": false
-                  }
-                ],
-                "yaxis": {
-                  "align": false,
-                  "alignLevel": null
-                }
-              },
-              {
-                "aliasColors": {
-                  " update :wholion-lbs": "purple",
-                  " restart :wholion-lbs": "green"
-                },
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "datasource": "${datasource}",
-                "decimals": 2,
-                "editable": true,
-                "error": false,
                 "fieldConfig": {
-                  "defaults": {
-                    "links": []
-                  },
-                  "overrides": []
+                    "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                        "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                        "mode": "off"
+                        }
+                    },
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                        {
+                            "color": "green"
+                        },
+                        {
+                            "color": "red",
+                            "value": 80
+                        }
+                        ]
+                    },
+                    "unit": "binbps"
+                    },
+                    "overrides": []
                 },
-                "fill": 0,
-                "fillGradient": 0,
-                "grid": {},
                 "gridPos": {
-                  "h": 9,
-                  "w": 8,
-                  "x": 16,
-                  "y": 10
+                    "h": 7,
+                    "w": 8,
+                    "x": 16,
+                    "y": 12
                 },
-                "hiddenSeries": false,
                 "id": 16,
-                "isNew": true,
-                "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-                },
-                "lines": true,
-                "linewidth": 1,
-                "links": [],
-                "nullPointMode": "null",
                 "options": {
-                  "alertThreshold": true
+                    "legend": {
+                    "calcs": [
+                        "mean",
+                        "last",
+                        "max"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                    },
+                    "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                    }
                 },
-                "percentage": false,
-                "pluginVersion": "7.5.11",
-                "pointradius": 5,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
+                "pluginVersion": "10.4.1",
                 "targets": [
-                  {
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
                     "exemplar": true,
-                    "expr": "sum(sum(irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(container) *8",
+                    "expr": "sum(sum(irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\",container =~\"$Container\"}) by(container) *8",
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": " update :{{ container }}",
+                    "legendFormat": "Inflow:{{ container }}",
                     "metric": "network",
+                    "range": true,
                     "refId": "A",
                     "step": 10
-                  },
-                  {
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
                     "exemplar": true,
-                    "expr": "sum(sum(irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(container) *8",
+                    "expr": "sum(sum(irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\",container =~\"$Container\"}) by(container) *8",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": " restart :{{ container }}",
+                    "legendFormat": "Outflow:{{ container }}",
                     "metric": "network",
+                    "range": true,
                     "refId": "B",
                     "step": 10
-                  },
-                  {
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
                     "expr": "sum (rate (container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)",
                     "hide": true,
                     "interval": "",
@@ -27620,8 +30778,12 @@ items:
                     "metric": "network",
                     "refId": "C",
                     "step": 10
-                  },
-                  {
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
                     "expr": "- sum (rate (container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)",
                     "hide": true,
                     "interval": "",
@@ -27630,1325 +30792,594 @@ items:
                     "metric": "network",
                     "refId": "D",
                     "step": 10
-                  }
+                    }
                 ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": " usage ( container number ) Container memory usage ( Memory Usage )",
-                "tooltip": {
-                  "msResolution": false,
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "cumulative"
+                "title": "Microservice (Container Name) Network bandwidth per second (Associable Nodes)",
+                "type": "timeseries"
                 },
-                "type": "graph",
-                "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": []
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
                 },
-                "yaxes": [
-                  {
-                    "$$hashKey": "object:8106",
-                    "format": "binbps",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                  },
-                  {
-                    "$$hashKey": "object:8107",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": false
-                  }
-                ],
-                "yaxis": {
-                  "align": false,
-                  "alignLevel": null
-                }
-              }
-            ],
-            "title": " usage ( container number ) Memory Requirements ： Associated nodes :【$Container】",
-            "type": "row"
-          },
-          {
-            "collapsed": true,
-            "datasource": "${datasource}",
-            "gridPos": {
-              "h": 1,
-              "w": 24,
-              "x": 0,
-              "y": 28
-            },
-            "id": 49,
-            "panels": [
-              {
-                "datasource": "${datasource}",
                 "fieldConfig": {
-                  "defaults": {
+                    "defaults": {
                     "color": {
-                      "mode": "thresholds"
+                        "mode": "palette-classic"
                     },
                     "custom": {
-                      "align": "center",
-                      "displayMode": "auto",
-                      "filterable": false
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                        "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                        "mode": "off"
+                        }
                     },
-                    "displayName": "",
+                    "links": [],
                     "mappings": [],
                     "thresholds": {
-                      "mode": "percentage",
-                      "steps": [
+                        "mode": "absolute",
+                        "steps": [
                         {
-                          "color": "green",
-                          "value": null
+                            "color": "green"
                         },
                         {
-                          "color": "#EAB839",
-                          "value": 80
-                        },
-                        {
-                          "color": "red",
-                          "value": 90
+                            "color": "red",
+                            "value": 80
                         }
-                      ]
-                    },
-                    "unit": "short"
-                  },
-                  "overrides": [
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": "CPU%( overall 100%)"
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 140
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " average memory "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 78
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": "Pod core count "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 136
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " core usage "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 71
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": "CPU selected "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 68
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": "CPU total "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 65
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": "WSS%"
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 129
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": "WSS"
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 73
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": "RSS%"
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 132
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": "RSS"
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 68
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " resource statistics "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 69
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " Network bandwidth "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 71
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " send "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 67
-                        },
-                        {
-                          "id": "thresholds",
-                          "value": {
-                            "mode": "absolute",
-                            "steps": [
-                              {
-                                "color": "green",
-                                "value": null
-                              },
-                              {
-                                "color": "#EAB839",
-                                "value": 1
-                              },
-                              {
-                                "color": "red",
-                                "value": 3
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "id": "custom.displayMode",
-                          "value": "color-background"
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " demand "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 71
-                        },
-                        {
-                          "id": "unit",
-                          "value": "bytes"
-                        },
-                        {
-                          "id": "thresholds",
-                          "value": {
-                            "mode": "absolute",
-                            "steps": [
-                              {
-                                "color": "green",
-                                "value": null
-                              },
-                              {
-                                "color": "#EAB839",
-                                "value": 10737418240
-                              },
-                              {
-                                "color": "red",
-                                "value": 16106127360
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "id": "custom.displayMode",
-                          "value": "color-background"
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byRegexp",
-                        "options": ".*%.*"
-                      },
-                      "properties": [
-                        {
-                          "id": "unit",
-                          "value": "percent"
-                        },
-                        {
-                          "id": "custom.displayMode",
-                          "value": "gradient-gauge"
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byRegexp",
-                        "options": " config .*|WSS$|RSS$"
-                      },
-                      "properties": [
-                        {
-                          "id": "unit",
-                          "value": "bytes"
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byRegexp",
-                        "options": ".* total "
-                      },
-                      "properties": [
-                        {
-                          "id": "color",
-                          "value": {
-                            "fixedColor": "blue",
-                            "mode": "fixed"
-                          }
-                        },
-                        {
-                          "id": "custom.displayMode",
-                          "value": "color-background"
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " container "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 87
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byRegexp",
-                        "options": " core usage $|WSS$|RSS$"
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.displayMode",
-                          "value": "color-text"
-                        },
-                        {
-                          "id": "color",
-                          "value": {
-                            "fixedColor": "orange",
-                            "mode": "fixed"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "matcher": {
-                        "id": "byName",
-                        "options": " container number "
-                      },
-                      "properties": [
-                        {
-                          "id": "custom.width",
-                          "value": 116
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "gridPos": {
-                  "h": 8,
-                  "w": 24,
-                  "x": 0,
-                  "y": 3
-                },
-                "id": 47,
-                "options": {
-                  "showHeader": true,
-                  "sortBy": []
-                },
-                "pluginVersion": "7.5.11",
-                "targets": [
-                  {
-                    "exemplar": true,
-                    "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (container, pod,node,namespace) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}/100000) by (container, pod,node,namespace)) * 100",
-                    "format": "table",
-                    "hide": false,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "A"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (container, pod,node,namespace)",
-                    "format": "table",
-                    "hide": false,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "CPU disk usage ",
-                    "refId": "Q"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
-                    "format": "table",
-                    "hide": false,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "B"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
-                    "format": "table",
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "C"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace) * 100",
-                    "format": "table",
-                    "hide": false,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "wss%",
-                    "refId": "I"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)",
-                    "format": "table",
-                    "hide": false,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "wss",
-                    "refId": "D"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace) * 100",
-                    "format": "table",
-                    "hide": false,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "rss%",
-                    "refId": "L"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)",
-                    "format": "table",
-                    "hide": false,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "rss",
-                    "refId": "K"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
-                    "format": "table",
-                    "hide": false,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "E"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
-                    "format": "table",
-                    "hide": false,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "F"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "sum(container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
-                    "format": "table",
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "J"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "kube_pod_container_status_restarts_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"} * on (pod) group_left(node) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}",
-                    "format": "table",
-                    "hide": false,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "H"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "cass_jvm_heap{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}",
-                    "format": "table",
-                    "hide": true,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "M"
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "cass_jvm_heap_max{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}",
-                    "format": "table",
-                    "hide": true,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "N"
-                  },
-                  {
-                    "expr": "cass_jvm_noheap{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}",
-                    "format": "table",
-                    "hide": true,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "O"
-                  },
-                  {
-                    "expr": "cass_jvm_noheap_max{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}",
-                    "format": "table",
-                    "hide": true,
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "",
-                    "refId": "P"
-                  }
-                ],
-                "timeFrom": null,
-                "timeShift": null,
-                "title": "$Node：Pod Memory Limit ( Memory Usage )",
-                "transformations": [
-                  {
-                    "id": "merge",
-                    "options": {}
-                  },
-                  {
-                    "id": "organize",
-                    "options": {
-                      "excludeByName": {
-                        "Time": true,
-                        "Time 1": true,
-                        "Time 10": true,
-                        "Time 11": true,
-                        "Time 12": true,
-                        "Time 13": true,
-                        "Time 2": true,
-                        "Time 3": true,
-                        "Time 4": true,
-                        "Time 5": true,
-                        "Time 6": true,
-                        "Time 7": true,
-                        "Time 8": true,
-                        "Time 9": true,
-                        "Value #G": true,
-                        "__name__": true,
-                        "app_kubernetes_io_name": true,
-                        "app_kubernetes_io_name 1": true,
-                        "app_kubernetes_io_name 2": true,
-                        "app_kubernetes_io_version": true,
-                        "app_kubernetes_io_version 1": true,
-                        "app_kubernetes_io_version 2": true,
-                        "container 1": true,
-                        "container 10": true,
-                        "container 11": true,
-                        "container 12": true,
-                        "container 2": true,
-                        "container 3": true,
-                        "container 4": true,
-                        "container 5": true,
-                        "container 6": true,
-                        "container 7": true,
-                        "container 8": true,
-                        "container 9": true,
-                        "created_by_kind": true,
-                        "created_by_name": true,
-                        "host_ip": true,
-                        "instance": true,
-                        "instance 1": true,
-                        "instance 2": true,
-                        "job": true,
-                        "job 1": true,
-                        "job 2": true,
-                        "k8s_namespace": true,
-                        "k8s_namespace 1": true,
-                        "k8s_namespace 2": true,
-                        "k8s_sname": true,
-                        "k8s_sname 1": true,
-                        "k8s_sname 2": true,
-                        "namespace": false,
-                        "namespace 1": true,
-                        "namespace 10": true,
-                        "namespace 11": true,
-                        "namespace 12": false,
-                        "namespace 2": true,
-                        "namespace 3": true,
-                        "namespace 4": true,
-                        "namespace 5": true,
-                        "namespace 6": true,
-                        "namespace 7": true,
-                        "namespace 8": true,
-                        "namespace 9": true,
-                        "node 1": true,
-                        "node 10": true,
-                        "node 11": false,
-                        "node 12": true,
-                        "node 2": true,
-                        "node 3": true,
-                        "node 4": true,
-                        "node 5": true,
-                        "node 6": true,
-                        "node 7": true,
-                        "node 8": true,
-                        "node 9": true,
-                        "origin_prometheus": true,
-                        "origin_prometheus 1": true,
-                        "origin_prometheus 2": true,
-                        "phase": true,
-                        "pod_ip": true,
-                        "priority_class": true,
-                        "uid": true
-                      },
-                      "indexByName": {
-                        "Time": 23,
-                        "Value #A": 4,
-                        "Value #B": 6,
-                        "Value #C": 7,
-                        "Value #D": 9,
-                        "Value #E": 12,
-                        "Value #F": 13,
-                        "Value #H": 22,
-                        "Value #I": 8,
-                        "Value #J": 14,
-                        "Value #K": 11,
-                        "Value #L": 10,
-                        "Value #Q": 5,
-                        "app_kubernetes_io_name": 15,
-                        "app_kubernetes_io_version": 16,
-                        "container": 2,
-                        "instance": 17,
-                        "job": 18,
-                        "k8s_namespace": 19,
-                        "k8s_sname": 20,
-                        "namespace": 1,
-                        "node": 0,
-                        "origin_prometheus": 21,
-                        "pod": 3
-                      },
-                      "renameByName": {
-                        "Value #A": "CPU%( overall 100%)",
-                        "Value #B": "CPU selected ",
-                        "Value #C": "CPU total ",
-                        "Value #D": "WSS",
-                        "Value #E": " resource statistics ",
-                        "Value #F": " Network bandwidth ",
-                        "Value #H": " send ",
-                        "Value #I": "WSS%",
-                        "Value #J": " demand ",
-                        "Value #K": "RSS",
-                        "Value #L": "RSS%",
-                        "Value #Q": " core usage ",
-                        "container": " container number ",
-                        "namespace": " average memory ",
-                        "namespace 1": "",
-                        "namespace 12": " average memory ",
-                        "node": " container ",
-                        "node 1": "",
-                        "node 11": " container ",
-                        "pod": "Pod core count ",
-                        "priority_class": ""
-                      }
-                    }
-                  },
-                  {
-                    "id": "filterFieldsByName",
-                    "options": {
-                      "include": {
-                        "names": [
-                          " container ",
-                          " average memory ",
-                          "Pod core count ",
-                          "CPU%( overall 100%)",
-                          " core usage ",
-                          "CPU selected ",
-                          "CPU total ",
-                          "WSS%",
-                          "WSS",
-                          "RSS%",
-                          "RSS",
-                          " resource statistics ",
-                          " Network bandwidth ",
-                          " demand ",
-                          " send ",
-                          " container number "
                         ]
-                      }
+                    },
+                    "unit": "none"
+                    },
+                    "overrides": [
+                    {
+                        "matcher": {
+                        "id": "byRegexp",
+                        "options": "/CPU Limit.*/"
+                        },
+                        "properties": [
+                        {
+                            "id": "color",
+                            "value": {
+                            "fixedColor": "red",
+                            "mode": "fixed"
+                            }
+                        }
+                        ]
                     }
-                  }
-                ],
-                "type": "table"
-              },
-              {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "datasource": "${datasource}",
-                "decimals": 2,
-                "editable": true,
-                "error": false,
-                "fieldConfig": {
-                  "defaults": {
-                    "links": []
-                  },
-                  "overrides": []
+                    ]
                 },
-                "fill": 0,
-                "fillGradient": 0,
-                "grid": {},
                 "gridPos": {
-                  "h": 9,
-                  "w": 8,
-                  "x": 0,
-                  "y": 11
+                    "h": 8,
+                    "w": 8,
+                    "x": 0,
+                    "y": 19
                 },
-                "height": "",
-                "hiddenSeries": false,
-                "id": 58,
-                "isNew": true,
-                "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "hideEmpty": false,
-                  "hideZero": false,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-                },
-                "lines": true,
-                "linewidth": 1,
-                "links": [],
-                "nullPointMode": "null",
+                "id": 91,
                 "options": {
-                  "alertThreshold": true
+                    "legend": {
+                    "calcs": [
+                        "max",
+                        "last",
+                        "mean"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true,
+                    "sortBy": "Max",
+                    "sortDesc": true
+                    },
+                    "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                    }
                 },
-                "percentage": false,
-                "pluginVersion": "7.5.11",
-                "pointradius": 5,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
+                "pluginVersion": "10.4.1",
                 "targets": [
-                  {
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
                     "exemplar": true,
-                    "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (container, pod) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}/100000) by (container, pod)) * 100",
+                    "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
                     "hide": false,
                     "instant": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "{{ pod }}",
+                    "legendFormat": "CPU Limitations：{{ container}}",
                     "metric": "container_cpu",
                     "refId": "A",
                     "step": 10
-                  }
-                ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Pod upper limit CPU Request Rate ( overall 100% Memory Usage )",
-                "tooltip": {
-                  "msResolution": true,
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "cumulative"
-                },
-                "type": "graph",
-                "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": []
-                },
-                "yaxes": [
-                  {
-                    "$$hashKey": "object:5607",
-                    "format": "percent",
-                    "label": "",
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                  },
-                  {
-                    "$$hashKey": "object:5608",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": false
-                  }
-                ],
-                "yaxis": {
-                  "align": false,
-                  "alignLevel": null
-                }
-              },
-              {
-                "aliasColors": {},
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "datasource": "${datasource}",
-                "decimals": 2,
-                "editable": true,
-                "error": false,
-                "fieldConfig": {
-                  "defaults": {
-                    "links": []
-                  },
-                  "overrides": []
-                },
-                "fill": 0,
-                "fillGradient": 0,
-                "grid": {},
-                "gridPos": {
-                  "h": 9,
-                  "w": 8,
-                  "x": 8,
-                  "y": 11
-                },
-                "hiddenSeries": false,
-                "id": 27,
-                "isNew": true,
-                "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": false,
-                  "total": false,
-                  "values": true
-                },
-                "lines": true,
-                "linewidth": 2,
-                "links": [],
-                "nullPointMode": "null",
-                "options": {
-                  "alertThreshold": true
-                },
-                "percentage": false,
-                "pluginVersion": "7.5.11",
-                "pointradius": 5,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
-                "targets": [
-                  {
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
                     "exemplar": true,
-                    "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod) * 100",
-                    "interval": "",
-                    "intervalFactor": 1,
-                    "legendFormat": "WSS：{{ pod }}",
-                    "metric": "container_memory_usage:sort_desc",
-                    "refId": "A",
-                    "step": 10
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod) * 100",
-                    "interval": "",
-                    "intervalFactor": 1,
-                    "legendFormat": "RSS：{{ pod }}",
-                    "metric": "container_memory_usage:sort_desc",
-                    "refId": "B",
-                    "step": 10
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "(cass_jvm_heap{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}) / (cass_jvm_heap_max{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}) * 100",
+                    "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}[2m])) by (container)",
+                    "hide": false,
                     "instant": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "Heap：{{ pod }}",
-                    "metric": "container_memory_usage:sort_desc",
-                    "refId": "C",
+                    "legendFormat": "CPU Core Usage：{{ container}}",
+                    "metric": "container_cpu",
+                    "refId": "B",
                     "step": 10
-                  }
+                    }
                 ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Pod View more dashboards ( Memory Usage )",
-                "tooltip": {
-                  "msResolution": false,
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "cumulative"
+                "title": "Microservices (Container Name) Overall CPU Cores Used",
+                "type": "timeseries"
                 },
-                "type": "graph",
-                "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": []
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
                 },
-                "yaxes": [
-                  {
-                    "$$hashKey": "object:5686",
-                    "format": "percent",
-                    "label": null,
-                    "logBase": 1,
-                    "max": "100",
-                    "min": null,
-                    "show": true
-                  },
-                  {
-                    "$$hashKey": "object:5687",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": false
-                  }
-                ],
-                "yaxis": {
-                  "align": false,
-                  "alignLevel": null
-                }
-              },
-              {
-                "aliasColors": {
-                  " update :wholion-lbs": "purple",
-                  " restart :wholion-lbs": "green"
-                },
-                "bars": false,
-                "dashLength": 10,
-                "dashes": false,
-                "datasource": "${datasource}",
-                "decimals": 2,
-                "editable": true,
-                "error": false,
                 "fieldConfig": {
-                  "defaults": {
-                    "links": []
-                  },
-                  "overrides": []
+                    "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                        "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                        "mode": "off"
+                        }
+                    },
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                        {
+                            "color": "green"
+                        },
+                        {
+                            "color": "red",
+                            "value": 80
+                        }
+                        ]
+                    },
+                    "unit": "bytes"
+                    },
+                    "overrides": [
+                    {
+                        "matcher": {
+                        "id": "byRegexp",
+                        "options": "/Memory Limit.*/"
+                        },
+                        "properties": [
+                        {
+                            "id": "color",
+                            "value": {
+                            "fixedColor": "red",
+                            "mode": "fixed"
+                            }
+                        }
+                        ]
+                    }
+                    ]
                 },
-                "fill": 0,
-                "fillGradient": 0,
-                "grid": {},
                 "gridPos": {
-                  "h": 9,
-                  "w": 8,
-                  "x": 16,
-                  "y": 11
+                    "h": 8,
+                    "w": 8,
+                    "x": 8,
+                    "y": 19
                 },
-                "hiddenSeries": false,
-                "id": 77,
-                "isNew": true,
-                "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-                },
-                "lines": true,
-                "linewidth": 1,
-                "links": [],
-                "nullPointMode": "null",
+                "id": 90,
                 "options": {
-                  "alertThreshold": true
+                    "legend": {
+                    "calcs": [
+                        "max",
+                        "last",
+                        "mean"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true,
+                    "sortBy": "Max",
+                    "sortDesc": true
+                    },
+                    "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                    }
                 },
-                "percentage": false,
-                "pluginVersion": "7.5.11",
-                "pointradius": 5,
-                "points": false,
-                "renderer": "flot",
-                "seriesOverrides": [],
-                "spaceLength": 10,
-                "stack": false,
-                "steppedLine": false,
+                "pluginVersion": "10.4.1",
                 "targets": [
-                  {
-                    "exemplar": true,
-                    "expr": "sum(sum(irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(pod) *8",
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "WSS：{{ container }}",
+                    "metric": "container_memory_usage:sort_desc",
+                    "range": true,
+                    "refId": "A",
+                    "step": 10
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Memory Limit：{{ container }}",
+                    "metric": "container_memory_usage:sort_desc",
+                    "range": true,
+                    "refId": "B",
+                    "step": 10
+                    },
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
+                    "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
                     "hide": false,
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": " update :{{ pod}}",
-                    "metric": "network",
-                    "refId": "A",
-                    "step": 10
-                  },
-                  {
-                    "exemplar": true,
-                    "expr": "sum(sum(irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(pod) *8",
-                    "interval": "",
-                    "intervalFactor": 1,
-                    "legendFormat": " restart :{{ pod}}",
-                    "metric": "network",
-                    "refId": "B",
-                    "step": 10
-                  },
-                  {
-                    "expr": "sum (rate (container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)",
-                    "hide": true,
-                    "interval": "",
-                    "intervalFactor": 1,
-                    "legendFormat": "-> {{ pod }}",
-                    "metric": "network",
+                    "legendFormat": "RSS：{{ container }}",
+                    "metric": "container_memory_usage:sort_desc",
+                    "range": true,
                     "refId": "C",
                     "step": 10
-                  },
-                  {
-                    "expr": "- sum (rate (container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)",
-                    "hide": true,
+                    }
+                ],
+                "title": "Microservices (Container Name) Overall Memory Usage",
+                "type": "timeseries"
+                },
+                {
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "P1809F7CD0C75ACF3"
+                },
+                "fieldConfig": {
+                    "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                        "legend": false,
+                        "tooltip": false,
+                        "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                        "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": false,
+                        "stacking": {
+                        "group": "A",
+                        "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                        "mode": "off"
+                        }
+                    },
+                    "links": [],
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                        {
+                            "color": "green"
+                        },
+                        {
+                            "color": "red",
+                            "value": 80
+                        }
+                        ]
+                    },
+                    "unit": "none"
+                    },
+                    "overrides": []
+                },
+                "gridPos": {
+                    "h": 8,
+                    "w": 8,
+                    "x": 16,
+                    "y": 19
+                },
+                "id": 59,
+                "options": {
+                    "legend": {
+                    "calcs": [
+                        "max",
+                        "last",
+                        "mean"
+                    ],
+                    "displayMode": "table",
+                    "placement": "bottom",
+                    "showLegend": true
+                    },
+                    "tooltip": {
+                    "mode": "multi",
+                    "sort": "desc"
+                    }
+                },
+                "pluginVersion": "10.4.1",
+                "targets": [
+                    {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "P1809F7CD0C75ACF3"
+                    },
+                    "editorMode": "code",
+                    "expr": "count(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by(container,namespace)",
                     "interval": "",
                     "intervalFactor": 1,
-                    "legendFormat": "<- {{ pod }}",
-                    "metric": "network",
-                    "refId": "D",
+                    "legendFormat": "{{namespace}}：{{ container }}",
+                    "metric": "container_memory_usage:sort_desc",
+                    "range": true,
+                    "refId": "A",
                     "step": 10
-                  }
+                    }
                 ],
-                "thresholds": [],
-                "timeFrom": null,
-                "timeRegions": [],
-                "timeShift": null,
-                "title": "Pod Container memory usage ( Memory Usage )",
-                "tooltip": {
-                  "msResolution": false,
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "cumulative"
-                },
-                "type": "graph",
-                "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": []
-                },
-                "yaxes": [
-                  {
-                    "$$hashKey": "object:8106",
-                    "format": "binbps",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": true
-                  },
-                  {
-                    "$$hashKey": "object:8107",
-                    "format": "short",
-                    "label": null,
-                    "logBase": 1,
-                    "max": null,
-                    "min": null,
-                    "show": false
-                  }
-                ],
-                "yaxis": {
-                  "align": false,
-                  "alignLevel": null
+                "title": "Microservice (Container Name) Pod Number",
+                "type": "timeseries"
                 }
-              }
             ],
-            "title": "Pod Memory Requirements ： space Pod:【$Pod】",
+            "title": "Microservices (Container Name) Resource Overview：Selected Microservices:【$Container】",
             "type": "row"
-          }
+            }
         ],
         "refresh": "",
-        "schemaVersion": 27,
-        "style": "dark",
+        "schemaVersion": 39,
         "tags": [
-          "StarsL.cn",
-          "Prometheus",
-          "Kubernetes"
+            "Prometheus",
+            "Kubernetes"
         ],
         "templating": {
-          "list": [
+            "list": [
             {
-              "allValue": "",
-              "current": {},
-              "datasource": "${datasource}",
-              "definition": "label_values(origin_prometheus)",
-              "description": null,
-              "error": null,
-              "hide": 0,
-              "includeAll": false,
-              "label": "K8S",
-              "multi": false,
-              "name": "origin_prometheus",
-              "options": [],
-              "query": {
-                "query": "label_values(origin_prometheus)",
-                "refId": "Prometheus-origin_prometheus-Variable-Query"
-              },
-              "refresh": 2,
-              "regex": "",
-              "skipUrlSync": false,
-              "sort": 5,
-              "tagValuesQuery": "",
-              "tags": [],
-              "tagsQuery": "",
-              "type": "query",
-              "useTags": false
+                "allValue": "",
+                "current": {
+                "isNone": true,
+                "selected": false,
+                "text": "None",
+                "value": ""
+                },
+                "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+                },
+                "definition": "label_values(kube_node_info,origin_prometheus)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "K8S",
+                "multi": false,
+                "name": "origin_prometheus",
+                "options": [],
+                "query": {
+                "query": "label_values(kube_node_info,origin_prometheus)",
+                "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 5,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
             },
             {
-              "allValue": "",
-              "current": {},
-              "datasource": "${datasource}",
-              "definition": "label_values(kube_node_info{origin_prometheus=~\"$origin_prometheus\"},node)",
-              "description": null,
-              "error": null,
-              "hide": 0,
-              "includeAll": true,
-              "label": " container ",
-              "multi": false,
-              "name": "Node",
-              "options": [],
-              "query": {
+                "allValue": ".*",
+                "current": {
+                "selected": false,
+                "text": "All",
+                "value": "$__all"
+                },
+                "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+                },
+                "definition": "label_values(kube_node_info{origin_prometheus=~\"$origin_prometheus\"},node)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Nodes",
+                "multi": false,
+                "name": "Node",
+                "options": [],
+                "query": {
                 "query": "label_values(kube_node_info{origin_prometheus=~\"$origin_prometheus\"},node)",
-                "refId": "Prometheus-Node-Variable-Query"
-              },
-              "refresh": 1,
-              "regex": "",
-              "skipUrlSync": false,
-              "sort": 5,
-              "tagValuesQuery": "",
-              "tags": [],
-              "tagsQuery": "",
-              "type": "query",
-              "useTags": false
+                "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 5,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
             },
             {
-              "allValue": "",
-              "current": {},
-              "datasource": "${datasource}",
-              "definition": "label_values(kube_namespace_labels{origin_prometheus=~\"$origin_prometheus\"},namespace)",
-              "description": null,
-              "error": null,
-              "hide": 0,
-              "includeAll": true,
-              "label": " average memory ",
-              "multi": false,
-              "name": "NameSpace",
-              "options": [],
-              "query": {
-                "query": "label_values(kube_namespace_labels{origin_prometheus=~\"$origin_prometheus\"},namespace)",
-                "refId": "Prometheus-NameSpace-Variable-Query"
-              },
-              "refresh": 1,
-              "regex": "",
-              "skipUrlSync": false,
-              "sort": 5,
-              "tagValuesQuery": "",
-              "tags": [],
-              "tagsQuery": "",
-              "type": "query",
-              "useTags": false
+                "allValue": ".*",
+                "current": {
+                "selected": false,
+                "text": "All",
+                "value": "$__all"
+                },
+                "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+                },
+                "definition": "label_values(kube_namespace_created{origin_prometheus=~\"$origin_prometheus\"},namespace)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Namespace",
+                "multi": false,
+                "name": "NameSpace",
+                "options": [],
+                "query": {
+                "query": "label_values(kube_namespace_created{origin_prometheus=~\"$origin_prometheus\"},namespace)",
+                "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 5,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
             },
             {
-              "allValue": ".*",
-              "current": {},
-              "datasource": "${datasource}",
-              "definition": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\"},container)",
-              "description": null,
-              "error": null,
-              "hide": 0,
-              "includeAll": true,
-              "label": " usage ( container number )",
-              "multi": false,
-              "name": "Container",
-              "options": [],
-              "query": {
+                "allValue": ".*",
+                "current": {
+                "selected": false,
+                "text": "All",
+                "value": "$__all"
+                },
+                "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+                },
+                "definition": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\"},container)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Microservice (Container Name)",
+                "multi": false,
+                "name": "Container",
+                "options": [],
+                "query": {
                 "query": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\"},container)",
-                "refId": "Prometheus-Container-Variable-Query"
-              },
-              "refresh": 1,
-              "regex": "",
-              "skipUrlSync": false,
-              "sort": 5,
-              "tagValuesQuery": "",
-              "tags": [],
-              "tagsQuery": "",
-              "type": "query",
-              "useTags": false
+                "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 5,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
             },
             {
-              "allValue": ".*",
-              "current": {},
-              "datasource": "${datasource}",
-              "definition": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\",container=~\"$Container\"},pod)",
-              "description": null,
-              "error": null,
-              "hide": 0,
-              "includeAll": true,
-              "label": "Pod",
-              "multi": false,
-              "name": "Pod",
-              "options": [],
-              "query": {
+                "allValue": ".*",
+                "current": {
+                "selected": false,
+                "text": "All",
+                "value": "$__all"
+                },
+                "datasource": {
+                "type": "prometheus",
+                "uid": "P1809F7CD0C75ACF3"
+                },
+                "definition": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\",container=~\"$Container\"},pod)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Pod",
+                "multi": false,
+                "name": "Pod",
+                "options": [],
+                "query": {
                 "query": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\",container=~\"$Container\"},pod)",
-                "refId": "Prometheus-Pod-Variable-Query"
-              },
-              "refresh": 1,
-              "regex": "",
-              "skipUrlSync": false,
-              "sort": 5,
-              "tagValuesQuery": "",
-              "tags": [],
-              "tagsQuery": "",
-              "type": "query",
-              "useTags": false
+                "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 5,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
             }
-          ]
+            ]
         },
         "time": {
-          "from": "now-30m",
-          "to": "now"
+            "from": "now-30m",
+            "to": "now"
         },
         "timepicker": {
-          "refresh_intervals": [
-            "5s",
-            "10s",
+            "refresh_intervals": [
             "30s",
             "1m",
             "5m",
             "15m",
             "30m",
-            "1h",
-            "2h",
-            "1d"
-          ],
-          "time_options": [
+            "1h"
+            ],
+            "time_options": [
             "5m",
             "15m",
             "1h",
@@ -28958,13 +31389,15 @@ items:
             "2d",
             "7d",
             "30d"
-          ]
+            ]
         },
         "timezone": "browser",
-        "title": "1 K8S for Prometheus Dashboard 20250125 EN",
-        "uid": "PwMJtdvnz",
-        "version": 10
-      }  kind: ConfigMap
+        "title": "K8S Dashboard",
+        "uid": "aerzmx14gohs0a",
+        "version": 2,
+        "weekStart": ""
+        }
+  kind: ConfigMap
   metadata:
     labels:
       app.kubernetes.io/component: grafana
@@ -28973,6 +31406,4 @@ items:
       app.kubernetes.io/version: 11.2.0
     name: grafana-dashboard-k8s-overview
     namespace: monitoring
-
-
 kind: ConfigMapList

--- a/k8s/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
+++ b/k8s/kube-prometheus/manifests/grafana-dashboardDefinitions.yaml
@@ -24676,4 +24676,4303 @@ items:
       app.kubernetes.io/version: 11.2.0
     name: grafana-dashboard-workload-total
     namespace: monitoring
+- apiVersion: v1
+  data:
+    k8s-overview.json: |-
+      {
+        "__inputs": [
+          {
+            "name": "DS_PROMETHEUS",
+            "label": "Prometheus",
+            "description": "",
+            "type": "datasource",
+            "pluginId": "prometheus",
+            "pluginName": "Prometheus"
+          }
+        ],
+        "__requires": [
+          {
+            "type": "panel",
+            "id": "bargauge",
+            "name": "Bar gauge",
+            "version": ""
+          },
+          {
+            "type": "grafana",
+            "id": "grafana",
+            "name": "Grafana",
+            "version": "7.5.11"
+          },
+          {
+            "type": "panel",
+            "id": "graph",
+            "name": "Graph",
+            "version": ""
+          },
+          {
+            "type": "datasource",
+            "id": "prometheus",
+            "name": "Prometheus",
+            "version": "1.0.0"
+          },
+          {
+            "type": "panel",
+            "id": "table",
+            "name": "Table",
+            "version": ""
+          }
+        ],
+        "annotations": {
+          "list": [
+            {
+              "$$hashKey": "object:247",
+              "builtIn": 1,
+              "datasource": "-- Grafana --",
+              "enable": true,
+              "hide": true,
+              "iconColor": "rgba(0, 211, 255, 1)",
+              "name": "Annotations & Alerts",
+              "target": {
+                "limit": 100,
+                "matchAny": false,
+                "tags": [],
+                "type": "dashboard"
+              },
+              "type": "dashboard"
+            }
+          ]
+        },
+        "description": "【 resource overview 】2025.01.25 detail ，kubernetes Node information details ！ outflow K8S Node resource overview 、 Network bandwidth per second 、Pod Resource details K8S Network overview ， Optimizing important metrics display 。https://github.com/starsliao/Prometheus",
+        "editable": true,
+        "gnetId": 15661,
+        "graphTooltip": 0,
+        "id": null,
+        "iteration": 1633873748245,
+        "links": [
+          {
+            "icon": "bolt",
+            "tags": [],
+            "targetBlank": true,
+            "title": "Update",
+            "tooltip": " Update current dashboard ",
+            "type": "link",
+            "url": "https://grafana.com/dashboards/13105"
+          },
+          {
+            "$$hashKey": "object:831",
+            "icon": "question",
+            "tags": [
+              "node_exporter"
+            ],
+            "targetBlank": true,
+            "title": "GitHub",
+            "tooltip": " Overall memory usage  ",
+            "type": "link",
+            "url": "https://github.com/starsliao/Prometheus"
+          },
+          {
+            "$$hashKey": "object:1091",
+            "asDropdown": true,
+            "icon": "external link",
+            "tags": [],
+            "targetBlank": true,
+            "type": "dashboards"
+          }
+        ],
+        "panels": [
+          {
+            "collapsed": false,
+            "datasource": "${datasource}",
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "id": 54,
+            "panels": [],
+            "title": " Node Storage Information ： Number of cores used :【$Node】",
+            "type": "row"
+          },
+          {
+            "cacheTimeout": null,
+            "datasource": "${datasource}",
+            "fieldConfig": {
+              "defaults": {
+                "decimals": 1,
+                "mappings": [],
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "rgba(50, 172, 45, 0.97)",
+                      "value": null
+                    },
+                    {
+                      "color": "rgba(237, 129, 40, 0.89)",
+                      "value": 0.8
+                    },
+                    {
+                      "color": "rgba(245, 54, 54, 0.9)",
+                      "value": 0.99
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 4,
+              "w": 4,
+              "x": 0,
+              "y": 1
+            },
+            "id": 44,
+            "links": [],
+            "options": {
+              "displayMode": "basic",
+              "orientation": "vertical",
+              "reduceOptions": {
+                "calcs": [
+                  "last"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "text": {}
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": " Memory Limit Rate ",
+                "refId": "C"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": " Total memory usage ",
+                "refId": "A"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})",
+                "hide": false,
+                "instant": true,
+                "interval": "10s",
+                "intervalFactor": 1,
+                "legendFormat": " Total Memory Demand ",
+                "refId": "B",
+                "step": 10
+              }
+            ],
+            "title": " Overall core usage ",
+            "type": "bargauge"
+          },
+          {
+            "cacheTimeout": null,
+            "datasource": "${datasource}",
+            "fieldConfig": {
+              "defaults": {
+                "decimals": 1,
+                "mappings": [],
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "rgba(50, 172, 45, 0.97)",
+                      "value": null
+                    },
+                    {
+                      "color": "rgba(237, 129, 40, 0.89)",
+                      "value": 0.8
+                    },
+                    {
+                      "color": "rgba(245, 54, 54, 0.9)",
+                      "value": 0.99
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 4,
+              "w": 4,
+              "x": 4,
+              "y": 1
+            },
+            "id": 45,
+            "links": [],
+            "options": {
+              "displayMode": "basic",
+              "orientation": "vertical",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "text": {}
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}[2m])) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "CPU Request Rate ",
+                "refId": "C"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "CPU total memory ",
+                "refId": "A"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"}) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "CPU Nodes ",
+                "refId": "B"
+              }
+            ],
+            "title": " container CPU proportion ",
+            "type": "bargauge"
+          },
+          {
+            "datasource": "${datasource}",
+            "description": " Memory Request Rate ， container POD core ， container POD disk ",
+            "fieldConfig": {
+              "defaults": {
+                "mappings": [],
+                "max": 1000,
+                "min": 1,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 1000
+                    },
+                    {
+                      "color": "red",
+                      "value": 2000
+                    }
+                  ]
+                },
+                "unit": "none"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 4,
+              "w": 3,
+              "x": 8,
+              "y": 1
+            },
+            "id": 74,
+            "options": {
+              "displayMode": "basic",
+              "orientation": "vertical",
+              "reduceOptions": {
+                "calcs": [
+                  "last"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "text": {}
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+              {
+                "expr": "count(kube_node_info{origin_prometheus=~\"$origin_prometheus\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": " Total Cores ",
+                "refId": "A"
+              },
+              {
+                "expr": "count(kube_pod_info{origin_prometheus=~\"$origin_prometheus\",created_by_kind!~\"<none>|Job\",node=~\"^$Node$\"})",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "Pod core ",
+                "refId": "B"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"pods\", unit=\"integer\",node=~\"^$Node$\"})",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": " disk Pod",
+                "refId": "C"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": " microservice Pod",
+            "type": "bargauge"
+          },
+          {
+            "datasource": "${datasource}",
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "align": "center",
+                  "displayMode": "auto",
+                  "filterable": false
+                },
+                "mappings": [],
+                "noValue": "0",
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " use "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 8
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Pod"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 21
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "SVC"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 7
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " usage "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 4
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " memory "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 16
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " request "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 33
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 5,
+              "x": 11,
+              "y": 1
+            },
+            "id": 51,
+            "options": {
+              "showHeader": true,
+              "sortBy": [
+                {
+                  "desc": true,
+                  "displayName": " use "
+                }
+              ]
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+              {
+                "expr": "count(kube_pod_info{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\"}) by (namespace)",
+                "format": "table",
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "A"
+              },
+              {
+                "expr": "count(kube_service_info{origin_prometheus=~\"$origin_prometheus\"}) by(namespace)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "C"
+              },
+              {
+                "expr": "count(count(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\"}) by(container,namespace))by(namespace)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "D"
+              },
+              {
+                "expr": "count(kube_configmap_info{origin_prometheus=~\"$origin_prometheus\"}) by(namespace)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "configmap",
+                "refId": "B"
+              },
+              {
+                "expr": "count(kube_secret_info{origin_prometheus=~\"$origin_prometheus\"}) by(namespace)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "secret",
+                "refId": "E"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": " average memory ",
+            "transformations": [
+              {
+                "id": "seriesToColumns",
+                "options": {
+                  "byField": "namespace"
+                }
+              },
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time 1": true,
+                    "Time 2": true,
+                    "Time 3": true,
+                    "Time 4": true,
+                    "Time 5": true
+                  },
+                  "indexByName": {
+                    "Time 1": 2,
+                    "Time 2": 4,
+                    "Time 3": 6,
+                    "Value #A": 3,
+                    "Value #C": 5,
+                    "Value #D": 1,
+                    "namespace": 0
+                  },
+                  "renameByName": {
+                    "Time 1": "",
+                    "Time 2": "",
+                    "Value #A": "Pod",
+                    "Value #B": " memory ",
+                    "Value #C": "SVC",
+                    "Value #D": " usage ",
+                    "Value #E": " request ",
+                    "namespace": " use "
+                  }
+                }
+              }
+            ],
+            "type": "table"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fieldConfig": {
+              "defaults": {
+                "links": []
+              },
+              "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 16,
+              "y": 1
+            },
+            "height": "200px",
+            "hiddenSeries": false,
+            "id": 32,
+            "isNew": true,
+            "legend": {
+              "alignAsTable": false,
+              "avg": true,
+              "current": true,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": false,
+              "sideWidth": 200,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+              "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.11",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum (rate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m]))*8",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": " inflow ",
+                "metric": "network",
+                "refId": "A",
+                "step": 10
+              },
+              {
+                "exemplar": true,
+                "expr": "sum (rate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m]))*8",
+                "instant": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": " status ",
+                "metric": "network",
+                "refId": "B",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$NameSpace： selected nodes （ Associating nodes and namespaces ）",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "$$hashKey": "object:750",
+                "format": "binbps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "$$hashKey": "object:751",
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "datasource": "${datasource}",
+            "fieldConfig": {
+              "defaults": {
+                "decimals": 1,
+                "mappings": [],
+                "max": 1000000000000,
+                "min": 1,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 800000000000
+                    },
+                    {
+                      "color": "red",
+                      "value": 1000000000000
+                    }
+                  ]
+                },
+                "unit": "bytes"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 4,
+              "w": 4,
+              "x": 0,
+              "y": 5
+            },
+            "id": 71,
+            "options": {
+              "displayMode": "basic",
+              "orientation": "vertical",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "text": {}
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": " Requests ",
+                "refId": "A"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": " Nodes ",
+                "refId": "C"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": " total disk ",
+                "refId": "D"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": " limit rate ",
+                "refId": "B"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": " Resource comprehensive display ",
+            "type": "bargauge"
+          },
+          {
+            "datasource": "${datasource}",
+            "fieldConfig": {
+              "defaults": {
+                "decimals": 1,
+                "mappings": [],
+                "max": 500,
+                "min": 1,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 500
+                    },
+                    {
+                      "color": "red",
+                      "value": 1000
+                    }
+                  ]
+                },
+                "unit": "locale"
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 4,
+              "w": 4,
+              "x": 4,
+              "y": 5
+            },
+            "id": 72,
+            "options": {
+              "displayMode": "basic",
+              "orientation": "vertical",
+              "reduceOptions": {
+                "calcs": [
+                  "last"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "text": {}
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": " usage ",
+                "refId": "A"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",id=\"/\",node=~\"^$Node$\"}[2m]))",
+                "instant": true,
+                "interval": "",
+                "legendFormat": " Nodes ",
+                "refId": "C"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": " total disk ",
+                "refId": "D"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": " limit rate ",
+                "refId": "B"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": " container CPU node ",
+            "type": "bargauge"
+          },
+          {
+            "datasource": "${datasource}",
+            "fieldConfig": {
+              "defaults": {
+                "decimals": 2,
+                "mappings": [],
+                "max": 8000000000000,
+                "min": 1,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "#EAB839",
+                      "value": 5000000000000
+                    },
+                    {
+                      "color": "red",
+                      "value": 10000000000000
+                    }
+                  ]
+                },
+                "unit": "bytes"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " Request Rate "
+                  },
+                  "properties": [
+                    {
+                      "id": "unit",
+                      "value": "percentunit"
+                    },
+                    {
+                      "id": "max",
+                      "value": 1
+                    },
+                    {
+                      "id": "min",
+                      "value": 0
+                    },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "percentage",
+                        "steps": [
+                          {
+                            "color": "green",
+                            "value": null
+                          },
+                          {
+                            "color": "orange",
+                            "value": 80
+                          },
+                          {
+                            "color": "red",
+                            "value": 90
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 4,
+              "w": 3,
+              "x": 8,
+              "y": 5
+            },
+            "id": 73,
+            "options": {
+              "displayMode": "basic",
+              "orientation": "vertical",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showUnfilled": true,
+              "text": {}
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+              {
+                "expr": "sum (container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"}) / sum (container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": " Request Rate ",
+                "refId": "C"
+              },
+              {
+                "expr": "sum (container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": " Nodes ",
+                "refId": "A"
+              },
+              {
+                "expr": "sum (container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})",
+                "instant": true,
+                "interval": "",
+                "legendFormat": " name ",
+                "refId": "B"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": " Node memory ratio ",
+            "type": "bargauge"
+          },
+          {
+            "datasource": "${datasource}",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "custom": {
+                  "align": "center",
+                  "displayMode": "auto",
+                  "filterable": false
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Pod"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 51
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " include "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 51
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "CPU limit ( number )"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 63
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "CPU total "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 54
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "CPU total "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 58
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " memory request "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 78
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " Total Memory "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 76
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " Network bandwidth "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 83
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " English version "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 85
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " container name "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 84
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " config %"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 92
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " Memory Usage %"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 63
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " Network bandwidth %"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 59
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "CPU limit %"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 81
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "CPU max %"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 77
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "CPU total %"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 59
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " English version %"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 72
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byRegexp",
+                    "options": ".*%"
+                  },
+                  "properties": [
+                    {
+                      "id": "unit",
+                      "value": "percentunit"
+                    },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "percentage",
+                        "steps": [
+                          {
+                            "color": "green",
+                            "value": null
+                          },
+                          {
+                            "color": "orange",
+                            "value": 80
+                          },
+                          {
+                            "color": "red",
+                            "value": 90
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "id": "custom.displayMode",
+                      "value": "color-background"
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byRegexp",
+                    "options": "( memory request | Total Memory | Memory Usage | Network bandwidth | English version | container name )"
+                  },
+                  "properties": [
+                    {
+                      "id": "unit",
+                      "value": "bytes"
+                    },
+                    {
+                      "id": "decimals",
+                      "value": 2
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " container "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 96
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " memory request %"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 67
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": " Memory Usage "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 75
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "CPU max "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 58
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byRegexp",
+                    "options": "(CPU total | Total Memory | container name |Pod disk )"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.displayMode",
+                      "value": "color-background"
+                    },
+                    {
+                      "id": "thresholds",
+                      "value": {
+                        "mode": "absolute",
+                        "steps": [
+                          {
+                            "color": "blue",
+                            "value": null
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "Pod disk "
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.width",
+                      "value": 54
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byRegexp",
+                    "options": "CPU limit \\( number \\)$| memory request $| English version $"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.displayMode",
+                      "value": "color-text"
+                    },
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 9
+            },
+            "id": 52,
+            "options": {
+              "showHeader": true,
+              "sortBy": [
+                {
+                  "desc": true,
+                  "displayName": " English version %"
+                }
+              ]
+            },
+            "pluginVersion": "7.5.11",
+            "targets": [
+              {
+                "expr": "count(kube_pod_info{origin_prometheus=~\"$origin_prometheus\",created_by_kind!~\"<none>|Job\",node=~\"^$Node$\"}) by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "pod core ",
+                "refId": "A"
+              },
+              {
+                "exemplar": true,
+                "expr": "kube_node_status_condition{origin_prometheus=~\"$origin_prometheus\",status=\"true\",node=~\"^$Node$\"}  == 1",
+                "format": "table",
+                "instant": true,
+                "interval": "",
+                "legendFormat": " include ",
+                "refId": "B"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}[2m])) by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "I"
+              },
+              {
+                "exemplar": true,
+                "expr": "kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"} - 0",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "C"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"}) by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "E"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"}) by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "F"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}) by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "J"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"}) by (node) - 0",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "D"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"}) by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "G"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"}) by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "H"
+              },
+              {
+                "expr": "sum (container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"}) by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "K"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum (container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"}) by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "",
+                "refId": "L"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": " memory request %",
+                "refId": "M"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": " Memory Usage %",
+                "refId": "N"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": " Network bandwidth %",
+                "refId": "O"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}[2m]))by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "CPU limit %",
+                "refId": "P"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "CPU max %",
+                "refId": "Q"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": " Network bandwidth %",
+                "refId": "R"
+              },
+              {
+                "expr": "sum (container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})by (node) / sum (container_fs_limit_bytes{origin_prometheus=~\"$origin_prometheus\",device=~\"^/dev/.*$\",id=\"/\",node=~\"^$Node$\"})by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": " English version %",
+                "refId": "S"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"pods\", unit=\"integer\",node=~\"^$Node$\"})by (node)",
+                "format": "table",
+                "hide": false,
+                "instant": true,
+                "interval": "",
+                "legendFormat": "Pod disk ",
+                "refId": "T"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "$Node： Node memory details ",
+            "transformations": [
+              {
+                "id": "merge",
+                "options": {}
+              },
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time": true,
+                    "Time 1": true,
+                    "Time 10": true,
+                    "Time 11": true,
+                    "Time 12": true,
+                    "Time 13": true,
+                    "Time 14": true,
+                    "Time 15": true,
+                    "Time 16": true,
+                    "Time 17": true,
+                    "Time 18": true,
+                    "Time 19": true,
+                    "Time 2": true,
+                    "Time 20": true,
+                    "Time 3": true,
+                    "Time 4": true,
+                    "Time 5": true,
+                    "Time 6": true,
+                    "Time 7": true,
+                    "Time 8": true,
+                    "Time 9": true,
+                    "Value #B": true,
+                    "Value #E": false,
+                    "Value #F": false,
+                    "__name__": true,
+                    "app_kubernetes_io_name": true,
+                    "app_kubernetes_io_name 1": true,
+                    "app_kubernetes_io_name 2": true,
+                    "app_kubernetes_io_name 3": true,
+                    "app_kubernetes_io_version": true,
+                    "app_kubernetes_io_version 1": true,
+                    "app_kubernetes_io_version 2": true,
+                    "app_kubernetes_io_version 3": true,
+                    "condition": false,
+                    "instance": true,
+                    "instance 1": true,
+                    "instance 2": true,
+                    "instance 3": true,
+                    "job": true,
+                    "job 1": true,
+                    "job 2": true,
+                    "job 3": true,
+                    "k8s_namespace": true,
+                    "k8s_namespace 1": true,
+                    "k8s_namespace 2": true,
+                    "k8s_namespace 3": true,
+                    "k8s_sname": true,
+                    "k8s_sname 1": true,
+                    "k8s_sname 2": true,
+                    "k8s_sname 3": true,
+                    "origin_prometheus": true,
+                    "origin_prometheus 1": true,
+                    "origin_prometheus 2": true,
+                    "origin_prometheus 3": true,
+                    "resource": true,
+                    "status": true,
+                    "unit": true
+                  },
+                  "indexByName": {
+                    "Time": 26,
+                    "Value #A": 3,
+                    "Value #B": 6,
+                    "Value #C": 7,
+                    "Value #D": 14,
+                    "Value #E": 10,
+                    "Value #F": 12,
+                    "Value #G": 17,
+                    "Value #H": 19,
+                    "Value #I": 8,
+                    "Value #J": 15,
+                    "Value #K": 22,
+                    "Value #L": 21,
+                    "Value #M": 16,
+                    "Value #N": 18,
+                    "Value #O": 20,
+                    "Value #P": 9,
+                    "Value #Q": 11,
+                    "Value #R": 13,
+                    "Value #S": 23,
+                    "Value #T": 2,
+                    "__name__": 4,
+                    "app_kubernetes_io_name": 27,
+                    "app_kubernetes_io_version": 28,
+                    "condition": 1,
+                    "instance": 29,
+                    "job": 30,
+                    "k8s_namespace": 31,
+                    "k8s_sname": 32,
+                    "node": 0,
+                    "origin_prometheus": 33,
+                    "resource": 24,
+                    "status": 5,
+                    "unit": 25
+                  },
+                  "renameByName": {
+                    "Value #A": "Pod",
+                    "Value #C": "CPU total ",
+                    "Value #D": " Total Memory ",
+                    "Value #E": "CPU max ",
+                    "Value #F": "CPU total ",
+                    "Value #G": " Memory Usage ",
+                    "Value #H": " Network bandwidth ",
+                    "Value #I": "CPU limit ( number )",
+                    "Value #J": " memory request ",
+                    "Value #K": " English version ",
+                    "Value #L": " container name ",
+                    "Value #M": " memory request %",
+                    "Value #N": " Memory Usage %",
+                    "Value #O": " Network bandwidth %",
+                    "Value #P": "CPU limit %",
+                    "Value #Q": "CPU max %",
+                    "Value #R": "CPU total %",
+                    "Value #S": " English version %",
+                    "Value #T": "Pod disk ",
+                    "condition": " include ",
+                    "node": " container "
+                  }
+                }
+              },
+              {
+                "id": "filterFieldsByName",
+                "options": {}
+              }
+            ],
+            "type": "table"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "fieldConfig": {
+              "defaults": {},
+              "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 10,
+              "w": 8,
+              "x": 0,
+              "y": 17
+            },
+            "hiddenSeries": false,
+            "id": 75,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+              "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.11",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "$$hashKey": "object:2068",
+                "alias": "/ usage .*/",
+                "color": "#C4162A"
+              }
+            ],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum (irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"}[2m]))by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\", node=~\"^$Node$\"})by (node)*100",
+                "format": "time_series",
+                "hide": false,
+                "instant": false,
+                "interval": "",
+                "legendFormat": "{{node}}",
+                "refId": "I"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$Node： container CPU receive ",
+            "tooltip": {
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
+            },
+            "transformations": [],
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "$$hashKey": "object:1711",
+                "format": "percent",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "$$hashKey": "object:1712",
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "fieldConfig": {
+              "defaults": {},
+              "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 10,
+              "w": 8,
+              "x": 8,
+              "y": 17
+            },
+            "hiddenSeries": false,
+            "id": 76,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sort": "current",
+              "sortDesc": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+              "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.11",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container!=\"\",node=~\"^$Node$\"})by (node) / sum(kube_node_status_allocatable{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\", node=~\"^$Node$\"})by (node)*100",
+                "format": "time_series",
+                "hide": false,
+                "instant": false,
+                "interval": "",
+                "legendFormat": "{{node}}",
+                "refId": "I"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$Node： Node Memory Information ",
+            "tooltip": {
+              "shared": true,
+              "sort": 2,
+              "value_type": "individual"
+            },
+            "transformations": [],
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "$$hashKey": "object:1711",
+                "format": "percent",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "$$hashKey": "object:1712",
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "${datasource}",
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fieldConfig": {
+              "defaults": {
+                "links": []
+              },
+              "overrides": []
+            },
+            "fill": 0,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+              "h": 10,
+              "w": 8,
+              "x": 16,
+              "y": 17
+            },
+            "height": "200px",
+            "hiddenSeries": false,
+            "id": 78,
+            "isNew": true,
+            "legend": {
+              "alignAsTable": true,
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+              "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.11",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum (irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\"}[2m]))by (node) *8",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": " update :{{node}}",
+                "metric": "network",
+                "refId": "A",
+                "step": 10
+              },
+              {
+                "exemplar": true,
+                "expr": "sum (irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",node=~\"^$Node$\"}[2m]))by (node) *8",
+                "instant": false,
+                "interval": "",
+                "intervalFactor": 1,
+                "legendFormat": " restart :{{node}}",
+                "metric": "network",
+                "refId": "B",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "$Node： Overall resource overview ",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 2,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "$$hashKey": "object:750",
+                "format": "binbps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "$$hashKey": "object:751",
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "collapsed": true,
+            "datasource": "${datasource}",
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 27
+            },
+            "id": 61,
+            "panels": [
+              {
+                "datasource": "${datasource}",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "custom": {
+                      "align": "center",
+                      "displayMode": "auto",
+                      "filterable": false
+                    },
+                    "displayName": "",
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "percentage",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "orange",
+                          "value": 70
+                        },
+                        {
+                          "color": "red",
+                          "value": 90
+                        }
+                      ]
+                    },
+                    "unit": "short"
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byRegexp",
+                        "options": ".*%.*"
+                      },
+                      "properties": [
+                        {
+                          "id": "unit",
+                          "value": "percent"
+                        },
+                        {
+                          "id": "custom.displayMode",
+                          "value": "gradient-gauge"
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byRegexp",
+                        "options": " Requests .*"
+                      },
+                      "properties": [
+                        {
+                          "id": "unit",
+                          "value": "bytes"
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " Number of cluster nodes "
+                      },
+                      "properties": [
+                        {
+                          "id": "unit",
+                          "value": "bytes"
+                        },
+                        {
+                          "id": "thresholds",
+                          "value": {
+                            "mode": "absolute",
+                            "steps": [
+                              {
+                                "color": "green",
+                                "value": null
+                              },
+                              {
+                                "color": "orange",
+                                "value": 10737418240
+                              },
+                              {
+                                "color": "red",
+                                "value": 16106127360
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "id": "custom.displayMode",
+                          "value": "color-background"
+                        },
+                        {
+                          "id": "custom.width",
+                          "value": 90
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byRegexp",
+                        "options": ".* total "
+                      },
+                      "properties": [
+                        {
+                          "id": "color",
+                          "value": {
+                            "fixedColor": "blue",
+                            "mode": "fixed"
+                          }
+                        },
+                        {
+                          "id": "custom.displayMode",
+                          "value": "color-background"
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " total CPU total "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 84
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " Total Disk Usage "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 77
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " Selected microservices (RSS) "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 119
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " Total memory limit "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 82
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " limit amount "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 69
+                        },
+                        {
+                          "id": "thresholds",
+                          "value": {
+                            "mode": "absolute",
+                            "steps": [
+                              {
+                                "color": "orange",
+                                "value": null
+                              },
+                              {
+                                "color": "green",
+                                "value": 2
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "id": "custom.displayMode",
+                          "value": "color-background"
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " Resource Details %(RSS)"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 112
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " password CPU%( overall 100%)"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 150
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " Node Network Overview "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 100
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " total CPU selected "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 82
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " Resource Details %(WSS)"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 130
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " Selected microservices (WSS)"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 120
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " average memory "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 79
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byRegexp",
+                        "options": " Node Network Overview $| Selected microservices \\(WSS\\)$| Selected microservices \\(RSS\\) $"
+                      },
+                      "properties": [
+                        {
+                          "id": "color",
+                          "value": {
+                            "fixedColor": "orange",
+                            "mode": "fixed"
+                          }
+                        },
+                        {
+                          "id": "custom.displayMode",
+                          "value": "color-text"
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " container number "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 149
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 24,
+                  "x": 0,
+                  "y": 2
+                },
+                "id": 57,
+                "options": {
+                  "showHeader": true,
+                  "sortBy": [
+                    {
+                      "desc": true,
+                      "displayName": " container number "
+                    }
+                  ]
+                },
+                "pluginVersion": "7.5.11",
+                "targets": [
+                  {
+                    "exemplar": true,
+                    "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}[2m])) by (container) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}/100000) by (container)) * 100",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}[2m])) by (container)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": " Node Network Overview ",
+                    "refId": "L"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "B"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "C"
+                  },
+                  {
+                    "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container) * 100",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "I"
+                  },
+                  {
+                    "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "D"
+                  },
+                  {
+                    "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container) * 100",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": " Resource Details %(RSS)",
+                    "refId": "H"
+                  },
+                  {
+                    "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": " Selected microservices (RSS) ",
+                    "refId": "K"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "E"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "F"
+                  },
+                  {
+                    "expr": "sum(container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "J"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "count(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by(container,namespace) - 0",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "G"
+                  }
+                ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": " usage ( container number ) namespace ",
+                "transformations": [
+                  {
+                    "id": "merge",
+                    "options": {}
+                  },
+                  {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 10": true,
+                        "Time 11": true,
+                        "Time 12": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Time 5": true,
+                        "Time 6": true,
+                        "Time 7": true,
+                        "Time 8": true,
+                        "Time 9": true
+                      },
+                      "indexByName": {
+                        "Time 1": 2,
+                        "Time 10": 20,
+                        "Time 11": 22,
+                        "Time 12": 24,
+                        "Time 2": 4,
+                        "Time 3": 6,
+                        "Time 4": 8,
+                        "Time 5": 10,
+                        "Time 6": 12,
+                        "Time 7": 14,
+                        "Time 8": 16,
+                        "Time 9": 18,
+                        "Value #A": 3,
+                        "Value #B": 7,
+                        "Value #C": 9,
+                        "Value #D": 13,
+                        "Value #E": 19,
+                        "Value #F": 21,
+                        "Value #G": 25,
+                        "Value #H": 15,
+                        "Value #I": 11,
+                        "Value #J": 23,
+                        "Value #K": 17,
+                        "Value #L": 5,
+                        "container": 1,
+                        "namespace": 0
+                      },
+                      "renameByName": {
+                        "Time 1": "",
+                        "Value #A": " password CPU%( overall 100%)",
+                        "Value #B": " total CPU selected ",
+                        "Value #C": " total CPU total ",
+                        "Value #D": " Selected microservices (WSS)",
+                        "Value #E": " Total memory limit ",
+                        "Value #F": " Total Disk Usage ",
+                        "Value #G": " limit amount ",
+                        "Value #H": " Resource Details %(RSS)",
+                        "Value #I": " Resource Details %(WSS)",
+                        "Value #J": " Number of cluster nodes ",
+                        "Value #K": " Selected microservices (RSS) ",
+                        "Value #L": " Node Network Overview ",
+                        "container": " container number ",
+                        "namespace": " average memory "
+                      }
+                    }
+                  },
+                  {
+                    "id": "filterFieldsByName",
+                    "options": {}
+                  }
+                ],
+                "type": "table"
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "${datasource}",
+                "decimals": 3,
+                "editable": true,
+                "error": false,
+                "fieldConfig": {
+                  "defaults": {
+                    "links": []
+                  },
+                  "overrides": []
+                },
+                "fill": 0,
+                "fillGradient": 0,
+                "grid": {},
+                "gridPos": {
+                  "h": 9,
+                  "w": 8,
+                  "x": 0,
+                  "y": 10
+                },
+                "height": "",
+                "hiddenSeries": false,
+                "id": 24,
+                "isNew": true,
+                "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": false,
+                  "hideZero": false,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "options": {
+                  "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "7.5.11",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "sum(rate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}[2m])) by (container) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}/100000) by (container)) * 100",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ container}}",
+                    "metric": "container_cpu",
+                    "refId": "A",
+                    "step": 10
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeRegions": [],
+                "timeShift": null,
+                "title": " usage ( container number ) password CPU Request Rate ( overall 100%)",
+                "tooltip": {
+                  "msResolution": true,
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "cumulative"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "$$hashKey": "object:5607",
+                    "format": "percent",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                  },
+                  {
+                    "$$hashKey": "object:5608",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                  }
+                ],
+                "yaxis": {
+                  "align": false,
+                  "alignLevel": null
+                }
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "${datasource}",
+                "decimals": 2,
+                "editable": true,
+                "error": false,
+                "fieldConfig": {
+                  "defaults": {
+                    "links": []
+                  },
+                  "overrides": []
+                },
+                "fill": 0,
+                "fillGradient": 0,
+                "grid": {},
+                "gridPos": {
+                  "h": 9,
+                  "w": 8,
+                  "x": 8,
+                  "y": 10
+                },
+                "hiddenSeries": false,
+                "id": 59,
+                "isNew": true,
+                "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": true,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+                },
+                "lines": true,
+                "linewidth": 2,
+                "links": [],
+                "nullPointMode": "null",
+                "options": {
+                  "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "7.5.11",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container) * 100",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "WSS：{{ container }}",
+                    "metric": "container_memory_usage:sort_desc",
+                    "refId": "A",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"}) by (container) * 100",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "RSS：{{ container }}",
+                    "metric": "container_memory_usage:sort_desc",
+                    "refId": "B",
+                    "step": 10
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeRegions": [],
+                "timeShift": null,
+                "title": " usage ( container number ) Microservice resource details ",
+                "tooltip": {
+                  "msResolution": false,
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "cumulative"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "$$hashKey": "object:5686",
+                    "format": "percent",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                  },
+                  {
+                    "$$hashKey": "object:5687",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                  }
+                ],
+                "yaxis": {
+                  "align": false,
+                  "alignLevel": null
+                }
+              },
+              {
+                "aliasColors": {
+                  " update :wholion-lbs": "purple",
+                  " restart :wholion-lbs": "green"
+                },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "${datasource}",
+                "decimals": 2,
+                "editable": true,
+                "error": false,
+                "fieldConfig": {
+                  "defaults": {
+                    "links": []
+                  },
+                  "overrides": []
+                },
+                "fill": 0,
+                "fillGradient": 0,
+                "grid": {},
+                "gridPos": {
+                  "h": 9,
+                  "w": 8,
+                  "x": 16,
+                  "y": 10
+                },
+                "hiddenSeries": false,
+                "id": 16,
+                "isNew": true,
+                "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "options": {
+                  "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "7.5.11",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "exemplar": true,
+                    "expr": "sum(sum(irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(container) *8",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": " update :{{ container }}",
+                    "metric": "network",
+                    "refId": "A",
+                    "step": 10
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum(sum(irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(container) *8",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": " restart :{{ container }}",
+                    "metric": "network",
+                    "refId": "B",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum (rate (container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)",
+                    "hide": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "-> {{ pod }}",
+                    "metric": "network",
+                    "refId": "C",
+                    "step": 10
+                  },
+                  {
+                    "expr": "- sum (rate (container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)",
+                    "hide": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "<- {{ pod }}",
+                    "metric": "network",
+                    "refId": "D",
+                    "step": 10
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeRegions": [],
+                "timeShift": null,
+                "title": " usage ( container number ) Container memory usage ( Memory Usage )",
+                "tooltip": {
+                  "msResolution": false,
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "cumulative"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "$$hashKey": "object:8106",
+                    "format": "binbps",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                  },
+                  {
+                    "$$hashKey": "object:8107",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                  }
+                ],
+                "yaxis": {
+                  "align": false,
+                  "alignLevel": null
+                }
+              }
+            ],
+            "title": " usage ( container number ) Memory Requirements ： Associated nodes :【$Container】",
+            "type": "row"
+          },
+          {
+            "collapsed": true,
+            "datasource": "${datasource}",
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 28
+            },
+            "id": 49,
+            "panels": [
+              {
+                "datasource": "${datasource}",
+                "fieldConfig": {
+                  "defaults": {
+                    "color": {
+                      "mode": "thresholds"
+                    },
+                    "custom": {
+                      "align": "center",
+                      "displayMode": "auto",
+                      "filterable": false
+                    },
+                    "displayName": "",
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "percentage",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "#EAB839",
+                          "value": 80
+                        },
+                        {
+                          "color": "red",
+                          "value": 90
+                        }
+                      ]
+                    },
+                    "unit": "short"
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "CPU%( overall 100%)"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 140
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " average memory "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 78
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "Pod core count "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 136
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " core usage "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 71
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "CPU selected "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 68
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "CPU total "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 65
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "WSS%"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 129
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "WSS"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 73
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "RSS%"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 132
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "RSS"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 68
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " resource statistics "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 69
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " Network bandwidth "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 71
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " send "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 67
+                        },
+                        {
+                          "id": "thresholds",
+                          "value": {
+                            "mode": "absolute",
+                            "steps": [
+                              {
+                                "color": "green",
+                                "value": null
+                              },
+                              {
+                                "color": "#EAB839",
+                                "value": 1
+                              },
+                              {
+                                "color": "red",
+                                "value": 3
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "id": "custom.displayMode",
+                          "value": "color-background"
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " demand "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 71
+                        },
+                        {
+                          "id": "unit",
+                          "value": "bytes"
+                        },
+                        {
+                          "id": "thresholds",
+                          "value": {
+                            "mode": "absolute",
+                            "steps": [
+                              {
+                                "color": "green",
+                                "value": null
+                              },
+                              {
+                                "color": "#EAB839",
+                                "value": 10737418240
+                              },
+                              {
+                                "color": "red",
+                                "value": 16106127360
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "id": "custom.displayMode",
+                          "value": "color-background"
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byRegexp",
+                        "options": ".*%.*"
+                      },
+                      "properties": [
+                        {
+                          "id": "unit",
+                          "value": "percent"
+                        },
+                        {
+                          "id": "custom.displayMode",
+                          "value": "gradient-gauge"
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byRegexp",
+                        "options": " config .*|WSS$|RSS$"
+                      },
+                      "properties": [
+                        {
+                          "id": "unit",
+                          "value": "bytes"
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byRegexp",
+                        "options": ".* total "
+                      },
+                      "properties": [
+                        {
+                          "id": "color",
+                          "value": {
+                            "fixedColor": "blue",
+                            "mode": "fixed"
+                          }
+                        },
+                        {
+                          "id": "custom.displayMode",
+                          "value": "color-background"
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " container "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 87
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byRegexp",
+                        "options": " core usage $|WSS$|RSS$"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.displayMode",
+                          "value": "color-text"
+                        },
+                        {
+                          "id": "color",
+                          "value": {
+                            "fixedColor": "orange",
+                            "mode": "fixed"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": " container number "
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 116
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "gridPos": {
+                  "h": 8,
+                  "w": 24,
+                  "x": 0,
+                  "y": 3
+                },
+                "id": 47,
+                "options": {
+                  "showHeader": true,
+                  "sortBy": []
+                },
+                "pluginVersion": "7.5.11",
+                "targets": [
+                  {
+                    "exemplar": true,
+                    "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (container, pod,node,namespace) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}/100000) by (container, pod,node,namespace)) * 100",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "A"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (container, pod,node,namespace)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "CPU disk usage ",
+                    "refId": "Q"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "B"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"cpu\", unit=\"core\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "C"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace) * 100",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "wss%",
+                    "refId": "I"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "wss",
+                    "refId": "D"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace) * 100",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "rss%",
+                    "refId": "L"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod,node,namespace)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "rss",
+                    "refId": "K"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum(kube_pod_container_resource_requests{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "E"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum(kube_pod_container_resource_limits{origin_prometheus=~\"$origin_prometheus\",resource=\"memory\", unit=\"byte\",pod=~\"$Pod\",container =~\"$Container\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "F"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum(container_fs_usage_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container,pod,node,namespace)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "J"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "kube_pod_container_status_restarts_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",namespace=~\"$NameSpace\"} * on (pod) group_left(node) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}",
+                    "format": "table",
+                    "hide": false,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "H"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "cass_jvm_heap{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}",
+                    "format": "table",
+                    "hide": true,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "M"
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "cass_jvm_heap_max{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}",
+                    "format": "table",
+                    "hide": true,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "N"
+                  },
+                  {
+                    "expr": "cass_jvm_noheap{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}",
+                    "format": "table",
+                    "hide": true,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "O"
+                  },
+                  {
+                    "expr": "cass_jvm_noheap_max{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}",
+                    "format": "table",
+                    "hide": true,
+                    "instant": true,
+                    "interval": "",
+                    "legendFormat": "",
+                    "refId": "P"
+                  }
+                ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "$Node：Pod Memory Limit ( Memory Usage )",
+                "transformations": [
+                  {
+                    "id": "merge",
+                    "options": {}
+                  },
+                  {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 10": true,
+                        "Time 11": true,
+                        "Time 12": true,
+                        "Time 13": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Time 5": true,
+                        "Time 6": true,
+                        "Time 7": true,
+                        "Time 8": true,
+                        "Time 9": true,
+                        "Value #G": true,
+                        "__name__": true,
+                        "app_kubernetes_io_name": true,
+                        "app_kubernetes_io_name 1": true,
+                        "app_kubernetes_io_name 2": true,
+                        "app_kubernetes_io_version": true,
+                        "app_kubernetes_io_version 1": true,
+                        "app_kubernetes_io_version 2": true,
+                        "container 1": true,
+                        "container 10": true,
+                        "container 11": true,
+                        "container 12": true,
+                        "container 2": true,
+                        "container 3": true,
+                        "container 4": true,
+                        "container 5": true,
+                        "container 6": true,
+                        "container 7": true,
+                        "container 8": true,
+                        "container 9": true,
+                        "created_by_kind": true,
+                        "created_by_name": true,
+                        "host_ip": true,
+                        "instance": true,
+                        "instance 1": true,
+                        "instance 2": true,
+                        "job": true,
+                        "job 1": true,
+                        "job 2": true,
+                        "k8s_namespace": true,
+                        "k8s_namespace 1": true,
+                        "k8s_namespace 2": true,
+                        "k8s_sname": true,
+                        "k8s_sname 1": true,
+                        "k8s_sname 2": true,
+                        "namespace": false,
+                        "namespace 1": true,
+                        "namespace 10": true,
+                        "namespace 11": true,
+                        "namespace 12": false,
+                        "namespace 2": true,
+                        "namespace 3": true,
+                        "namespace 4": true,
+                        "namespace 5": true,
+                        "namespace 6": true,
+                        "namespace 7": true,
+                        "namespace 8": true,
+                        "namespace 9": true,
+                        "node 1": true,
+                        "node 10": true,
+                        "node 11": false,
+                        "node 12": true,
+                        "node 2": true,
+                        "node 3": true,
+                        "node 4": true,
+                        "node 5": true,
+                        "node 6": true,
+                        "node 7": true,
+                        "node 8": true,
+                        "node 9": true,
+                        "origin_prometheus": true,
+                        "origin_prometheus 1": true,
+                        "origin_prometheus 2": true,
+                        "phase": true,
+                        "pod_ip": true,
+                        "priority_class": true,
+                        "uid": true
+                      },
+                      "indexByName": {
+                        "Time": 23,
+                        "Value #A": 4,
+                        "Value #B": 6,
+                        "Value #C": 7,
+                        "Value #D": 9,
+                        "Value #E": 12,
+                        "Value #F": 13,
+                        "Value #H": 22,
+                        "Value #I": 8,
+                        "Value #J": 14,
+                        "Value #K": 11,
+                        "Value #L": 10,
+                        "Value #Q": 5,
+                        "app_kubernetes_io_name": 15,
+                        "app_kubernetes_io_version": 16,
+                        "container": 2,
+                        "instance": 17,
+                        "job": 18,
+                        "k8s_namespace": 19,
+                        "k8s_sname": 20,
+                        "namespace": 1,
+                        "node": 0,
+                        "origin_prometheus": 21,
+                        "pod": 3
+                      },
+                      "renameByName": {
+                        "Value #A": "CPU%( overall 100%)",
+                        "Value #B": "CPU selected ",
+                        "Value #C": "CPU total ",
+                        "Value #D": "WSS",
+                        "Value #E": " resource statistics ",
+                        "Value #F": " Network bandwidth ",
+                        "Value #H": " send ",
+                        "Value #I": "WSS%",
+                        "Value #J": " demand ",
+                        "Value #K": "RSS",
+                        "Value #L": "RSS%",
+                        "Value #Q": " core usage ",
+                        "container": " container number ",
+                        "namespace": " average memory ",
+                        "namespace 1": "",
+                        "namespace 12": " average memory ",
+                        "node": " container ",
+                        "node 1": "",
+                        "node 11": " container ",
+                        "pod": "Pod core count ",
+                        "priority_class": ""
+                      }
+                    }
+                  },
+                  {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          " container ",
+                          " average memory ",
+                          "Pod core count ",
+                          "CPU%( overall 100%)",
+                          " core usage ",
+                          "CPU selected ",
+                          "CPU total ",
+                          "WSS%",
+                          "WSS",
+                          "RSS%",
+                          "RSS",
+                          " resource statistics ",
+                          " Network bandwidth ",
+                          " demand ",
+                          " send ",
+                          " container number "
+                        ]
+                      }
+                    }
+                  }
+                ],
+                "type": "table"
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "${datasource}",
+                "decimals": 2,
+                "editable": true,
+                "error": false,
+                "fieldConfig": {
+                  "defaults": {
+                    "links": []
+                  },
+                  "overrides": []
+                },
+                "fill": 0,
+                "fillGradient": 0,
+                "grid": {},
+                "gridPos": {
+                  "h": 9,
+                  "w": 8,
+                  "x": 0,
+                  "y": 11
+                },
+                "height": "",
+                "hiddenSeries": false,
+                "id": 58,
+                "isNew": true,
+                "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "hideEmpty": false,
+                  "hideZero": false,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "options": {
+                  "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "7.5.11",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "exemplar": true,
+                    "expr": "sum(irate(container_cpu_usage_seconds_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}[2m])) by (container, pod) / (sum(container_spec_cpu_quota{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}/100000) by (container, pod)) * 100",
+                    "hide": false,
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "{{ pod }}",
+                    "metric": "container_cpu",
+                    "refId": "A",
+                    "step": 10
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeRegions": [],
+                "timeShift": null,
+                "title": "Pod upper limit CPU Request Rate ( overall 100% Memory Usage )",
+                "tooltip": {
+                  "msResolution": true,
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "cumulative"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "$$hashKey": "object:5607",
+                    "format": "percent",
+                    "label": "",
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                  },
+                  {
+                    "$$hashKey": "object:5608",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                  }
+                ],
+                "yaxis": {
+                  "align": false,
+                  "alignLevel": null
+                }
+              },
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "${datasource}",
+                "decimals": 2,
+                "editable": true,
+                "error": false,
+                "fieldConfig": {
+                  "defaults": {
+                    "links": []
+                  },
+                  "overrides": []
+                },
+                "fill": 0,
+                "fillGradient": 0,
+                "grid": {},
+                "gridPos": {
+                  "h": 9,
+                  "w": 8,
+                  "x": 8,
+                  "y": 11
+                },
+                "hiddenSeries": false,
+                "id": 27,
+                "isNew": true,
+                "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": false,
+                  "total": false,
+                  "values": true
+                },
+                "lines": true,
+                "linewidth": 2,
+                "links": [],
+                "nullPointMode": "null",
+                "options": {
+                  "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "7.5.11",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "exemplar": true,
+                    "expr": "sum (container_memory_working_set_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod) * 100",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "WSS：{{ pod }}",
+                    "metric": "container_memory_usage:sort_desc",
+                    "refId": "A",
+                    "step": 10
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum (container_memory_rss{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod)/ sum(container_spec_memory_limit_bytes{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",container =~\"$Container\",container !=\"\",container!=\"POD\",node=~\"^$Node$\",namespace=~\"$NameSpace\"}) by (container, pod) * 100",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "RSS：{{ pod }}",
+                    "metric": "container_memory_usage:sort_desc",
+                    "refId": "B",
+                    "step": 10
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "(cass_jvm_heap{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}) / (cass_jvm_heap_max{service=~\"$Container\"} * on (pod_ip) group_right(service) kube_pod_info{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",namespace=~\"$NameSpace\"}) * 100",
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "Heap：{{ pod }}",
+                    "metric": "container_memory_usage:sort_desc",
+                    "refId": "C",
+                    "step": 10
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeRegions": [],
+                "timeShift": null,
+                "title": "Pod View more dashboards ( Memory Usage )",
+                "tooltip": {
+                  "msResolution": false,
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "cumulative"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "$$hashKey": "object:5686",
+                    "format": "percent",
+                    "label": null,
+                    "logBase": 1,
+                    "max": "100",
+                    "min": null,
+                    "show": true
+                  },
+                  {
+                    "$$hashKey": "object:5687",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                  }
+                ],
+                "yaxis": {
+                  "align": false,
+                  "alignLevel": null
+                }
+              },
+              {
+                "aliasColors": {
+                  " update :wholion-lbs": "purple",
+                  " restart :wholion-lbs": "green"
+                },
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "${datasource}",
+                "decimals": 2,
+                "editable": true,
+                "error": false,
+                "fieldConfig": {
+                  "defaults": {
+                    "links": []
+                  },
+                  "overrides": []
+                },
+                "fill": 0,
+                "fillGradient": 0,
+                "grid": {},
+                "gridPos": {
+                  "h": 9,
+                  "w": 8,
+                  "x": 16,
+                  "y": 11
+                },
+                "hiddenSeries": false,
+                "id": 77,
+                "isNew": true,
+                "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null",
+                "options": {
+                  "alertThreshold": true
+                },
+                "percentage": false,
+                "pluginVersion": "7.5.11",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "exemplar": true,
+                    "expr": "sum(sum(irate(container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(pod) *8",
+                    "hide": false,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": " update :{{ pod}}",
+                    "metric": "network",
+                    "refId": "A",
+                    "step": 10
+                  },
+                  {
+                    "exemplar": true,
+                    "expr": "sum(sum(irate(container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)* on(pod) group_right kube_pod_container_info) by(pod) *8",
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": " restart :{{ pod}}",
+                    "metric": "network",
+                    "refId": "B",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum (rate (container_network_receive_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)",
+                    "hide": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "-> {{ pod }}",
+                    "metric": "network",
+                    "refId": "C",
+                    "step": 10
+                  },
+                  {
+                    "expr": "- sum (rate (container_network_transmit_bytes_total{origin_prometheus=~\"$origin_prometheus\",pod=~\"$Pod\",image!=\"\",name=~\"^k8s_.*\",node=~\"^$Node$\",namespace=~\"$NameSpace\",pod=~\".*$Container.*\"}[2m])) by (pod)",
+                    "hide": true,
+                    "interval": "",
+                    "intervalFactor": 1,
+                    "legendFormat": "<- {{ pod }}",
+                    "metric": "network",
+                    "refId": "D",
+                    "step": 10
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeRegions": [],
+                "timeShift": null,
+                "title": "Pod Container memory usage ( Memory Usage )",
+                "tooltip": {
+                  "msResolution": false,
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "cumulative"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "$$hashKey": "object:8106",
+                    "format": "binbps",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                  },
+                  {
+                    "$$hashKey": "object:8107",
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                  }
+                ],
+                "yaxis": {
+                  "align": false,
+                  "alignLevel": null
+                }
+              }
+            ],
+            "title": "Pod Memory Requirements ： space Pod:【$Pod】",
+            "type": "row"
+          }
+        ],
+        "refresh": "",
+        "schemaVersion": 27,
+        "style": "dark",
+        "tags": [
+          "StarsL.cn",
+          "Prometheus",
+          "Kubernetes"
+        ],
+        "templating": {
+          "list": [
+            {
+              "allValue": "",
+              "current": {},
+              "datasource": "${datasource}",
+              "definition": "label_values(origin_prometheus)",
+              "description": null,
+              "error": null,
+              "hide": 0,
+              "includeAll": false,
+              "label": "K8S",
+              "multi": false,
+              "name": "origin_prometheus",
+              "options": [],
+              "query": {
+                "query": "label_values(origin_prometheus)",
+                "refId": "Prometheus-origin_prometheus-Variable-Query"
+              },
+              "refresh": 2,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 5,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            },
+            {
+              "allValue": "",
+              "current": {},
+              "datasource": "${datasource}",
+              "definition": "label_values(kube_node_info{origin_prometheus=~\"$origin_prometheus\"},node)",
+              "description": null,
+              "error": null,
+              "hide": 0,
+              "includeAll": true,
+              "label": " container ",
+              "multi": false,
+              "name": "Node",
+              "options": [],
+              "query": {
+                "query": "label_values(kube_node_info{origin_prometheus=~\"$origin_prometheus\"},node)",
+                "refId": "Prometheus-Node-Variable-Query"
+              },
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 5,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            },
+            {
+              "allValue": "",
+              "current": {},
+              "datasource": "${datasource}",
+              "definition": "label_values(kube_namespace_labels{origin_prometheus=~\"$origin_prometheus\"},namespace)",
+              "description": null,
+              "error": null,
+              "hide": 0,
+              "includeAll": true,
+              "label": " average memory ",
+              "multi": false,
+              "name": "NameSpace",
+              "options": [],
+              "query": {
+                "query": "label_values(kube_namespace_labels{origin_prometheus=~\"$origin_prometheus\"},namespace)",
+                "refId": "Prometheus-NameSpace-Variable-Query"
+              },
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 5,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            },
+            {
+              "allValue": ".*",
+              "current": {},
+              "datasource": "${datasource}",
+              "definition": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\"},container)",
+              "description": null,
+              "error": null,
+              "hide": 0,
+              "includeAll": true,
+              "label": " usage ( container number )",
+              "multi": false,
+              "name": "Container",
+              "options": [],
+              "query": {
+                "query": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\"},container)",
+                "refId": "Prometheus-Container-Variable-Query"
+              },
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 5,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            },
+            {
+              "allValue": ".*",
+              "current": {},
+              "datasource": "${datasource}",
+              "definition": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\",container=~\"$Container\"},pod)",
+              "description": null,
+              "error": null,
+              "hide": 0,
+              "includeAll": true,
+              "label": "Pod",
+              "multi": false,
+              "name": "Pod",
+              "options": [],
+              "query": {
+                "query": "label_values(kube_pod_container_info{origin_prometheus=~\"$origin_prometheus\",namespace=~\"$NameSpace\",container=~\"$Container\"},pod)",
+                "refId": "Prometheus-Pod-Variable-Query"
+              },
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 5,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            }
+          ]
+        },
+        "time": {
+          "from": "now-30m",
+          "to": "now"
+        },
+        "timepicker": {
+          "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+          ],
+          "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+          ]
+        },
+        "timezone": "browser",
+        "title": "1 K8S for Prometheus Dashboard 20250125 EN",
+        "uid": "PwMJtdvnz",
+        "version": 10
+      }  kind: ConfigMap
+  metadata:
+    labels:
+      app.kubernetes.io/component: grafana
+      app.kubernetes.io/name: grafana
+      app.kubernetes.io/part-of: kube-prometheus
+      app.kubernetes.io/version: 11.2.0
+    name: grafana-dashboard-k8s-overview
+    namespace: monitoring
+
+
 kind: ConfigMapList

--- a/k8s/kube-prometheus/manifests/grafana-dashboardSources.yaml
+++ b/k8s/kube-prometheus/manifests/grafana-dashboardSources.yaml
@@ -13,6 +13,26 @@ data:
                 },
                 "orgId": 1,
                 "type": "file"
+            },
+            {
+                "folder": "K8s Dashboards",
+                "folderUid": "k8s-dashboards",
+                "name": "k8s-dashboards",
+                "options": {
+                    "path": "/grafana-dashboard-definitions/k8s-dashboards"
+                },
+                "orgId": 1,
+                "type": "file"
+            },
+            {
+                "folder": "Migration Dashboards",
+                "folderUid": "migration-dashboards",
+                "name": "migration-dashboards",
+                "options": {
+                    "path": "/grafana-dashboard-definitions/migration-dashboards"
+                },
+                "orgId": 1,
+                "type": "file"
             }
         ]
     }

--- a/k8s/kube-prometheus/manifests/grafana-deployment.yaml
+++ b/k8s/kube-prometheus/manifests/grafana-deployment.yaml
@@ -149,6 +149,9 @@ spec:
         - mountPath: /grafana-dashboard-definitions/0/workload-total
           name: grafana-dashboard-workload-total
           readOnly: false
+        - mountPath: /grafana-dashboard-definitions/0/k8s-overview
+          name: grafana-dashboard-k8s-overview
+          readOnly: false
         - mountPath: /etc/grafana
           name: grafana-config
           readOnly: false
@@ -253,6 +256,9 @@ spec:
       - configMap:
           name: grafana-dashboard-workload-total
         name: grafana-dashboard-workload-total
+      - configMap:
+          name: grafana-dashboard-k8s-overview
+        name: grafana-dashboard-k8s-overview
       - name: grafana-config
         secret:
           secretName: grafana-config

--- a/k8s/kube-prometheus/manifests/grafana-deployment.yaml
+++ b/k8s/kube-prometheus/manifests/grafana-deployment.yaml
@@ -65,10 +65,13 @@ spec:
         - mountPath: /etc/grafana/provisioning/dashboards
           name: grafana-dashboards
           readOnly: false
+        - mountPath: /etc/grafana/provisioning/folders
+          name: grafana-folders
+          readOnly: false
         - mountPath: /tmp
           name: tmp-plugins
           readOnly: false
-        - mountPath: /grafana-dashboard-definitions/0/migration-overview
+        - mountPath: /grafana-dashboard-definitions/migration-dashboards/migration-overview
           name: grafana-dashboard-migration-overview
           readOnly: false
         - mountPath: /grafana-dashboard-definitions/0/alertmanager-overview
@@ -149,7 +152,7 @@ spec:
         - mountPath: /grafana-dashboard-definitions/0/workload-total
           name: grafana-dashboard-workload-total
           readOnly: false
-        - mountPath: /grafana-dashboard-definitions/0/k8s-overview
+        - mountPath: /grafana-dashboard-definitions/k8s-dashboards/k8s-overview
           name: grafana-dashboard-k8s-overview
           readOnly: false
         - mountPath: /etc/grafana
@@ -172,6 +175,9 @@ spec:
       - configMap:
           name: grafana-dashboards
         name: grafana-dashboards
+      - configMap:
+          name: grafana-folders
+        name: grafana-folders
       - emptyDir:
           medium: Memory
         name: tmp-plugins

--- a/k8s/kube-prometheus/manifests/grafana-folders.yaml
+++ b/k8s/kube-prometheus/manifests/grafana-folders.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: grafana
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 11.2.0
+  name: grafana-folders
+  namespace: monitoring
+data:
+  folders.yaml: |-
+    apiVersion: 1
+    
+    folders:
+      - name: K8s Dashboards
+        uid: k8s-dashboards
+        title: K8s Dashboards
+        
+      - name: Migration Dashboards
+        uid: migration-dashboards
+        title: Migration Dashboards


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #713 
fixed #103 

## Special notes for your reviewer


## Testing done
<img width="1597" height="433" alt="Screenshot 2025-07-15 at 2 42 25 PM" src="https://github.com/user-attachments/assets/1d9e9294-0a8c-4df4-a34f-47465fb35302" />
<img width="1879" height="940" alt="Screenshot 2025-07-15 at 2 42 03 PM" src="https://github.com/user-attachments/assets/41096334-0f26-48f7-9612-88670f24d470" />

_please add testing details (logs, screenshots, etc.)_
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces a comprehensive Grafana dashboard for Kubernetes monitoring, featuring multiple panels for CPU, memory, network, and pod metrics. The dashboard enhances observability with various visualization settings including graphs, bar gauges, and tables. It addresses issue #713 and improves overall cluster performance monitoring capabilities.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 5
-->
</div>