### PR TITLE
fix scaling vjb link in getting started

### DIFF
--- a/docs/src/content/docs/introduction/getting_started.mdx
+++ b/docs/src/content/docs/introduction/getting_started.mdx
@@ -51,5 +51,5 @@ VMware VDDK library is required for vJailbreak to interact with the VMware envir
 - Migrate your VMs.
 
 ### Scaling vJailbreak
-<ReadMore>Read more about [scaling vJailbreak](../../guides/scaling/).</ReadMore>
+<ReadMore>Read more about [scaling vJailbreak](../../guides/How-to/scaling/).</ReadMore>
 


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes an incorrect documentation link in the Getting Started guide for scaling vJailbreak. The URL path was updated to correctly point to the new guide location, improving navigation and ensuring users can access the proper scaling information.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>