### PR TITLE
v2v-helper: log time taken by disk copy and conversion

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -275,11 +275,15 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 		// If its the first copy, copy the entire disk
 		if incrementalCopyCount == 0 {
 			for idx := range vminfo.VMDisks {
+				startTime := time.Now()
+				migobj.logMessage(fmt.Sprintf("Starting full disk copy of disk %d ", idx))
+
 				err = nbdops[idx].CopyDisk(ctx, vminfo.VMDisks[idx].Path, idx)
 				if err != nil {
 					return vminfo, fmt.Errorf("failed to copy disk: %s", err)
 				}
-				migobj.logMessage(fmt.Sprintf("Disk %d copied successfully: %s", idx, vminfo.VMDisks[idx].Path))
+				duration := time.Since(startTime)
+				migobj.logMessage(fmt.Sprintf("Disk %d (%s) copied successfully in %s, copying changed blocks now", idx, vminfo.VMDisks[idx].Path, duration))
 			}
 		} else {
 			migration_snapshot, err := vmops.GetSnapshot(constants.MigrationSnapshotName)
@@ -318,8 +322,15 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 					done = false
 					changedBlockCopySuccess := true
 					migobj.logMessage("Copying changed blocks")
+					// incremental block copy
+
+					startTime := time.Now()
+					migobj.logMessage(fmt.Sprintf("Starting incremental block copy for disk %d at %s", idx, startTime))
 
 					err = nbdops[idx].CopyChangedBlocks(ctx, changedAreas, vminfo.VMDisks[idx].Path)
+
+					duration := time.Since(startTime)
+
 					if err != nil {
 						changedBlockCopySuccess = false
 					}
@@ -330,10 +341,11 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 					}
 					if !changedBlockCopySuccess {
 						migobj.logMessage(fmt.Sprintf("Failed to copy changed blocks: %s", err))
-						migobj.logMessage(fmt.Sprintf("Since full copy has completed, Retrying copy of changed block	s for disk: %d", idx))
+						migobj.logMessage(fmt.Sprintf("Since full copy has completed, Retrying copy of changed blocks for disk: %d", idx))
 					}
-					migobj.logMessage("Finished copying changed blocks")
-					migobj.logMessage(fmt.Sprintf("Syncing Changed blocks [%d/20]", incrementalCopyCount))
+
+					migobj.logMessage(fmt.Sprintf("Finished copying and syncing changed blocks for disk %d in %s [Progress: %d/20]", idx, duration, incrementalCopyCount))
+
 				}
 			}
 			if final {
@@ -469,7 +481,7 @@ func (migobj *Migrate) ConvertVolumes(ctx context.Context, vminfo vm.VMInfo) err
 			}
 			osRelease, err = virtv2v.RunCommandInGuestAllVolumes(vminfo.VMDisks, "cat", false, "/etc/os-release")
 			if err != nil {
-				return fmt.Errorf("failed to get os release: %s: %s\n", err, strings.TrimSpace(osRelease))
+				return fmt.Errorf("failed to get os release: %s: %s", err, strings.TrimSpace(osRelease))
 			}
 		}
 		osDetected := strings.ToLower(strings.TrimSpace(osRelease))
@@ -773,7 +785,7 @@ func (migobj *Migrate) pingVM(ips []string) error {
 		if pinger.Statistics().PacketLoss == 0 {
 			migobj.logMessage("Ping succeeded")
 		} else {
-			return fmt.Errorf("Ping failed")
+			return fmt.Errorf("ping failed")
 		}
 	}
 	return nil
@@ -802,7 +814,7 @@ func (migobj *Migrate) checkHTTPGet(ips []string, port string) error {
 		}
 
 		// Both HTTP and HTTPS failed
-		return fmt.Errorf("Both HTTP and HTTPS failed for %s:%s", ip, port)
+		return fmt.Errorf("both HTTP and HTTPS failed for %s:%s", ip, port)
 	}
 
 	return nil

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/platform9/vjailbreak/v2v-helper/pkg/constants"
@@ -184,6 +185,7 @@ func ConvertDisk(ctx context.Context, xmlFile, path, ostype, virtiowindriver str
 		args = append(args, "-i", "libvirtxml", xmlFile, "--root", path)
 	}
 
+	start := time.Now()
 	// Step 5: Run virt-v2v-in-place
 	cmd := exec.CommandContext(ctx, "virt-v2v-in-place", args...)
 	log.Printf("Executing %s", cmd.String())
@@ -191,9 +193,12 @@ func ConvertDisk(ctx context.Context, xmlFile, path, ostype, virtiowindriver str
 	cmd.Stderr = os.Stderr
 
 	err := cmd.Run()
+	duration := time.Since(start)
+
 	if err != nil {
 		return fmt.Errorf("failed to run virt-v2v-in-place: %s", err)
 	}
+	log.Printf("virt-v2v-in-place conversion took: %s", duration)
 	return nil
 }
 


### PR DESCRIPTION
Log time taken for operations like full copy, incremental copy, and total conversion using time.Now(). Helps benchmark and analyze migration performance over time.

fixes: https://github.com/platform9/vjailbreak/issues/513

Testing done

-  Performed a live migration of a VM.
- Verified that the VM was successfully migrated.
- Checked v2v-helper logs to confirm expected log messages were printed. Confirmed durations were logged for full copy, each incremental copy, and total conversion of a disk.

<img width="2832" height="441" alt="image" src="https://github.com/user-attachments/assets/c206ccfe-7cce-4bd4-862a-f28cddf9df93" /> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances migration processes by adding detailed time tracking for disk and block copy operations. It implements duration logging for key migration steps in migrate.go and performance measurement during virt-v2v conversion in virtv2vops.go. These changes improve error reporting and diagnostics, enabling better benchmarking and troubleshooting during VM migrations.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>