### PR TITLE
unblock vcenter with no clusters

### DIFF
--- a/k8s/migration/internal/controller/esximigration_controller.go
+++ b/k8s/migration/internal/controller/esximigration_controller.go
@@ -218,12 +218,17 @@ func (r *ESXIMigrationReconciler) handleESXiCordoned(ctx context.Context, scope 
 func (r *ESXIMigrationReconciler) handleESXiWaitingForPCDHost(ctx context.Context, scope *scope.ESXIMigrationScope) (ctrl.Result, error) {
 	log := scope.Logger
 	log.Info("ESXi is waiting for PCD host", "esxiName", scope.ESXIMigration.Spec.ESXiName)
-	destOpenstackCreds, err := utils.GetDestinationOpenstackCredsFromRollingMigrationPlan(ctx, r.Client, scope.RollingMigrationPlan)
+	destOpenstackCreds, err := utils.GetOpenstackCredsFromRollingMigrationPlan(ctx, r.Client, scope.RollingMigrationPlan)
 	if err != nil {
 		log.Error(err, "Failed to get destination openstack credentials", "openstackCreds", destOpenstackCreds)
 		return ctrl.Result{}, errors.Wrap(err, "failed to get destination openstack credentials")
 	}
-	vmwareHost, err := utils.GetVMwareHostFromESXiName(ctx, r.Client, scope.ESXIMigration.Spec.ESXiName)
+	sourceVMwareCreds, err := utils.GetVMwareCredsFromRollingMigrationPlan(ctx, r.Client, scope.RollingMigrationPlan)
+	if err != nil {
+		log.Error(err, "Failed to get source vmware credentials", "vmwareCreds", sourceVMwareCreds)
+		return ctrl.Result{}, errors.Wrap(err, "failed to get source vmware credentials")
+	}
+	vmwareHost, err := utils.GetVMwareHostFromESXiName(ctx, r.Client, scope.ESXIMigration.Spec.ESXiName, sourceVMwareCreds.Name)
 	if err != nil {
 		log.Error(err, "Failed to get VMware host", "esxiName", scope.ESXIMigration.Spec.ESXiName)
 		return ctrl.Result{}, errors.Wrap(err, "failed to get VMware host")
@@ -252,12 +257,17 @@ func (r *ESXIMigrationReconciler) handleESXiConfiguringPCDHost(ctx context.Conte
 	log.Info("ESXi is configuring PCD host", "esxiName", scope.ESXIMigration.Spec.ESXiName)
 	var pcdClusterName string
 
-	destOpenstackCreds, err := utils.GetDestinationOpenstackCredsFromRollingMigrationPlan(ctx, r.Client, scope.RollingMigrationPlan)
+	destOpenstackCreds, err := utils.GetOpenstackCredsFromRollingMigrationPlan(ctx, r.Client, scope.RollingMigrationPlan)
 	if err != nil {
 		log.Error(err, "Failed to get destination openstack credentials", "openstackCreds", destOpenstackCreds)
 		return ctrl.Result{}, errors.Wrap(err, "failed to get destination openstack credentials")
 	}
-	vmwareHost, err := utils.GetVMwareHostFromESXiName(ctx, r.Client, scope.ESXIMigration.Spec.ESXiName)
+	sourceVMwareCreds, err := utils.GetVMwareCredsFromRollingMigrationPlan(ctx, r.Client, scope.RollingMigrationPlan)
+	if err != nil {
+		log.Error(err, "Failed to get source vmware credentials", "vmwareCreds", sourceVMwareCreds)
+		return ctrl.Result{}, errors.Wrap(err, "failed to get source vmware credentials")
+	}
+	vmwareHost, err := utils.GetVMwareHostFromESXiName(ctx, r.Client, scope.ESXIMigration.Spec.ESXiName, sourceVMwareCreds.Name)
 	if err != nil {
 		log.Error(err, "Failed to get VMware host", "esxiName", scope.ESXIMigration.Spec.ESXiName)
 		return ctrl.Result{}, errors.Wrap(err, "failed to get VMware host")

--- a/k8s/migration/internal/controller/migration_controller.go
+++ b/k8s/migration/internal/controller/migration_controller.go
@@ -226,14 +226,18 @@ loop:
 // Extracted function to handle successful migration updates
 func (r *MigrationReconciler) markMigrationSuccessful(ctx context.Context, scope *scope.MigrationScope) error {
 	scope.Migration.Status.Phase = vjailbreakv1alpha1.VMMigrationPhaseSucceeded
-	name, err := utils.GetVMwareMachineNameForVMName(scope.Migration.Spec.VMName)
+	vmwareCredsName, err := utils.GetVMwareCredsNameFromMigration(ctx, r.Client, scope.Migration)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get vmware credentials name")
+	}
+	name, err := utils.GetK8sCompatibleVMWareObjectName(scope.Migration.Spec.VMName, vmwareCredsName)
+	if err != nil {
+		return errors.Wrap(err, "failed to get vmware machine name")
 	}
 
 	vmwvm := &vjailbreakv1alpha1.VMwareMachine{}
 	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: scope.Migration.Namespace}, vmwvm); err != nil {
-		return err
+		return errors.Wrap(err, "failed to get vmware machine")
 	}
 
 	vmwvm.Status.Migrated = true
@@ -275,7 +279,11 @@ func (r *MigrationReconciler) GetEventsSorted(ctx context.Context, scope *scope.
 // GetPod retrieves the pod associated with a migration
 func (r *MigrationReconciler) GetPod(ctx context.Context, scope *scope.MigrationScope) (*corev1.Pod, error) {
 	migration := scope.Migration
-	vmname, err := utils.GetVMwareMachineNameForVMName(migration.Spec.VMName)
+	vmwareCredsName, err := utils.GetVMwareCredsNameFromMigration(ctx, r.Client, scope.Migration)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get vmware credentials name")
+	}
+	vmname, err := utils.GetK8sCompatibleVMWareObjectName(migration.Spec.VMName, vmwareCredsName)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get vm name")
 	}

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -455,7 +455,11 @@ func (r *MigrationPlanReconciler) CreateMigration(ctx context.Context,
 	ctxlog := r.ctxlog.WithValues("vm", vm)
 	ctxlog.Info("Creating Migration for VM")
 
-	vmk8sname, err := utils.GetVMwareMachineNameForVMName(vm)
+	vmwarecreds, err := utils.GetVMwareCredsNameFromMigrationPlan(ctx, r.Client, migrationplan)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get vmware credentials")
+	}
+	vmk8sname, err := utils.GetK8sCompatibleVMWareObjectName(vm, vmwarecreds)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get vm name")
 	}
@@ -498,11 +502,15 @@ func (r *MigrationPlanReconciler) CreateJob(ctx context.Context,
 	firstbootconfigMapName string,
 	vmwareSecretRef string,
 	openstackSecretRef string) error {
-	vmk8sname, err := utils.GetVMwareMachineNameForVMName(vm)
+	vmwarecreds, err := utils.GetVMwareCredsNameFromMigrationPlan(ctx, r.Client, migrationplan)
+	if err != nil {
+		return errors.Wrap(err, "failed to get vmware credentials")
+	}
+	vmk8sname, err := utils.GetK8sCompatibleVMWareObjectName(vm, vmwarecreds)
 	if err != nil {
 		return errors.Wrap(err, "failed to get vm name")
 	}
-	jobName, err := utils.GetJobNameForVMName(vmk8sname)
+	jobName, err := utils.GetJobNameForVMName(vmk8sname, vmwarecreds)
 	if err != nil {
 		return errors.Wrap(err, "failed to get job name")
 	}
@@ -691,7 +699,11 @@ func (r *MigrationPlanReconciler) CreateJob(ctx context.Context,
 // CreateFirstbootConfigMap creates a firstboot config map for migration
 func (r *MigrationPlanReconciler) CreateFirstbootConfigMap(ctx context.Context,
 	migrationplan *vjailbreakv1alpha1.MigrationPlan, vm string) (*corev1.ConfigMap, error) {
-	vmname, err := utils.GetVMwareMachineNameForVMName(vm)
+	vmwarecreds, err := utils.GetVMwareCredsNameFromMigrationPlan(ctx, r.Client, migrationplan)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get vmware credentials")
+	}
+	vmname, err := utils.GetK8sCompatibleVMWareObjectName(vm, vmwarecreds)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get vm name")
 	}
@@ -725,7 +737,7 @@ func (r *MigrationPlanReconciler) CreateMigrationConfigMap(ctx context.Context,
 	migrationobj *vjailbreakv1alpha1.Migration,
 	openstackcreds *vjailbreakv1alpha1.OpenstackCreds,
 	vmwcreds *vjailbreakv1alpha1.VMwareCreds, vm string, vmMachine *vjailbreakv1alpha1.VMwareMachine) (*corev1.ConfigMap, error) {
-	vmname, err := utils.GetVMwareMachineNameForVMName(vm)
+	vmname, err := utils.GetK8sCompatibleVMWareObjectName(vm, vmwcreds.Name)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get vm name")
 	}

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -510,7 +510,7 @@ func (r *MigrationPlanReconciler) CreateJob(ctx context.Context,
 	if err != nil {
 		return errors.Wrap(err, "failed to get vm name")
 	}
-	jobName, err := utils.GetJobNameForVMName(vmk8sname, vmwarecreds)
+	jobName, err := utils.GetJobNameForVMName(vm, vmwarecreds)
 	if err != nil {
 		return errors.Wrap(err, "failed to get job name")
 	}

--- a/k8s/migration/internal/controller/openstackcreds_controller.go
+++ b/k8s/migration/internal/controller/openstackcreds_controller.go
@@ -227,7 +227,7 @@ func handleValidatedCreds(ctx context.Context, r *OpenstackCredsReconciler, scop
 	}
 
 	ctxlog.Info("Creating dummy PCD cluster", "openstackcreds", scope.OpenstackCreds.Name)
-	err = utils.CreateEntryForNoPCDCluster(ctx, r.Client, scope.OpenstackCreds)
+	err = utils.CreateDummyPCDClusterForStandAlonePCDHosts(ctx, r.Client, scope.OpenstackCreds)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrap(err, "failed to create dummy PCD cluster")
 	}

--- a/k8s/migration/internal/controller/rollingmigrationplan_controller.go
+++ b/k8s/migration/internal/controller/rollingmigrationplan_controller.go
@@ -402,7 +402,6 @@ func (r *RollingMigrationPlanReconciler) SetupWithManager(mgr ctrl.Manager) erro
 // UpdateRollingMigrationPlanStatus updates the status fields of a RollingMigrationPlan resource including phase, message, and current targets.
 // It also updates statistics about migrated and failed VMs by checking the status of related VMMigration resources.
 func (r *RollingMigrationPlanReconciler) UpdateRollingMigrationPlanStatus(ctx context.Context, scope *scope.RollingMigrationPlanScope, status vjailbreakv1alpha1.RollingMigrationPlanPhase, message, currentCluster, currentESXi string) error {
-
 	// update phase and message
 	scope.RollingMigrationPlan.Status.Phase = status
 	scope.RollingMigrationPlan.Status.Message = message

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -110,7 +110,7 @@ func (r *VMwareCredsReconciler) reconcileNormal(ctx context.Context, scope *scop
 	ctxlog.Info("Successfully validated VMwareCreds, adding finalizer", "name", scope.Name(), "finalizers", scope.VMwareCreds.Finalizers)
 	controllerutil.AddFinalizer(scope.VMwareCreds, constants.VMwareCredsFinalizer)
 
-	err := utils.CreateVMwareClustersAndHosts(ctx, r.Client, scope)
+	err := utils.CreateVMwareClustersAndHosts(ctx, scope)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, fmt.Sprintf("Error creating VMs for VMwareCreds '%s'", scope.Name()))
 	}
@@ -124,7 +124,7 @@ func (r *VMwareCredsReconciler) reconcileNormal(ctx context.Context, scope *scop
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, fmt.Sprintf("Error finding deleted VMs for VMwareCreds '%s'", scope.Name()))
 	}
-	err = utils.DeleteStaleVMwareClustersAndHosts(ctx, r.Client, scope)
+	err = utils.DeleteStaleVMwareClustersAndHosts(ctx, scope)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, fmt.Sprintf("Error finding deleted clusters and hosts for VMwareCreds '%s'", scope.Name()))
 	}

--- a/k8s/migration/pkg/constants/constants.go
+++ b/k8s/migration/pkg/constants/constants.go
@@ -170,6 +170,8 @@ const (
 
 	// VCenterVMScanConcurrencyLimit is the limit for concurrency while scanning vCenter VMs
 	VCenterVMScanConcurrencyLimit = 100
+	// VMwareClusterNameStandAloneESX is the name of the VMware cluster when there is no cluster
+	VMwareClusterNameStandAloneESX = "NO CLUSTER"
 )
 
 // CloudInitScript contains the cloud-init script for VM initialization

--- a/k8s/migration/pkg/utils/bmprovisionerutils.go
+++ b/k8s/migration/pkg/utils/bmprovisionerutils.go
@@ -573,7 +573,6 @@ func GetVMwareCredsNameFromMigration(ctx context.Context, k3sclient client.Clien
 		return "", errors.Wrap(err, "failed to get migration template")
 	}
 	return migrationTemplate.Spec.Source.VMwareRef, nil
-
 }
 
 // GetOpenstackCredsNameFromMigration retrieves the destination OpenStack credentials name from a Migration
@@ -592,7 +591,6 @@ func GetVMwareCredsNameFromMigrationPlan(ctx context.Context, k3sclient client.C
 		return "", errors.Wrap(err, "failed to get migration template")
 	}
 	return migrationTemplate.Spec.Source.VMwareRef, nil
-
 }
 
 // GetOpenstackCredsNameFromMigrationPlan retrieves the destination OpenStack credentials name from a MigrationPlan

--- a/k8s/migration/pkg/utils/bmprovisionerutils.go
+++ b/k8s/migration/pkg/utils/bmprovisionerutils.go
@@ -43,7 +43,7 @@ func ConvertESXiToPCDHost(ctx context.Context,
 	bmProvider providers.BMCProvider) error {
 	ctxlog := log.FromContext(ctx).WithName(constants.ESXIMigrationControllerName)
 
-	vmwarecreds, err := GetSourceVMwareCredsFromRollingMigrationPlan(ctx, scope.Client, scope.RollingMigrationPlan)
+	vmwarecreds, err := GetVMwareCredsFromRollingMigrationPlan(ctx, scope.Client, scope.RollingMigrationPlan)
 	if err != nil {
 		return errors.Wrap(err, "failed to get vmware credentials")
 	}
@@ -281,7 +281,7 @@ func MergeCloudInitAndCreateSecret(ctx context.Context, scope *scope.RollingMigr
 }
 
 func generatePCDOnboardingCloudInit(ctx context.Context, scope *scope.RollingMigrationPlanScope, local bool) (string, error) {
-	openstackCreds, err := GetDestinationOpenstackCredsInfoFromRollingMigrationPlan(ctx, scope.Client, scope.RollingMigrationPlan)
+	openstackCreds, err := GetOpenstackCredsInfoFromRollingMigrationPlan(ctx, scope.Client, scope.RollingMigrationPlan)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get openstack credentials")
 	}
@@ -467,8 +467,8 @@ func GetResmgrClient(openstackCreds vjailbreakv1alpha1.OpenStackCredsInfo) (resm
 	), nil
 }
 
-// GetSourceVMwareCredsFromRollingMigrationPlan retrieves the source VMware credentials from a RollingMigrationPlan
-func GetSourceVMwareCredsFromRollingMigrationPlan(ctx context.Context, k3sclient client.Client, rollingMigrationPlan *vjailbreakv1alpha1.RollingMigrationPlan) (*vjailbreakv1alpha1.VMwareCreds, error) {
+// GetVMwareCredsFromRollingMigrationPlan retrieves the source VMware credentials from a RollingMigrationPlan
+func GetVMwareCredsFromRollingMigrationPlan(ctx context.Context, k3sclient client.Client, rollingMigrationPlan *vjailbreakv1alpha1.RollingMigrationPlan) (*vjailbreakv1alpha1.VMwareCreds, error) {
 	migrationTemplate, err := GetMigrationTemplateFromRollingMigrationPlan(ctx, k3sclient, rollingMigrationPlan)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get migration template")
@@ -481,9 +481,9 @@ func GetSourceVMwareCredsFromRollingMigrationPlan(ctx context.Context, k3sclient
 	return vmwarecreds, nil
 }
 
-// GetSourceVMwareCredsInfoFromRollingMigrationPlan retrieves the source VMware credentials info from a RollingMigrationPlan
-func GetSourceVMwareCredsInfoFromRollingMigrationPlan(ctx context.Context, k3sclient client.Client, rollingMigrationPlan *vjailbreakv1alpha1.RollingMigrationPlan) (*vjailbreakv1alpha1.VMwareCredsInfo, error) {
-	vmwarecreds, err := GetSourceVMwareCredsFromRollingMigrationPlan(ctx, k3sclient, rollingMigrationPlan)
+// GetVMwareCredsInfoFromRollingMigrationPlan retrieves the source VMware credentials info from a RollingMigrationPlan
+func GetVMwareCredsInfoFromRollingMigrationPlan(ctx context.Context, k3sclient client.Client, rollingMigrationPlan *vjailbreakv1alpha1.RollingMigrationPlan) (*vjailbreakv1alpha1.VMwareCredsInfo, error) {
+	vmwarecreds, err := GetVMwareCredsFromRollingMigrationPlan(ctx, k3sclient, rollingMigrationPlan)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get vmware credentials")
 	}
@@ -494,8 +494,8 @@ func GetSourceVMwareCredsInfoFromRollingMigrationPlan(ctx context.Context, k3scl
 	return &vmwareCredsInfo, nil
 }
 
-// GetDestinationOpenstackCredsFromRollingMigrationPlan retrieves the destination OpenStack credentials from a RollingMigrationPlan
-func GetDestinationOpenstackCredsFromRollingMigrationPlan(ctx context.Context, k3sclient client.Client, rollingMigrationPlan *vjailbreakv1alpha1.RollingMigrationPlan) (*vjailbreakv1alpha1.OpenstackCreds, error) {
+// GetOpenstackCredsFromRollingMigrationPlan retrieves the destination OpenStack credentials from a RollingMigrationPlan
+func GetOpenstackCredsFromRollingMigrationPlan(ctx context.Context, k3sclient client.Client, rollingMigrationPlan *vjailbreakv1alpha1.RollingMigrationPlan) (*vjailbreakv1alpha1.OpenstackCreds, error) {
 	migrationTemplate, err := GetMigrationTemplateFromRollingMigrationPlan(ctx, k3sclient, rollingMigrationPlan)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get migration template")
@@ -508,9 +508,9 @@ func GetDestinationOpenstackCredsFromRollingMigrationPlan(ctx context.Context, k
 	return openstackcreds, nil
 }
 
-// GetDestinationOpenstackCredsInfoFromRollingMigrationPlan retrieves the destination OpenStack credentials info from a RollingMigrationPlan
-func GetDestinationOpenstackCredsInfoFromRollingMigrationPlan(ctx context.Context, k3sclient client.Client, rollingMigrationPlan *vjailbreakv1alpha1.RollingMigrationPlan) (*vjailbreakv1alpha1.OpenStackCredsInfo, error) {
-	openstackcreds, err := GetDestinationOpenstackCredsFromRollingMigrationPlan(ctx, k3sclient, rollingMigrationPlan)
+// GetOpenstackCredsInfoFromRollingMigrationPlan retrieves the destination OpenStack credentials info from a RollingMigrationPlan
+func GetOpenstackCredsInfoFromRollingMigrationPlan(ctx context.Context, k3sclient client.Client, rollingMigrationPlan *vjailbreakv1alpha1.RollingMigrationPlan) (*vjailbreakv1alpha1.OpenStackCredsInfo, error) {
+	openstackcreds, err := GetOpenstackCredsFromRollingMigrationPlan(ctx, k3sclient, rollingMigrationPlan)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get openstack credentials")
 	}
@@ -531,4 +531,75 @@ func GetMigrationTemplateFromRollingMigrationPlan(ctx context.Context, k3sclient
 		return nil, errors.Wrap(err, "failed to get migration template")
 	}
 	return &migrationTemplate, nil
+}
+
+// GetMigrationPlanFromMigration retrieves the migration plan from a Migration
+func GetMigrationPlanFromMigration(ctx context.Context, k3sclient client.Client, migration *vjailbreakv1alpha1.Migration) (*vjailbreakv1alpha1.MigrationPlan, error) {
+	migrationPlan := vjailbreakv1alpha1.MigrationPlan{}
+	if err := k3sclient.Get(ctx, types.NamespacedName{
+		Name:      migration.Spec.MigrationPlan,
+		Namespace: constants.NamespaceMigrationSystem},
+		&migrationPlan); err != nil {
+		return nil, errors.Wrap(err, "failed to get migration plan")
+	}
+	return &migrationPlan, nil
+}
+
+// GetMigrationTemplateFromMigrationPlan retrieves the migration template from a MigrationPlan
+func GetMigrationTemplateFromMigrationPlan(ctx context.Context, k3sclient client.Client, migrationPlan *vjailbreakv1alpha1.MigrationPlan) (*vjailbreakv1alpha1.MigrationTemplate, error) {
+	migrationTemplate := vjailbreakv1alpha1.MigrationTemplate{}
+	if err := k3sclient.Get(ctx, types.NamespacedName{
+		Name:      migrationPlan.Spec.MigrationTemplate,
+		Namespace: constants.NamespaceMigrationSystem},
+		&migrationTemplate); err != nil {
+		return nil, errors.Wrap(err, "failed to get migration template")
+	}
+	return &migrationTemplate, nil
+}
+
+// GetMigrationTemplateFromMigration retrieves the migration template from a Migration
+func GetMigrationTemplateFromMigration(ctx context.Context, k3sclient client.Client, migration *vjailbreakv1alpha1.Migration) (*vjailbreakv1alpha1.MigrationTemplate, error) {
+	migrationPlan, err := GetMigrationPlanFromMigration(ctx, k3sclient, migration)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get migration plan")
+	}
+	return GetMigrationTemplateFromMigrationPlan(ctx, k3sclient, migrationPlan)
+}
+
+// GetVMwareCredsNameFromMigration retrieves the source VMware credentials name from a Migration
+func GetVMwareCredsNameFromMigration(ctx context.Context, k3sclient client.Client, migration *vjailbreakv1alpha1.Migration) (string, error) {
+	migrationTemplate, err := GetMigrationTemplateFromMigration(ctx, k3sclient, migration)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get migration template")
+	}
+	return migrationTemplate.Spec.Source.VMwareRef, nil
+
+}
+
+// GetOpenstackCredsNameFromMigration retrieves the destination OpenStack credentials name from a Migration
+func GetOpenstackCredsNameFromMigration(ctx context.Context, k3sclient client.Client, migration *vjailbreakv1alpha1.Migration) (string, error) {
+	migrationTemplate, err := GetMigrationTemplateFromMigration(ctx, k3sclient, migration)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get migration template")
+	}
+	return migrationTemplate.Spec.Destination.OpenstackRef, nil
+}
+
+// GetVMwareCredsNameFromMigrationPlan retrieves the source VMware credentials name from a MigrationPlan
+func GetVMwareCredsNameFromMigrationPlan(ctx context.Context, k3sclient client.Client, migrationPlan *vjailbreakv1alpha1.MigrationPlan) (string, error) {
+	migrationTemplate, err := GetMigrationTemplateFromMigrationPlan(ctx, k3sclient, migrationPlan)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get migration template")
+	}
+	return migrationTemplate.Spec.Source.VMwareRef, nil
+
+}
+
+// GetOpenstackCredsNameFromMigrationPlan retrieves the destination OpenStack credentials name from a MigrationPlan
+func GetOpenstackCredsNameFromMigrationPlan(ctx context.Context, k3sclient client.Client, migrationPlan *vjailbreakv1alpha1.MigrationPlan) (string, error) {
+	migrationTemplate, err := GetMigrationTemplateFromMigrationPlan(ctx, k3sclient, migrationPlan)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get migration template")
+	}
+	return migrationTemplate.Spec.Destination.OpenstackRef, nil
 }

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -737,15 +737,15 @@ func AppendUnique(slice []string, values ...string) []string {
 // CreateOrUpdateVMwareMachine creates or updates a VMwareMachine object for the given VM
 func CreateOrUpdateVMwareMachine(ctx context.Context, client client.Client,
 	vmwcreds *vjailbreakv1alpha1.VMwareCreds, vminfo *vjailbreakv1alpha1.VMInfo) error {
-	sanitizedVMName, err := GetVMwareMachineNameForVMName(vminfo.Name)
+	sanitizedVMName, err := GetK8sCompatibleVMWareObjectName(vminfo.Name, vmwcreds.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get VM name: %w", err)
 	}
-	esxiK8sName, err := ConvertToK8sName(vminfo.ESXiName)
+	esxiK8sName, err := GetK8sCompatibleVMWareObjectName(vminfo.ESXiName, vmwcreds.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to convert ESXi name to k8s name")
 	}
-	clusterK8sName, err := ConvertToK8sName(vminfo.ClusterName)
+	clusterK8sName, err := GetK8sCompatibleVMWareObjectName(vminfo.ClusterName, vmwcreds.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to convert cluster name to k8s name")
 	}
@@ -1425,7 +1425,7 @@ func processSingleVM(ctx context.Context, scope *scope.VMwareCredsScope, vm *obj
 	}
 
 	// Convert VM name to Kubernetes-safe name
-	vmName, err := GetVMwareMachineNameForVMName(vmProps.Config.Name)
+	vmName, err := GetK8sCompatibleVMWareObjectName(vmProps.Config.Name, scope.Name())
 	if err != nil {
 		appendToVMErrorsThreadSafe(errMu, vmErrors, vm.Name(), fmt.Errorf("failed to convert vm name: %w", err))
 	}

--- a/k8s/migration/pkg/utils/migrationplanutils.go
+++ b/k8s/migration/pkg/utils/migrationplanutils.go
@@ -85,20 +85,11 @@ func ValidateMigrationPlan(migrationplan *vjailbreakv1alpha1.MigrationPlan) erro
 	return nil
 }
 
-// GetVMwareMachineNameForVMName generates a unique name for a VMwareMachine resource
-func GetVMwareMachineNameForVMName(vmname string) (string, error) {
-	vmk8sname, err := ConvertToK8sName(vmname)
+// GetJobNameForVMName generates a unique name for a job resource
+func GetJobNameForVMName(vmname string, credName string) (string, error) {
+	vmk8sname, err := GetK8sCompatibleVMWareObjectName(vmname, credName)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to convert vm name to k8s name")
-	}
-	return fmt.Sprintf("%s-%s", vmk8sname[:min(len(vmk8sname), constants.VMNameMaxLength)], GenerateSha256Hash(vmname)[:constants.HashSuffixLength]), nil
-}
-
-// GetJobNameForVMName generates a unique name for a job resource
-func GetJobNameForVMName(vmname string) (string, error) {
-	vmk8sname, err := GetVMwareMachineNameForVMName(vmname)
-	if err != nil {
-		return "", err
 	}
 	return fmt.Sprintf("v2v-helper-%s-%s", vmk8sname[:min(len(vmk8sname), constants.MaxJobNameLength)], GenerateSha256Hash(vmname)[:constants.HashSuffixLength]), nil
 }

--- a/k8s/migration/pkg/utils/pcdutils.go
+++ b/k8s/migration/pkg/utils/pcdutils.go
@@ -108,8 +108,8 @@ func CreatePCDClusterFromResmgrCluster(ctx context.Context, k8sClient client.Cli
 	return nil
 }
 
-// CreateEntryForNoPCDCluster creates a PCDCluster for no cluster
-func CreateEntryForNoPCDCluster(ctx context.Context, k8sClient client.Client, openstackCreds *vjailbreakv1alpha1.OpenstackCreds) error {
+// CreateDummyPCDClusterForStandAlonePCDHosts creates a PCDCluster for no cluster
+func CreateDummyPCDClusterForStandAlonePCDHosts(ctx context.Context, k8sClient client.Client, openstackCreds *vjailbreakv1alpha1.OpenstackCreds) error {
 	k8sClusterName, err := getK8sClusterObjectName(constants.PCDClusterNameNoCluster, openstackCreds.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to convert cluster name to k8s name")
@@ -472,11 +472,11 @@ func WaitforHostToShowUpOnPCD(ctx context.Context, k8sClient client.Client, open
 	return false, nil
 }
 
-func getK8sClusterObjectName(clusterName, openstackCredsName string) (string, error) {
+func getK8sClusterObjectName(clusterName, credName string) (string, error) {
 	k8sClusterName, err := ConvertToK8sName(clusterName)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to convert cluster name to k8s name")
 	}
-	name := fmt.Sprintf("%s-%s", k8sClusterName, openstackCredsName)
+	name := fmt.Sprintf("%s-%s", k8sClusterName, credName)
 	return name[:min(len(name), 63)], nil
 }

--- a/k8s/migration/pkg/utils/pcdutils.go
+++ b/k8s/migration/pkg/utils/pcdutils.go
@@ -110,7 +110,7 @@ func CreatePCDClusterFromResmgrCluster(ctx context.Context, k8sClient client.Cli
 
 // CreateDummyPCDClusterForStandAlonePCDHosts creates a PCDCluster for no cluster
 func CreateDummyPCDClusterForStandAlonePCDHosts(ctx context.Context, k8sClient client.Client, openstackCreds *vjailbreakv1alpha1.OpenstackCreds) error {
-	k8sClusterName, err := getK8sClusterObjectName(constants.PCDClusterNameNoCluster, openstackCreds.Name)
+	k8sClusterName, err := GetK8sCompatibleVMWareObjectName(constants.PCDClusterNameNoCluster, openstackCreds.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to convert cluster name to k8s name")
 	}
@@ -144,7 +144,7 @@ func CreateDummyPCDClusterForStandAlonePCDHosts(ctx context.Context, k8sClient c
 
 // DeleteEntryForNoPCDCluster deletes the PCDCluster for null cluster
 func DeleteEntryForNoPCDCluster(ctx context.Context, k8sClient client.Client, openstackCreds *vjailbreakv1alpha1.OpenstackCreds) error {
-	k8sClusterName, err := getK8sClusterObjectName(constants.PCDClusterNameNoCluster, openstackCreds.Name)
+	k8sClusterName, err := GetK8sCompatibleVMWareObjectName(constants.PCDClusterNameNoCluster, openstackCreds.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to convert cluster name to k8s name")
 	}
@@ -185,7 +185,7 @@ func UpdatePCDHostFromResmgrHost(ctx context.Context, k8sClient client.Client, h
 func UpdatePCDClusterFromResmgrCluster(ctx context.Context, k8sClient client.Client, cluster resmgr.Cluster, openstackCreds *vjailbreakv1alpha1.OpenstackCreds) error {
 	oldPCDCluster := vjailbreakv1alpha1.PCDCluster{}
 
-	k8sClusterName, err := getK8sClusterObjectName(cluster.Name, openstackCreds.Name)
+	k8sClusterName, err := GetK8sCompatibleVMWareObjectName(cluster.Name, openstackCreds.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to convert cluster name to k8s name")
 	}
@@ -254,7 +254,7 @@ func generatePCDHostFromResmgrHost(openstackCreds *vjailbreakv1alpha1.OpenstackC
 }
 
 func generatePCDClusterFromResmgrCluster(openstackCreds *vjailbreakv1alpha1.OpenstackCreds, cluster resmgr.Cluster) (*vjailbreakv1alpha1.PCDCluster, error) {
-	k8sClusterName, err := getK8sClusterObjectName(cluster.Name, openstackCreds.Name)
+	k8sClusterName, err := GetK8sCompatibleVMWareObjectName(cluster.Name, openstackCreds.Name)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to convert cluster name to k8s name")
 	}
@@ -391,9 +391,9 @@ func filterPCDHostsOnOpenstackCreds(ctx context.Context, k8sClient client.Client
 }
 
 // GetVMwareHostFromESXiName retrieves a VMwareHost resource based on the ESXi host name
-func GetVMwareHostFromESXiName(ctx context.Context, k8sClient client.Client, esxiName string) (*vjailbreakv1alpha1.VMwareHost, error) {
+func GetVMwareHostFromESXiName(ctx context.Context, k8sClient client.Client, esxiName, credName string) (*vjailbreakv1alpha1.VMwareHost, error) {
 	vmwareHost := &vjailbreakv1alpha1.VMwareHost{}
-	esxiK8sName, err := ConvertToK8sName(esxiName)
+	esxiK8sName, err := GetK8sCompatibleVMWareObjectName(esxiName, credName)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to convert ESXi name to k8s name")
 	}
@@ -472,11 +472,21 @@ func WaitforHostToShowUpOnPCD(ctx context.Context, k8sClient client.Client, open
 	return false, nil
 }
 
-func getK8sClusterObjectName(clusterName, credName string) (string, error) {
-	k8sClusterName, err := ConvertToK8sName(clusterName)
+// GetK8sCompatibleVMWareObjectName returns a k8s compatible name for a vCenter object
+func GetK8sCompatibleVMWareObjectName(vCenterObjectName, credName string) (string, error) {
+	// get a unique string for the cluster + credentials
+	vCenterObjectCredsName := fmt.Sprintf("%s-%s", vCenterObjectName, credName)
+
+	// hash the cluster + credentials string
+	hash := GenerateSha256Hash(vCenterObjectCredsName)[:constants.HashSuffixLength]
+
+	// convert the cluster name to a k8s name
+	k8sClusterName, err := ConvertToK8sName(vCenterObjectName)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to convert cluster name to k8s name")
 	}
-	name := fmt.Sprintf("%s-%s", k8sClusterName, credName)
-	return name[:min(len(name), 63)], nil
+
+	// truncate the k8s cluster name to the max length
+	name := fmt.Sprintf("%s-%s", k8sClusterName[:min(len(k8sClusterName), constants.VMNameMaxLength)], hash)
+	return name[:min(len(name), constants.K8sNameMaxLength)], nil
 }

--- a/k8s/migration/pkg/utils/vjailbreaknodeutils.go
+++ b/k8s/migration/pkg/utils/vjailbreaknodeutils.go
@@ -579,7 +579,11 @@ func DeleteNodeByName(ctx context.Context, k3sclient client.Client, nodeName str
 // GetVMMigration retrieves a Migration resource for a specific VM in a rolling migration plan.
 // It returns the Migration resource associated with the VM or an error if not found.
 func GetVMMigration(ctx context.Context, k3sclient client.Client, vmName string, rollingMigrationPlan *vjailbreakv1alpha1.RollingMigrationPlan) (*vjailbreakv1alpha1.Migration, error) {
-	vmk8sName, err := GetVMwareMachineNameForVMName(vmName)
+	vmwarecreds, err := GetVMwareCredsFromRollingMigrationPlan(ctx, k3sclient, rollingMigrationPlan)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get vmware credentials")
+	}
+	vmk8sName, err := GetK8sCompatibleVMWareObjectName(vmName, vmwarecreds.Name)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get vm name")
 	}

--- a/k8s/migration/pkg/utils/vmwareutils.go
+++ b/k8s/migration/pkg/utils/vmwareutils.go
@@ -64,11 +64,11 @@ func GetVMwareClustersAndHosts(ctx context.Context, scope *scope.VMwareCredsScop
 
 // createVMwareHost creates a VMware host resource in Kubernetes
 func createVMwareHost(ctx context.Context, scope *scope.VMwareCredsScope, host VMwareHostInfo, credName, clusterName, namespace string) (string, error) {
-	hostk8sName, err := ConvertToK8sName(host.Name)
+	hostk8sName, err := GetK8sCompatibleVMWareObjectName(host.Name, credName)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to convert host name to k8s name")
 	}
-	clusterk8sName, err := ConvertToK8sName(clusterName)
+	clusterk8sName, err := GetK8sCompatibleVMWareObjectName(clusterName, credName)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to convert cluster name to k8s name")
 	}
@@ -111,7 +111,7 @@ func createVMwareHost(ctx context.Context, scope *scope.VMwareCredsScope, host V
 func createVMwareCluster(ctx context.Context, scope *scope.VMwareCredsScope, cluster VMwareClusterInfo) error {
 	log := scope.Logger
 
-	clusterk8sName, err := ConvertToK8sName(cluster.Name)
+	clusterk8sName, err := GetK8sCompatibleVMWareObjectName(cluster.Name, scope.Name())
 	if err != nil {
 		return errors.Wrap(err, "failed to convert cluster name to k8s name")
 	}
@@ -202,7 +202,7 @@ func DeleteStaleVMwareClustersAndHosts(ctx context.Context, scope *scope.VMwareC
 			Name: host.Name(),
 		})
 	}
-	k8sClusterName, err := getK8sClusterObjectName(constants.VMwareClusterNameStandAloneESX, scope.Name())
+	k8sClusterName, err := GetK8sCompatibleVMWareObjectName(constants.VMwareClusterNameStandAloneESX, scope.Name())
 	if err != nil {
 		return errors.Wrap(err, "failed to convert cluster name to k8s name")
 	}
@@ -229,7 +229,7 @@ func DeleteStaleVMwareClustersAndHosts(ctx context.Context, scope *scope.VMwareC
 	// Create a map of valid cluster names for O(1) lookups
 	clusterNames := make(map[string]bool)
 	for _, cluster := range clusters {
-		cname, err := ConvertToK8sName(cluster.Name)
+		cname, err := GetK8sCompatibleVMWareObjectName(cluster.Name, scope.Name())
 		if err != nil {
 			return errors.Wrap(err, "failed to convert cluster name to k8s name")
 		}
@@ -248,7 +248,7 @@ func DeleteStaleVMwareClustersAndHosts(ctx context.Context, scope *scope.VMwareC
 	// Create a map of valid host names for O(1) lookups
 	hostNames := make(map[string]bool)
 	for _, host := range hosts {
-		hname, err := ConvertToK8sName(host.Name)
+		hname, err := GetK8sCompatibleVMWareObjectName(host.Name, scope.Name())
 		if err != nil {
 			return errors.Wrap(err, "failed to convert host name to k8s name")
 		}
@@ -319,7 +319,7 @@ func FetchStandAloneESXHostsFromVcenter(ctx context.Context, scope *scope.VMware
 // CreateDummyClusterForStandAloneESX creates a VMware cluster for standalone ESX
 func CreateDummyClusterForStandAloneESX(ctx context.Context, scope *scope.VMwareCredsScope, existingClusters []VMwareClusterInfo) error {
 	log := scope.Logger
-	k8sClusterName, err := getK8sClusterObjectName(constants.VMwareClusterNameStandAloneESX, scope.Name())
+	k8sClusterName, err := GetK8sCompatibleVMWareObjectName(constants.VMwareClusterNameStandAloneESX, scope.Name())
 	if err != nil {
 		return errors.Wrap(err, "failed to convert cluster name to k8s name")
 	}

--- a/k8s/migration/pkg/utils/vmwareutils.go
+++ b/k8s/migration/pkg/utils/vmwareutils.go
@@ -169,7 +169,7 @@ func CreateVMwareClustersAndHosts(ctx context.Context, scope *scope.VMwareCredsS
 	}
 
 	// Create a dummy cluster for standalone ESX
-	if err := CreateDummyClusterForStandAloneESX(ctx, scope, clusters, scope.Client); err != nil {
+	if err := CreateDummyClusterForStandAloneESX(ctx, scope, clusters); err != nil {
 		return errors.Wrap(err, "failed to create dummy cluster for standalone ESX")
 	}
 
@@ -196,7 +196,7 @@ func DeleteStaleVMwareClustersAndHosts(ctx context.Context, scope *scope.VMwareC
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch standalone ESX hosts")
 	}
-	var vmHosts []VMwareHostInfo
+	vmHosts := make([]VMwareHostInfo, 0, len(standAloneHosts))
 	for _, host := range standAloneHosts {
 		vmHosts = append(vmHosts, VMwareHostInfo{
 			Name: host.Name(),
@@ -305,7 +305,7 @@ func FetchStandAloneESXHostsFromVcenter(ctx context.Context, scope *scope.VMware
 	if err != nil && !strings.Contains(err.Error(), "not found") {
 		return nil, errors.Wrap(err, "failed to get host list")
 	}
-	var vmHosts []*object.HostSystem
+	vmHosts := make([]*object.HostSystem, 0, len(hostList))
 	for _, host := range hostList {
 		// if part of a cluster, skip
 		if clusteredHosts[host.Name()] {
@@ -317,7 +317,7 @@ func FetchStandAloneESXHostsFromVcenter(ctx context.Context, scope *scope.VMware
 }
 
 // CreateDummyClusterForStandAloneESX creates a VMware cluster for standalone ESX
-func CreateDummyClusterForStandAloneESX(ctx context.Context, scope *scope.VMwareCredsScope, existingClusters []VMwareClusterInfo, k8sClient client.Client) error {
+func CreateDummyClusterForStandAloneESX(ctx context.Context, scope *scope.VMwareCredsScope, existingClusters []VMwareClusterInfo) error {
 	log := scope.Logger
 	k8sClusterName, err := getK8sClusterObjectName(constants.VMwareClusterNameStandAloneESX, scope.Name())
 	if err != nil {

--- a/k8s/migration/pkg/utils/vmwareutils.go
+++ b/k8s/migration/pkg/utils/vmwareutils.go
@@ -5,6 +5,7 @@ package utils
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
@@ -30,7 +31,7 @@ func GetVMwareClustersAndHosts(ctx context.Context, scope *scope.VMwareCredsScop
 		return nil, errors.Wrap(err, "failed to get finder for vCenter credentials")
 	}
 	clusterList, err := finder.ClusterComputeResourceList(ctx, "*")
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "not found") {
 		return nil, errors.Wrap(err, "failed to get cluster list")
 	}
 
@@ -301,7 +302,7 @@ func FetchStandAloneESXHostsFromVcenter(ctx context.Context, scope *scope.VMware
 		return nil, errors.Wrap(err, "failed to get finder for vCenter credentials")
 	}
 	hostList, err := finder.HostSystemList(ctx, "*")
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "not found") {
 		return nil, errors.Wrap(err, "failed to get host list")
 	}
 	var vmHosts []*object.HostSystem

--- a/k8s/migration/pkg/utils/vmwareutils.go
+++ b/k8s/migration/pkg/utils/vmwareutils.go
@@ -202,12 +202,8 @@ func DeleteStaleVMwareClustersAndHosts(ctx context.Context, scope *scope.VMwareC
 			Name: host.Name(),
 		})
 	}
-	k8sClusterName, err := GetK8sCompatibleVMWareObjectName(constants.VMwareClusterNameStandAloneESX, scope.Name())
-	if err != nil {
-		return errors.Wrap(err, "failed to convert cluster name to k8s name")
-	}
 	clusters = append(clusters, VMwareClusterInfo{
-		Name:  k8sClusterName,
+		Name:  constants.VMwareClusterNameStandAloneESX,
 		Hosts: vmHosts,
 	})
 

--- a/ui/src/features/migration/RollingMigrationForm.tsx
+++ b/ui/src/features/migration/RollingMigrationForm.tsx
@@ -971,7 +971,6 @@ export default function RollingMigrationFormDrawer({
                 .filter(vm => selectedVMs.includes(vm.id))
                 .map(vm => ({
                     vmName: vm.name,
-                    esxiName: vm.esxHost
                 })) as VMSequence[];
 
             // Create cluster mapping between VMware cluster and PCD cluster


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #696 

## Special notes for your reviewer


## Testing done
<img width="1440" height="900" alt="Screenshot 2025-07-24 at 7 05 56 PM" src="https://github.com/user-attachments/assets/49180875-888f-4b61-b3e9-e411a4b424af" />
<img width="1256" height="614" alt="Screenshot 2025-07-24 at 7 06 21 PM" src="https://github.com/user-attachments/assets/c46e278c-4371-4532-8dd1-65b7e0decef1" />

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request implements fixes to enable vCenter operations in environments without clusters by correcting credential retrieval and host information functions. The changes standardize naming conventions for VMware and Openstack resources, enhance error handling, and introduce dummy cluster support for standalone ESXi environments. It removes outdated code and consolidates error pathways for clearer feedback when retrieving credentials and migration objects.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 5
-->
</div>