### PR TITLE
revert back to metadata name

### DIFF
--- a/ui/src/features/migration/SourceDestinationClusterSelection.tsx
+++ b/ui/src/features/migration/SourceDestinationClusterSelection.tsx
@@ -155,7 +155,7 @@ export default function SourceDestinationClusterSelection({
                                 const sourceItem = sourceData.find(item => item.credName === credName);
                                 const vcenterName = sourceItem?.vcenterName || credName;
                                 const cluster = sourceItem?.clusters.find(c => c.id === selected);
-                                return `${vcenterName} - ${sourceItem?.datacenter || ""} - ${cluster?.name || ""}`;
+                                return `${vcenterName} - ${sourceItem?.datacenter || ""} - ${cluster?.displayName || ""}`;
                             }}
                             endAdornment={loadingVMware ? <CircularProgress size={25} sx={{ mr: 3, display: "flex", alignItems: "center", justifyContent: "center" }} /> : null}
                             MenuProps={{
@@ -181,7 +181,7 @@ export default function SourceDestinationClusterSelection({
                                         }
                                         acc[item.vcenterName].datacenters[item.datacenter] = item.clusters;
                                         return acc;
-                                    }, {} as Record<string, { credName: string, datacenters: Record<string, { id: string; name: string }[]> }>)
+                                    }, {} as Record<string, { credName: string, datacenters: Record<string, { id: string; name: string; displayName: string }[]> }>)
                                 ).map(([vcenterName, { credName, datacenters }]) => [
                                     <ListSubheader key={vcenterName} sx={{ fontWeight: 700 }}>
                                         <Box sx={{ display: 'flex', alignItems: 'center' }}>
@@ -212,7 +212,7 @@ export default function SourceDestinationClusterSelection({
                                                         {/* @ts-ignore */}
                                                         <cds-icon shape="cluster" size="md" ></cds-icon>
                                                     </CdsIconWrapper>
-                                                    {cluster.name}
+                                                    {cluster.displayName}
                                                 </Box>
                                             </MenuItem>
                                         ))

--- a/ui/src/features/migration/useClusterData.ts
+++ b/ui/src/features/migration/useClusterData.ts
@@ -15,6 +15,7 @@ export interface SourceDataItem {
   clusters: {
     id: string
     name: string
+    displayName: string
   }[]
 }
 
@@ -100,7 +101,8 @@ export const useClusterData = (
         const clusters = clustersResponse.items.map(
           (cluster: VMwareCluster) => ({
             id: `${credName}:${cluster.metadata.name}`,
-            name: cluster.spec.name,
+            name: cluster.metadata.name,
+            displayName: cluster.spec.name,
           })
         )
 


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR reverts to using metadata-dependent display names for clusters in the migration feature. It updates UI components and cluster data mapping to ensure correct display properties. Type definitions and rendering logic were adjusted to provide more consistent and reliable cluster information display throughout the application.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>