### PR TITLE
idle connection timeout for vcenter

### DIFF
--- a/v2v-helper/main.go
+++ b/v2v-helper/main.go
@@ -82,7 +82,7 @@ func main() {
 		handleError(fmt.Sprintf("Failed to validate vCenter connection: %v", err))
 	}
 	utils.PrintLog(fmt.Sprintf("Connected to vCenter: %s\n", vCenterURL))
-
+	defer vcclient.VCClient.CloseIdleConnections()
 	// Validate OpenStack connection
 	openstackclients, err := openstack.NewOpenStackClients(openstackInsecure)
 	if err != nil {

--- a/v2v-helper/vcenter/vcenterops.go
+++ b/v2v-helper/vcenter/vcenterops.go
@@ -54,7 +54,7 @@ func validateVCenter(ctx context.Context, username, password, host string, disab
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %v", err)
 	}
-	c.RoundTripper = session.KeepAlive(c.RoundTripper, 10*time.Minute)
+	c.RoundTripper = session.KeepAlive(c.RoundTripper, 1*time.Hour)
 	client := &govmomi.Client{
 		Client:         c,
 		SessionManager: session.NewManager(c),


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request addresses idle connection management issues in the vCenter integration components by modifying two key files. In main.go, a deferred function call has been added to close idle connections, ensuring resources are released properly. Additionally, in vcenterops.go, the KeepAlive duration is extended to improve connection stability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>