### PR TITLE
bring back dhcp for non-matching subnets

### DIFF
--- a/v2v-helper/pkg/utils/migrateutils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/migrateutils/openstackopsutils.go
@@ -410,18 +410,21 @@ func (osclient *OpenStackClients) CreatePort(network *networks.Network, mac, ip,
 
 	port, err := ports.Create(osclient.NetworkingClient, createOpts).Extract()
 	if err != nil {
-		// return nil, err
+		// Static IP assignment failed, fall back to DHCP
 		utils.PrintLog(fmt.Sprintf("Could Not Use IP: %s, using DHCP to create Port", ip))
-		_, err = ports.Create(osclient.NetworkingClient, ports.CreateOpts{
+		dhcpPort, dhcpErr := ports.Create(osclient.NetworkingClient, ports.CreateOpts{
 			Name:           "port-" + vmname,
 			NetworkID:      network.ID,
 			MACAddress:     mac,
 			SecurityGroups: &securityGroups,
 		}).Extract()
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to create port with static IP")
+		
+		if dhcpErr != nil {
+			return nil, errors.Wrap(dhcpErr, "failed to create port with DHCP after static IP failed")
 		}
-		return nil, fmt.Errorf("failed to create port with static IP %s. Error: %w", ip, err)
+		
+		utils.PrintLog(fmt.Sprintf("Port created with DHCP instead of static IP %s. Port ID: %s", ip, dhcpPort.ID))
+		return dhcpPort, nil
 	}
 
 	utils.PrintLog(fmt.Sprintf("Port created with ID: %s", port.ID))


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #796 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request reintroduces a DHCP fallback mechanism for port creation when static IP assignment fails. The implementation in openstackopsutils.go improves error handling by attempting DHCP port creation as a fallback strategy, with enhanced logging to track the process. These changes improve the overall robustness and reliability of network port assignment, particularly in non-matching subnet scenarios.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>