### PR TITLE
fix vm refresh for new govomi clients

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -401,7 +401,7 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 
 		err = vmops.CleanUpSnapshots(false)
 		if err != nil {
-			return vminfo, errors.Wrap(err, "failed to delete snapshot of source VM")
+			return vminfo, errors.Wrap(err, "failed to cleanup snapshot of source VM")
 		}
 		err = vmops.TakeSnapshot(constants.MigrationSnapshotName)
 		if err != nil {
@@ -428,7 +428,7 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 	utils.PrintLog("Deleting migration snapshot")
 	err = vmops.CleanUpSnapshots(true)
 	if err != nil {
-		migobj.logMessage(fmt.Sprintf(`Failed to delete snapshot of source VM: %s, since copy is completed, 
+		migobj.logMessage(fmt.Sprintf(`Failed to cleanup snapshot of source VM: %s, since copy is completed, 
 		continuing with the migration`, err))
 	}
 	return vminfo, nil
@@ -1028,6 +1028,8 @@ func (migobj *Migrate) gracefulTerminate(vminfo vm.VMInfo, cancel context.Cancel
 
 func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	// Wait until the data copy start time
 	var zerotime time.Time
 	if !migobj.MigrationTimes.DataCopyStart.Equal(zerotime) && migobj.MigrationTimes.DataCopyStart.After(time.Now()) {
@@ -1072,7 +1074,7 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 	if err != nil {
 		if cleanuperror := migobj.cleanup(vminfo, fmt.Sprintf("failed to live replicate disks: %s", err)); cleanuperror != nil {
 			// combine both errors
-			return errors.Wrapf(err, "failed to live replicate disks: %s", cleanuperror)
+			return errors.Wrapf(err, "failed to cleanup disks: %s", cleanuperror)
 		}
 		return errors.Wrap(err, "failed to live replicate disks")
 	}
@@ -1090,7 +1092,7 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 	if err != nil {
 		if cleanuperror := migobj.cleanup(vminfo, fmt.Sprintf("failed to convert volumes: %s", err)); cleanuperror != nil {
 			// combine both errors
-			return errors.Wrapf(err, "failed to convert disks: %s", cleanuperror)
+			return errors.Wrapf(err, "failed to cleanup disks: %s", cleanuperror)
 		}
 		return errors.Wrap(err, "failed to convert disks")
 	}
@@ -1099,7 +1101,7 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 	if err != nil {
 		if cleanuperror := migobj.cleanup(vminfo, fmt.Sprintf("failed to create target instance: %s", err)); cleanuperror != nil {
 			// combine both errors
-			return errors.Wrapf(err, "failed to create target instance: %s", cleanuperror)
+			return errors.Wrapf(err, "failed to cleanup disks: %s", cleanuperror)
 		}
 		return errors.Wrap(err, "failed to create target instance")
 	}
@@ -1108,7 +1110,6 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 		migobj.logMessage(fmt.Sprintf("Warning: Failed to disconnect source VM network interfaces: %v", err))
 	}
 
-	cancel()
 	return nil
 }
 
@@ -1124,8 +1125,8 @@ func (migobj *Migrate) cleanup(vminfo vm.VMInfo, message string) error {
 	}
 	err = migobj.VMops.CleanUpSnapshots(true)
 	if err != nil {
-		utils.PrintLog(fmt.Sprintf("Failed to delete snapshot of source VM: %s\n", err))
-		return errors.Wrap(err, fmt.Sprintf("Failed to delete snapshot of source VM: %s\n", err))
+		utils.PrintLog(fmt.Sprintf("Failed to cleanup snapshot of source VM: %s\n", err))
+		return errors.Wrap(err, fmt.Sprintf("Failed to cleanup snapshot of source VM: %s\n", err))
 	}
 	return nil
 }

--- a/v2v-helper/vcenter/vcenterops.go
+++ b/v2v-helper/vcenter/vcenterops.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
@@ -27,26 +26,28 @@ type VCenterOperations interface {
 }
 
 type VCenterClient struct {
-	VCClient            *vim25.Client
-	VCFinder            *find.Finder
+	VCClient           *vim25.Client
+	VCFinder          *find.Finder
 	VCPropertyCollector *property.Collector
+	Session            *cache.Session
 }
 
-func validateVCenter(ctx context.Context, username, password, host string, disableSSLVerification bool) (*vim25.Client, error) {
-	// add protocol to host if not present
-	if !strings.HasPrefix(host, "http") {
+func validateVCenter(ctx context.Context, username, password, host string, disableSSLVerification bool) (*vim25.Client, *cache.Session, error) {
+	// Validate and add protocol to host if not present
+	if len(host) >= 4 && host[:4] != "http" {
+		host = "https://" + host
+	} else if len(host) < 4 {
 		host = "https://" + host
 	}
 
-	// add SDK path if not present
-	if len(host) < 4 || !strings.HasSuffix(host, "/sdk") {
-		// Length check ensures we don't crash on short hosts when checking suffix
+	// Add SDK endpoint if not present
+	if len(host) >= 4 && host[len(host)-4:] != "/sdk" {
 		host += "/sdk"
 	}
 
 	u, err := url.Parse(host)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse URL: %v", err)
+		return nil, nil, fmt.Errorf("failed to parse URL: %v", err)
 	}
 	u.User = url.UserPassword(username, password)
 
@@ -61,20 +62,21 @@ func validateVCenter(ctx context.Context, username, password, host string, disab
 	c := new(vim25.Client)
 	err = s.Login(ctx, c, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to login: %v", err)
+		return nil, nil, fmt.Errorf("failed to login: %v", err)
 	}
 
-	return c, nil
+	// Return both the client and the session for persistent re-authentication
+	return c, s, nil
 }
 
 func VCenterClientBuilder(ctx context.Context, username, password, host string, disableSSLVerification bool) (*VCenterClient, error) {
-	client, err := validateVCenter(ctx, username, password, host, disableSSLVerification)
+	client, session, err := validateVCenter(ctx, username, password, host, disableSSLVerification)
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate vCenter connection: %v", err)
 	}
 	finder := find.NewFinder(client, false)
 	pc := property.DefaultCollector(client)
-	return &VCenterClient{VCClient: client, VCFinder: finder, VCPropertyCollector: pc}, nil
+	return &VCenterClient{VCClient: client, VCFinder: finder, VCPropertyCollector: pc, Session: session}, nil
 }
 
 func GetThumbprint(host string) (string, error) {

--- a/v2v-helper/vcenter/vcenterops.go
+++ b/v2v-helper/vcenter/vcenterops.go
@@ -26,10 +26,10 @@ type VCenterOperations interface {
 }
 
 type VCenterClient struct {
-	VCClient           *vim25.Client
-	VCFinder          *find.Finder
+	VCClient            *vim25.Client
+	VCFinder            *find.Finder
 	VCPropertyCollector *property.Collector
-	Session            *cache.Session
+	Session             *cache.Session
 }
 
 func validateVCenter(ctx context.Context, username, password, host string, disableSSLVerification bool) (*vim25.Client, *cache.Session, error) {

--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -202,9 +202,9 @@ func (vmops *VMOps) GetVMInfo(ostype string) (VMInfo, error) {
 		uefi = true
 	}
 	if ostype == "" {
-		if strings.ToLower(o.Guest.GuestFamily) == strings.ToLower(string(types.VirtualMachineGuestOsFamilyWindowsGuest)) {
+		if strings.EqualFold(string(o.Guest.GuestFamily), string(types.VirtualMachineGuestOsFamilyWindowsGuest)) {
 			ostype = constants.OSFamilyWindows
-		} else if strings.ToLower(o.Guest.GuestFamily) == strings.ToLower(string(types.VirtualMachineGuestOsFamilyLinuxGuest)) {
+		} else if strings.EqualFold(string(o.Guest.GuestFamily), string(types.VirtualMachineGuestOsFamilyLinuxGuest)) {
 			ostype = constants.OSFamilyLinux
 		} else {
 			return VMInfo{}, fmt.Errorf("no OS type provided and unable to determine OS type")
@@ -367,10 +367,10 @@ func (vmops *VMOps) UpdateDiskInfo(vminfo *VMInfo, disk VMDisk, blockCopySuccess
 				}
 				vminfo.VMDisks[idx].SnapBackingDisk = snapbackingdisk[idx]
 				vminfo.VMDisks[idx].Snapname = snapname[idx]
-				log.Println(fmt.Sprintf("Updated disk info for %s", disk.Name))
-				log.Println(fmt.Sprintf("Snapshot backing disk: %s", snapbackingdisk[idx]))
-				log.Println(fmt.Sprintf("Snapshot name: %s", snapname[idx]))
-				log.Println(fmt.Sprintf("Change ID: %s", snapid[idx]))
+				log.Printf("Updated disk info for %s", disk.Name)
+				log.Printf("Snapshot backing disk: %s", snapbackingdisk[idx])
+				log.Printf("Snapshot name: %s", snapname[idx])
+				log.Printf("Change ID: %s", snapid[idx])
 				break
 			}
 		}

--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -17,8 +17,8 @@ import (
 	"github.com/platform9/vjailbreak/v2v-helper/pkg/k8sutils"
 	"github.com/platform9/vjailbreak/v2v-helper/pkg/utils"
 	"github.com/platform9/vjailbreak/v2v-helper/vcenter"
-
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -294,6 +294,7 @@ func (vmops *VMOps) UpdateDisksInfo(vminfo *VMInfo) error {
 			return fmt.Errorf("failed to refresh VM reference: %s", err)
 		}
 		vm = vmops.VMObj
+		pc = property.DefaultCollector(vmops.vcclient.VCClient)
 		err = vm.Properties(vmops.ctx, vm.Reference(), []string{}, &o)
 		if err != nil {
 			return fmt.Errorf("failed to get VM properties: %s", err)
@@ -356,6 +357,7 @@ func (vmops *VMOps) UpdateDiskInfo(vminfo *VMInfo, disk VMDisk, blockCopySuccess
 			return fmt.Errorf("failed to refresh VM reference: %s", err)
 		}
 		vm = vmops.VMObj
+		pc = property.DefaultCollector(vmops.vcclient.VCClient)
 		err = vm.Properties(vmops.ctx, vm.Reference(), []string{}, &o)
 		if err != nil {
 			return fmt.Errorf("failed to get VM properties: %s", err)

--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -153,10 +153,8 @@ func (vmops *VMOps) RefreshVM() error {
 }
 
 func (vmops *VMOps) GetVMInfo(ostype string) (VMInfo, error) {
-	// Get a fresh VM object using the current authenticated client to ensure we have valid session
 	vm := vmops.VMObj
 
-	// Use the refreshed VM object with current authentication
 	var o mo.VirtualMachine
 	err := vm.Properties(vmops.ctx, vm.Reference(), []string{}, &o)
 	if err != nil {
@@ -286,7 +284,6 @@ func (vmops *VMOps) UpdateDisksInfo(vminfo *VMInfo) error {
 
 	vm := vmops.VMObj
 
-	// Use the refreshed VM object with current authentication
 	var o mo.VirtualMachine
 	err := vm.Properties(vmops.ctx, vm.Reference(), []string{}, &o)
 	if err != nil {
@@ -348,7 +345,7 @@ func (vmops *VMOps) UpdateDiskInfo(vminfo *VMInfo, disk VMDisk, blockCopySuccess
 	var snapid []string
 
 	vm := vmops.VMObj
-	// Use the refreshed VM object with current authentication
+
 	var o mo.VirtualMachine
 	err := vm.Properties(vmops.ctx, vm.Reference(), []string{}, &o)
 	if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #784 

## Special notes for your reviewer


## Testing done
Field tested

 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request addresses critical issues across migration, VCenter, and VM management modules by fixing VM session handling, ensuring fresh VM references for re-authentication, standardizing error messaging, and improving reliability of VM operations. The changes support new govomi client requirements by updating import statements and introducing property collector initialization while avoiding stale VM references.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 3
-->
</div>