### PR TITLE
equate mac id case insensitive

### DIFF
--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -194,7 +194,7 @@ func (vmops *VMOps) GetVMInfo(ostype string) (VMInfo, error) {
 		if vmwareMachine.Spec.VMInfo.GuestNetworks != nil {
 			for _, guestNetwork := range vmwareMachine.Spec.VMInfo.GuestNetworks {
 				// Every mac should have a corresponding IP, Ignore link layer ip
-				if guestNetwork.MAC == macAddresss && !strings.Contains(guestNetwork.IP, ":") {
+				if strings.EqualFold(guestNetwork.MAC, macAddresss) && !strings.Contains(guestNetwork.IP, ":") {
 					ips = append(ips, guestNetwork.IP)
 				}
 			}


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #856 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances CRD definitions by standardizing status configurations across migration plan YAML files. It fixes a bug in vmops.go by implementing case-insensitive MAC address comparison, preventing mismatches caused by letter casing differences. These changes improve system reliability and operational consistency.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>