### PR TITLE
Fix admin cutover

### DIFF
--- a/k8s/migration/internal/controller/migration_controller.go
+++ b/k8s/migration/internal/controller/migration_controller.go
@@ -132,8 +132,8 @@ func (r *MigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
+	ctxlog.Info("Updating migration spec podref", "migration", migration.Name, "podRef", migration.Spec.PodRef)
 	if migration.Spec.PodRef != pod.Name {
-		ctxlog.Info("Updating migration spec podref", "migration", migration.Name, "podRef", migration.Spec.PodRef)
 		migration.Spec.PodRef = pod.Name
 		if err := r.Update(ctx, migration); err != nil {
 			return ctrl.Result{}, err

--- a/k8s/migration/internal/controller/migration_controller.go
+++ b/k8s/migration/internal/controller/migration_controller.go
@@ -126,10 +126,18 @@ func (r *MigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	pod, err := r.GetPod(ctx, migrationScope)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			ctxlog.Info("Migration pod not found yet, requeuing.")
+			ctxlog.Info("Migration pod not found yet, requeuing", "migration", migration.Name)
 			return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	if migration.Spec.PodRef != pod.Name {
+		ctxlog.Info("Updating migration spec podref", "migration", migration.Name, "podRef", migration.Spec.PodRef)
+		migration.Spec.PodRef = pod.Name
+		if err := r.Update(ctx, migration); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	pod.Labels["startCutover"] = utils.SetCutoverLabel(migration.Spec.InitiateCutover, pod.Labels["startCutover"])
@@ -394,6 +402,5 @@ func (r *MigrationReconciler) GetPod(ctx context.Context, scope *scope.Migration
 	if len(podList.Items) == 0 {
 		return nil, apierrors.NewNotFound(corev1.Resource("pods"), fmt.Sprintf("migration pod not found for vm %s", migration.Spec.VMName))
 	}
-	scope.Migration.Spec.PodRef = podList.Items[0].Name
 	return &podList.Items[0], nil
 }

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -481,7 +481,6 @@ func (r *MigrationPlanReconciler) CreateMigration(ctx context.Context,
 				MigrationPlan: migrationplan.Name,
 				VMName:        vm,
 				// PodRef will be set in the migration controller
-				PodRef:                  fmt.Sprintf("v2v-helper-%s", vmk8sname),
 				InitiateCutover:         migrationplan.Spec.MigrationStrategy.AdminInitiatedCutOver,
 				DisconnectSourceNetwork: migrationplan.Spec.MigrationStrategy.DisconnectSourceNetwork,
 				UseFlavorless:           migrationplan.Spec.UseFlavorless,

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -1540,7 +1540,7 @@ func processSingleVM(ctx context.Context, scope *scope.VMwareCredsScope, vm *obj
 		}
 	}
 
-	if guestNetworksFromVmware != nil {
+	if len(guestNetworksFromVmware) > 0 {
 		// Extract IP addresses from guest networks and set it in network interfaces
 		for i, nic := range nicList {
 			for _, guestNet := range guestNetworksFromVmware {

--- a/v2v-helper/main.go
+++ b/v2v-helper/main.go
@@ -143,6 +143,7 @@ func main() {
 		SecurityGroups:         utils.RemoveEmptyStrings(strings.Split(migrationparams.SecurityGroups, ",")),
 		UseFlavorless:          os.Getenv("USE_FLAVORLESS") == "true",
 		TenantName:             openstackProjectName,
+		Reporter:               eventReporter,
 	}
 
 	if err := migrationobj.MigrateVM(ctx); err != nil {

--- a/v2v-helper/reporter/reporter.go
+++ b/v2v-helper/reporter/reporter.go
@@ -26,6 +26,7 @@ type ReporterOps interface {
 	UpdatePodEvents(ch <-chan string)
 	GetCutoverLabel() (string, error)
 	WatchPodLabels(ctx context.Context, ch chan<- string) error
+	GetPodLabels() (map[string]string, error)
 }
 
 type Reporter struct {

--- a/v2v-helper/reporter/reporter.go
+++ b/v2v-helper/reporter/reporter.go
@@ -26,7 +26,6 @@ type ReporterOps interface {
 	UpdatePodEvents(ch <-chan string)
 	GetCutoverLabel() (string, error)
 	WatchPodLabels(ctx context.Context, ch chan<- string) error
-	GetPodLabels() (map[string]string, error)
 }
 
 type Reporter struct {


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #859 

## Special notes for your reviewer


## Testing done
<img width="1130" height="656" alt="image" src="https://github.com/user-attachments/assets/69c721e6-c1a1-4a22-ad0d-5ca0d5f5a153" />
<img width="1086" height="620" alt="image" src="https://github.com/user-attachments/assets/b331879f-8fde-42f2-b711-fcacfa3ca75b" />

All these were done using admin cutover. 
_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request refines the migration process by addressing pod reference updates, admin cutover logic, and error reporting. It enhances the migration controller's logging and state handling, integrates a Reporter component for proper assessments, and prevents further disk copying when an admin cutover is initiated. The changes also include renaming functions, revising error conditions, and improving traceability for safer transitions. Additionally, it fixes a critical bug in guest network validation logic by updating the condition to check for network length rather than using a nil check.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>