### PR TITLE
tls: remove cert trust logic, rely on OS_INSECURE for skipping verification

### DIFF
--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -4,7 +4,6 @@ package utils
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"math"
 	"net/http"
@@ -148,30 +147,6 @@ func GetOpenstackCredentialsFromSecret(ctx context.Context, k3sclient client.Cli
 		TenantName: fields["TenantName"],
 		Insecure:   insecure,
 	}, nil
-}
-
-// GetCert retrieves an X.509 certificate from an endpoint
-func GetCert(endpoint string) (*x509.Certificate, error) {
-	conf := &tls.Config{
-		//nolint:gosec // This is required to skip certificate verification
-		InsecureSkipVerify: true,
-	}
-	parsedURL, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing URL")
-	}
-	hostname := parsedURL.Hostname()
-	conn, err := tls.Dial("tcp", hostname+":443", conf)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error connecting to %s", hostname)
-	}
-	defer func() {
-		if err := conn.Close(); err != nil {
-			log.Log.Info("Error closing connection", "error", err)
-		}
-	}()
-	cert := conn.ConnectionState().PeerCertificates[0]
-	return cert, nil
 }
 
 // VerifyNetworks verifies the existence of specified networks in OpenStack
@@ -429,21 +404,7 @@ func ValidateAndGetProviderClient(ctx context.Context, k3sclient client.Client,
 	if openstackCredential.Insecure {
 		tlsConfig.InsecureSkipVerify = true
 	} else {
-		// Get the certificate for the Openstack endpoint
-		caCert, certerr := GetCert(openstackCredential.AuthURL)
-		if certerr != nil {
-			return nil, errors.Wrap(certerr, "failed to get certificate for openstack")
-		}
-		// Trying to fetch the system cert pool and add the Openstack certificate to it
-		caCertPool, err := x509.SystemCertPool()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get system cert pool: %w", err)
-		}
-		if caCertPool == nil {
-			caCertPool = x509.NewCertPool()
-		}
-		caCertPool.AddCert(caCert)
-		tlsConfig.RootCAs = caCertPool
+		fmt.Printf("Warning: TLS verification is enforced by default. If you encounter certificate errors, set OS_INSECURE=true to skip verification.\n")
 	}
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,

--- a/ui/src/features/migration/RollingMigrationForm.tsx
+++ b/ui/src/features/migration/RollingMigrationForm.tsx
@@ -615,7 +615,7 @@ export default function RollingMigrationFormDrawer({
                     return {
                         authUrl: secret.data.OS_AUTH_URL || '',
                         domainName: secret.data.OS_DOMAIN_NAME || 'default',
-                        insecure: secret.data.OS_INSECURE === 'true' || true,
+                        insecure: (secret.data?.OS_INSECURE || '').trim() === 'true',
                         password: secret.data.OS_PASSWORD || '',
                         regionName: secret.data.OS_REGION_NAME || '',
                         tenantName: secret.data.OS_TENANT_NAME || '',


### PR DESCRIPTION
Previously, OpenStack connections trusted any certificate the endpoint presented, while PCD required explicit insecure configuration. Trusting all certificates by default is inconsistent and insecure.

This change removes the default certificate trust logic and makes the behavior consistent with PCD: TLS verification is enforced unless OS_INSECURE is set. This had previously caused failures in PCD operations like fetching host. 

UI:
- Added "Allow insecure TLS" toggle in OpenStack credentials drawer.
- Toggle reads OS_INSECURE values from rc file and skips TLS verification accordingly.
- Allows working with insecure endpoints and self-signed certs.

Test plan:
- Launched UI with and without OS_INSECURE in rc file.
- Verified toggle sends OS_INSECURE=true in POST body when enabled.
- Confirmed disabling the toggle causes SSL verification errors.
- Validated connections succeed only when insecure toggle is enabled.
- All the tests have been done against a PCD CE installation, and one migration was tested as well.

<img width="765" height="352" alt="Insecure_toggle" src="https://github.com/user-attachments/assets/6537d313-8304-42cb-ae76-6459659e0c95" /> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request refactors TLS verification logic across components, removing legacy certificate trust mechanisms. The changes enhance security consistency for OpenStack integrations by adding a new toggle in the credentials drawer for insecure TLS modes. However, the implementation introduces critical breaking changes in SSL certificate validation defaults.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>