### PR TITLE
fetch rpm from main

### DIFF
--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -27,12 +27,12 @@ FROM fedora:42
 
 WORKDIR /tmp/rpms
 
-RUN curl -L -o nbdkit.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/private/main/nbd-version-lock/assets/rpms/nbdkit-1.42.4-1.fc42.x86_64.rpm && \
-    curl -L -o nbdkit-vddk.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/private/main/nbd-version-lock/assets/rpms/nbdkit-vddk-plugin-1.42.4-1.fc42.x86_64.rpm && \
-    curl -L -o libnbd.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/private/main/nbd-version-lock/assets/rpms/libnbd-1.22.2-1.fc42.x86_64.rpm && \
-    curl -L -o nbdkit-server.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/private/main/nbd-version-lock/assets/rpms/nbdkit-server-1.42.4-1.fc42.x86_64.rpm && \
-    curl -L -o nbdkit-basic-plugins.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/private/main/nbd-version-lock/assets/rpms/nbdkit-basic-plugins-1.42.4-1.fc42.x86_64.rpm && \
-    curl -L -o nbdkit-basic-filters.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/private/main/nbd-version-lock/assets/rpms/nbdkit-basic-filters-1.42.4-1.fc42.x86_64.rpm && \
+RUN curl -L -o nbdkit.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/main/assets/rpms/nbdkit-1.42.4-1.fc42.x86_64.rpm && \
+    curl -L -o nbdkit-vddk.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/main/assets/rpms/nbdkit-vddk-plugin-1.42.4-1.fc42.x86_64.rpm && \
+    curl -L -o libnbd.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/main/assets/rpms/libnbd-1.22.2-1.fc42.x86_64.rpm && \
+    curl -L -o nbdkit-server.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/main/assets/rpms/nbdkit-server-1.42.4-1.fc42.x86_64.rpm && \
+    curl -L -o nbdkit-basic-plugins.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/main/assets/rpms/nbdkit-basic-plugins-1.42.4-1.fc42.x86_64.rpm && \
+    curl -L -o nbdkit-basic-filters.rpm https://github.com/platform9/vjailbreak/raw/refs/heads/main/assets/rpms/nbdkit-basic-filters-1.42.4-1.fc42.x86_64.rpm && \
     dnf install -y ./*.rpm && \
     dnf clean all && \
     rm -rf /tmp/rpms


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #869 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR updates the Dockerfile in v2v-helper to fetch RPM packages from the main branch instead of a private branch. The changes modify curl commands for downloading RPMs, ensuring correct package retrieval during builds. These updates improve dependency management and fix source misconfigurations, enhancing Docker build workflow reliability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>