### PR TITLE
admin cut over poweroff sequence prevent user error

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -342,7 +342,6 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 				if err != nil {
 					return vminfo, errors.Wrap(err, "failed to power off VM")
 				}
-				final = true
 			}
 		} else {
 			migration_snapshot, err := vmops.GetSnapshot(constants.MigrationSnapshotName)

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -266,7 +266,7 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 	envPassword := migobj.Password
 	thumbprint := migobj.Thumbprint
 
-	if migobj.MigrationType == "cold" {
+	if migobj.MigrationType == "cold" && !migobj.CheckIfAdminCutoverSelected() {
 		if err := vmops.VMPowerOff(); err != nil {
 			return vminfo, errors.Wrap(err, "failed to power off VM")
 		}


### PR DESCRIPTION
## What this PR does / why we need it

There is a situation where even though AdminCutOver option is selected, the VM gets powered off even before triggering cutOver.
This can happen when user has explicitly selected "cold" migration (power off live VM, then copy) in combination with AdminCutOver.
For cold migration, vjailbreak will power off the VM even before copy starts.
In such situation IMO we should assume that if "AdminCutOver" is selected, the expectation is "hot" migration (copy live VM, then power off)

In short, AdminCutOver takes precedence over "cold" migration

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #887 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR improves VM migration by updating the logic for powering off VMs during cold migration. It prevents accidental VM shutdowns during administrative cutover and removes a redundant flag, enhancing the overall reliability of the migration sequence.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>