### PR TITLE
bugfix: Add logic to assign IP from network interfaces if not already…

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -838,7 +838,14 @@ func (migobj *Migrate) CreateTargetInstance(vminfo vm.VMInfo) error {
 			} else {
 				ip = vminfo.IPs[idx]
 			}
-
+			if ip == "" {
+				for _, nic := range vminfo.NetworkInterfaces {
+					if nic.MAC == vminfo.Mac[idx] {
+						ip = nic.IPAddress
+						break
+					}
+				}
+			}
 			if migobj.AssignedIP != "" {
 				ip = migobj.AssignedIP
 			}

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -838,7 +838,7 @@ func (migobj *Migrate) CreateTargetInstance(vminfo vm.VMInfo) error {
 			} else {
 				ip = vminfo.IPs[idx]
 			}
-			if ip == "" {
+			if ip == "" && vminfo.NetworkInterfaces != nil {
 				for _, nic := range vminfo.NetworkInterfaces {
 					if nic.MAC == vminfo.Mac[idx] {
 						ip = nic.IPAddress


### PR DESCRIPTION
… set

## What this PR does / why we need it
During Windows VM migration, out of three NICs, two had the ipAddress field populated in the VMware machine’s network interfaces. However, these addresses were not passed to the v2vhelper pod, which defaulted to using DHCP for IP allocation instead of the statically assigned addresses.

Fix: Added logic to pick and assign the IP from the network interfaces when available, ensuring static IPs are used instead of relying on DHCP.

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #894 

## Special notes for your reviewer


## Testing done
Verified , that Ipaddress is passed to v2vhelper pod 

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes a critical bug in Windows VM migration by implementing proper IP assignment. It adds logic to retrieve missing IPs from network interfaces, ensuring static IPs are used instead of defaulting to DHCP. The solution verifies network interface availability before IP assignment, matching MAC addresses with appropriate IP addresses. This enhancement improves network reliability during migrations and successfully passes the IP to the v2vhelper pod.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>