### PR TITLE
remove --delete to not purge each others logs in master

### DIFF
--- a/image_builder/configs/daemonset.yaml
+++ b/image_builder/configs/daemonset.yaml
@@ -103,8 +103,8 @@ spec:
                   echo "Syncing from rsync://${MASTER_IP}"
                   rsync -avz rsync://${MASTER_IP}/vmwarelib/ /home/ubuntu/vmware-vix-disklib-distrib/
 
-                  # Sync logs from worker to master (with delete flag to sync deletions too)
-                  rsync -avz --delete /var/log/pf9 rsync://${MASTER_IP}/worker-logs
+                  # Sync logs from worker to master
+                  rsync -avz  /var/log/pf9 rsync://${MASTER_IP}/worker-logs
 
                   # Sync virtio-win drivers from master to worker
                   rsync -avz rsync://${MASTER_IP}/virtio-win /home/ubuntu/virtio-win


### PR DESCRIPTION
## What this PR does / why we need it.
Currently, the rsync command within the worker node's sync container uses the --delete flag. When multiple worker nodes are running, this creates a destructive race condition:

Each worker node attempts to make the shared log directory on the master an exact mirror of its own local log directory.

Since a worker only has its own logs locally, it perceives the logs from all other workers on the master as "extraneous" and deletes them.

This results in a "last writer wins" scenario, where workers continuously purge each other's logs from the master, leading to data loss.

The Solution:
This change removes the --delete flag from the rsync command.

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #893 

## Special notes for your reviewer


## Testing done
Before the fix:
1. Before scaling up the logs used to persisit:
<img width="1632" height="338" alt="image" src="https://github.com/user-attachments/assets/468f58b7-4579-4fc3-ba41-8ae8bf2dabdd" />

2. After scaling up:
<img width="881" height="258" alt="image" src="https://github.com/user-attachments/assets/73ffaaed-b703-4d33-8201-2cc7bc0c861d" />
logs are vanishing.

After the fix:
1. before scale up:
<img width="948" height="155" alt="image" src="https://github.com/user-attachments/assets/079f289b-3f1a-4eb2-b14c-d960a3944a77" />
2. after scale up:
<img width="1248" height="301" alt="image" src="https://github.com/user-attachments/assets/d3039bbe-8e55-442c-882a-f37d35a5d9c5" />
logs are present. 



_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes a critical log synchronization issue by removing the --delete flag from rsync commands. This change prevents accidental deletion of logs on the master server when multiple workers attempt concurrent updates, eliminating a race condition that was causing data loss.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>