### PR TITLE
configure maxConcurrentReconciles via config map

### DIFF
--- a/image_builder/configs/vjailbreak-settings.yaml
+++ b/image_builder/configs/vjailbreak-settings.yaml
@@ -11,3 +11,4 @@ data:
   VCENTER_SCAN_CONCURRENCY_LIMIT: "10" # max number of vms to scan at the same time
   CLEANUP_VOLUMES_AFTER_CONVERT_FAILURE: "false" # cleanup volumes after disk convert failure
   POPULATE_VMWARE_MACHINE_FLAVORS: "true" # automatically populate VMwareMachine objects with OpenStack flavors
+  MAX_CONCURRENT_RECONCILES: "5" # max number of concurrent reconciles for controllers

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationplans.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationplans.yaml
@@ -70,6 +70,8 @@ spec:
                       type: string
                     type: array
                 type: object
+              fallbackToDHCP:
+                type: boolean
               firstBootScript:
                 default: echo "Add your startup script here!"
                 type: string

--- a/v2v-helper/pkg/constants/constants.go
+++ b/v2v-helper/pkg/constants/constants.go
@@ -133,4 +133,7 @@ echo "$(date '+%Y-%m-%d %H:%M:%S') - Network fix script completed" >> "$LOG_FILE
 
 	// VjailbreakSettingsConfigMapName is the name of the vjailbreak settings configmap
 	VjailbreakSettingsConfigMapName = "vjailbreak-settings"
+
+	// MaxConcurrentReconciles is the default value for max concurrent reconciles for controllers
+	MaxConcurrentReconciles = 5
 )

--- a/v2v-helper/pkg/utils/types.go
+++ b/v2v-helper/pkg/utils/types.go
@@ -10,4 +10,5 @@ type VjailbreakSettings struct {
 	PopulateVMwareMachineFlavors        bool
 	VolumeAvailableWaitIntervalSeconds  int
 	VolumeAvailableWaitRetryLimit       int
+	MaxConcurrentReconciles             int
 }

--- a/v2v-helper/pkg/utils/utils.go
+++ b/v2v-helper/pkg/utils/utils.go
@@ -133,6 +133,7 @@ func GetVjailbreakSettings(ctx context.Context, k8sClient client.Client) (*Vjail
 			PopulateVMwareMachineFlavors:        constants.PopulateVMwareMachineFlavors,
 			VolumeAvailableWaitIntervalSeconds:  constants.VolumeAvailableWaitIntervalSeconds,
 			VolumeAvailableWaitRetryLimit:       constants.VolumeAvailableWaitRetryLimit,
+			MaxConcurrentReconciles:             constants.MaxConcurrentReconciles,
 		}, nil
 	}
 
@@ -171,6 +172,9 @@ func GetVjailbreakSettings(ctx context.Context, k8sClient client.Client) (*Vjail
 	if vjailbreakSettingsCM.Data["POPULATE_VMWARE_MACHINE_FLAVORS"] == "" {
 		vjailbreakSettingsCM.Data["POPULATE_VMWARE_MACHINE_FLAVORS"] = strconv.FormatBool(constants.PopulateVMwareMachineFlavors)
 	}
+	if vjailbreakSettingsCM.Data["MAX_CONCURRENT_RECONCILES"] == "" {
+		vjailbreakSettingsCM.Data["MAX_CONCURRENT_RECONCILES"] = strconv.Itoa(constants.MaxConcurrentReconciles)
+	}
 
 	return &VjailbreakSettings{
 		ChangedBlocksCopyIterationThreshold: atoi(vjailbreakSettingsCM.Data["CHANGED_BLOCKS_COPY_ITERATION_THRESHOLD"]),
@@ -182,5 +186,6 @@ func GetVjailbreakSettings(ctx context.Context, k8sClient client.Client) (*Vjail
 		VCenterScanConcurrencyLimit:         atoi(vjailbreakSettingsCM.Data["VCENTER_SCAN_CONCURRENCY_LIMIT"]),
 		CleanupVolumesAfterConvertFailure:   vjailbreakSettingsCM.Data["CLEANUP_VOLUMES_AFTER_CONVERT_FAILURE"] == "true",
 		PopulateVMwareMachineFlavors:        vjailbreakSettingsCM.Data["POPULATE_VMWARE_MACHINE_FLAVORS"] == "true",
+		MaxConcurrentReconciles:             atoi(vjailbreakSettingsCM.Data["MAX_CONCURRENT_RECONCILES"]),
 	}, nil
 }


### PR DESCRIPTION
## What this PR does / why we need it



## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #907 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces the MAX_CONCURRENT_RECONCILES parameter across multiple components to optimize resource utilization. It updates configuration files, Kubernetes controllers, and utility packages to support dynamic concurrency settings, while improving error handling and performance through non-cached API client usage for fetching the latest settings.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>