### PR TITLE
Added option in UI to retry Failed migrations

### DIFF
--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -631,6 +631,9 @@ spec:
               podRef:
                 description: PodRef is the name of the pod
                 type: string
+              retry:
+                description: Retry is the flag to trigger a retry for a failed migration.
+                type: boolean
               vmName:
                 description: VMName is the name of the VM getting migrated from VMWare
                   to Openstack
@@ -3632,7 +3635,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: quay.io/platform9/vjailbreak-controller:v0.3.3
+        image: quay.io/platform9/vjailbreak-controller:v0.3.4
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -3712,7 +3715,7 @@ spec:
         app: vpwned-sdk
     spec:
       containers:
-      - image: quay.io/platform9/vjailbreak-vpwned:v0.3.3
+      - image: quay.io/platform9/vjailbreak-vpwned:v0.3.4
         imagePullPolicy: IfNotPresent
         name: vpwned
         ports:

--- a/deploy/upgrade-all-resources.yaml
+++ b/deploy/upgrade-all-resources.yaml
@@ -631,6 +631,9 @@ spec:
               podRef:
                 description: PodRef is the name of the pod
                 type: string
+              retry:
+                description: Retry is the flag to trigger a retry for a failed migration.
+                type: boolean
               vmName:
                 description: VMName is the name of the VM getting migrated from VMWare
                   to Openstack

--- a/k8s/migration/api/v1alpha1/migration_types.go
+++ b/k8s/migration/api/v1alpha1/migration_types.go
@@ -76,6 +76,9 @@ type MigrationSpec struct {
 	// after a successful migration to prevent network conflicts. Defaults to false.
 	// +optional
 	DisconnectSourceNetwork bool `json:"disconnectSourceNetwork,omitempty"`
+
+	// Retry is the flag to trigger a retry for a failed migration.
+	Retry bool `json:"retry,omitempty"`
 }
 
 // MigrationStatus defines the observed state of Migration

--- a/k8s/migration/config/addons/kustomization.yaml
+++ b/k8s/migration/config/addons/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: vpwned
   newName: quay.io/platform9/vjailbreak-vpwned
-  newTag: v0.3.3
+  newTag: v0.3.4

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrations.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrations.yaml
@@ -69,6 +69,9 @@ spec:
               podRef:
                 description: PodRef is the name of the pod
                 type: string
+              retry:
+                description: Retry is the flag to trigger a retry for a failed migration.
+                type: boolean
               vmName:
                 description: VMName is the name of the VM getting migrated from VMWare
                   to Openstack

--- a/k8s/migration/config/manager/kustomization.yaml
+++ b/k8s/migration/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/platform9/vjailbreak-controller
-  newTag: v0.3.3
+  newTag: v0.3.4

--- a/k8s/migration/internal/controller/migration_controller.go
+++ b/k8s/migration/internal/controller/migration_controller.go
@@ -81,6 +81,15 @@ func (r *MigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
+	if migration.Spec.Retry && migration.Status.Phase == vjailbreakv1alpha1.VMMigrationPhaseFailed {
+		ctxlog.Info("Retry requested for failed migration. Deleting Migration object.", "MigrationName", migration.Name)
+		if err := r.Delete(ctx, migration); err != nil {
+			ctxlog.Error(err, "Failed to delete Migration object for retry")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
 	migrationScope, err := scope.NewMigrationScope(scope.MigrationScopeParams{
 		Logger:    ctxlog,
 		Client:    r.Client,

--- a/k8s/migration/internal/controller/migration_controller.go
+++ b/k8s/migration/internal/controller/migration_controller.go
@@ -219,16 +219,17 @@ func (r *MigrationReconciler) reconcileDelete(ctx context.Context, migration *vj
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			ctxlog.Info("VMwareMachine not found during migration deletion, nothing to do.", "VMwareMachineName", vmwMachineName)
-			return nil
+		} else {
+			ctxlog.Error(err, "Failed to get VMwareMachine for cleanup")
 		}
-		return errors.Wrap(err, "failed to get VMwareMachine for cleanup")
+		return nil
 	}
 
 	if vmwMachine.Status.Migrated {
 		ctxlog.Info("Setting VMwareMachine status.migrated to false", "VMwareMachineName", vmwMachineName)
 		vmwMachine.Status.Migrated = false
 		if err := r.Status().Update(ctx, vmwMachine); err != nil {
-			return errors.Wrap(err, "failed to update VMwareMachine status")
+			ctxlog.Error(err, "Failed to update VMwareMachine status during cleanup")
 		}
 	}
 

--- a/k8s/migration/internal/controller/migration_controller.go
+++ b/k8s/migration/internal/controller/migration_controller.go
@@ -81,8 +81,9 @@ func (r *MigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	if migration.Spec.Retry && migration.Status.Phase == vjailbreakv1alpha1.VMMigrationPhaseFailed {
-		ctxlog.Info("Retry requested for failed migration. Deleting Migration object.", "MigrationName", migration.Name)
+	// Only trigger deletion if a retry is requested AND the object is not already being deleted.
+	if migration.Spec.Retry && migration.Status.Phase == vjailbreakv1alpha1.VMMigrationPhaseFailed && migration.DeletionTimestamp.IsZero() {
+		ctxlog.Info("Retry requested for failed migration. Initiating deletion.", "MigrationName", migration.Name)
 		if err := r.Delete(ctx, migration); err != nil {
 			ctxlog.Error(err, "Failed to delete Migration object for retry")
 			return ctrl.Result{}, err

--- a/ui/src/api/migrations/migrations.ts
+++ b/ui/src/api/migrations/migrations.ts
@@ -119,3 +119,26 @@ export const triggerAdminCutover = async (
     };
   }
 };
+
+export const retryMigration = async (
+  migrationName: string,
+  namespace: string = VJAILBREAK_DEFAULT_NAMESPACE
+): Promise<Migration> => {
+  const endpoint = `${VJAILBREAK_API_BASE_PATH}/namespaces/${namespace}/migrations/${migrationName}`;
+  const patchPayload = {
+    spec: {
+      retry: true,
+    },
+  };
+
+  const response = await axios.patch<Migration>({
+    endpoint,
+    data: patchPayload,
+    config: {
+      headers: {
+        "Content-Type": "application/merge-patch+json",
+      },
+    },
+  });
+  return response;
+};

--- a/ui/src/api/migrations/model.ts
+++ b/ui/src/api/migrations/model.ts
@@ -63,6 +63,7 @@ export interface Spec {
   migrationPlan: MigrationPlan
   podRef: PodRef
   vmName: VMName
+  retry?: boolean
 }
 
 export enum MigrationPlan {

--- a/ui/src/pages/dashboard/MigrationsTable.tsx
+++ b/ui/src/pages/dashboard/MigrationsTable.tsx
@@ -163,7 +163,10 @@ const columns: GridColDef[] = [
                                     handleRetry();
                                 }}
                                 size="small"
-                                color="primary"
+                                sx={{
+                                cursor: 'pointer',
+                                position: 'relative'
+                            }}
                             >
                                 <ReplayIcon />
                             </IconButton>


### PR DESCRIPTION
## What this PR does / why we need it

This PR introduces a retry mechanism for failed migrations, adding a "Retry" button to the UI. When a migration fails due to an issue like an IP conflict, users can now resolve the external problem and restart the process with a single click. This avoids the need to create an entirely new migration plan, improving the overall user workflow.

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #612 

## Special notes for your reviewer


## Testing done
<img width="2880" height="1498" alt="image" src="https://github.com/user-attachments/assets/fce3a40f-40bf-4278-a710-46956f63f7ef" />