### PR TITLE
disabled docs update workflow to run on release event

### DIFF
--- a/.github/workflows/deploy_gh_page.yaml
+++ b/.github/workflows/deploy_gh_page.yaml
@@ -2,12 +2,10 @@ name: Deploy Docs & API Documentation
 
 
 on:
-  # Trigger the workflow every time you push to the `main` branch
-  # Using a different branch name? Replace `main` with your branch’s name
+  # Trigger the workflow every time you push to the `gh-pages` branch
+  # Using a different branch name? Replace `gh-pages` with your branch’s name
   push:
     branches: [ gh-pages ]
-    tags:
-      - 'v*'
   # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What this PR does / why we need it

This PR removes the tags trigger from the docs deployment workflow. This prevents the workflow from incorrectly running and failing every time a new release is created.

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #936 


## Testing done

workflows ran on creating release before:
<img width="1059" height="233" alt="image" src="https://github.com/user-attachments/assets/7b2c2f22-2420-4c67-a60f-eac7c0d05713" />

workflows ran on creating release after:
<img width="1054" height="224" alt="image" src="https://github.com/user-attachments/assets/ae87199e-5fa7-4e6d-ab9f-1256d4bb2385" />
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR updates the deployment workflow by changing the trigger from 'main' to 'gh-pages' branch and removing tag triggers. The changes aim to prevent workflow execution during releases, improving the stability of the automated release process and addressing configuration errors that caused failures.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>