### PR TITLE
Bugfix: Added vmwaresession logged out, after retrieving data from vmware

### DIFF
--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -101,7 +101,11 @@ func (r *VMwareCredsReconciler) reconcileNormal(ctx context.Context, scope *scop
 	}
 	if c != nil {
 		defer c.CloseIdleConnections()
-		defer utils.LogoutVMwareClient(ctx, r.Client, scope.VMwareCreds, c)
+		defer func() {
+			if err := utils.LogoutVMwareClient(ctx, r.Client, scope.VMwareCreds, c); err != nil {
+				ctxlog.Error(err, "Failed to logout VMware client")
+			}
+		}()
 	}
 	ctxlog.Info(fmt.Sprintf("Successfully authenticated to VMware '%s'", scope.Name()))
 	// Update the status of the VMwareCreds object

--- a/k8s/migration/pkg/utils/maintenance_mode.go
+++ b/k8s/migration/pkg/utils/maintenance_mode.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -22,6 +23,8 @@ import (
 // CanEnterMaintenanceMode checks if an ESXi host can successfully enter maintenance mode
 // with all VMs automatically migrating off to other hosts. It checks host, VM, and cluster
 // settings that could block automatic VM migration.
+//
+//nolint:gocyclo // reason: function is complex but intentionally so
 func CanEnterMaintenanceMode(ctx context.Context, scope *scope.RollingMigrationPlanScope, vmwcreds *vjailbreakv1alpha1.VMwareCreds, hostName string, config RollingMigartionValidationConfig) (bool, string, error) {
 	// List of VMs that cannot migrate
 	blockedVMs := make([]string, 0)
@@ -33,7 +36,11 @@ func CanEnterMaintenanceMode(ctx context.Context, scope *scope.RollingMigrationP
 	}
 	if c != nil {
 		defer c.CloseIdleConnections()
-		defer LogoutVMwareClient(ctx, k8sClient, vmwcreds, c)
+		defer func() {
+			if err := LogoutVMwareClient(ctx, k8sClient, vmwcreds, c); err != nil {
+				log.FromContext(ctx).Error(err, "Failed to logout VMware client")
+			}
+		}()
 	}
 	// Create a finder to locate objects
 	finder := find.NewFinder(c, true)
@@ -183,7 +190,10 @@ func GetMaintenanceModeOptions(ctx context.Context, k8sClient client.Client, vmw
 	if c != nil {
 		defer c.CloseIdleConnections()
 		defer func() {
-			LogoutVMwareClient(ctx, k8sClient, vmwcreds, c)
+			if err := LogoutVMwareClient(ctx, k8sClient, vmwcreds, c); err != nil {
+				// Log error but don't return it since this is a cleanup operation
+				log.FromContext(ctx).Error(err, "Failed to logout VMware client")
+			}
 		}()
 	}
 	// Create a finder to locate objects

--- a/k8s/migration/pkg/utils/rollingmigrationutils.go
+++ b/k8s/migration/pkg/utils/rollingmigrationutils.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // CreateClusterMigration creates a new ClusterMigration object from the given cluster info and rolling migration plan
@@ -224,7 +225,11 @@ func GetESXiHostSystem(ctx context.Context, k8sClient client.Client, esxiName st
 	}
 	if c != nil {
 		defer c.CloseIdleConnections()
-		defer LogoutVMwareClient(ctx, k8sClient, vmwarecreds, c)
+		defer func() {
+			if err := LogoutVMwareClient(ctx, k8sClient, vmwarecreds, c); err != nil {
+				log.FromContext(ctx).Error(err, "Failed to logout VMware client")
+			}
+		}()
 	}
 	finder := find.NewFinder(c, false)
 	dc, err := finder.Datacenter(ctx, vmwarecreds.Spec.DataCenter)


### PR DESCRIPTION
## What this PR does / why we need it

- Added Logout API call after VMware-related tasks are done.
- Ensured session cleanup occurs even on error paths to avoid leaks.


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #938 

## Special notes for your reviewer


## Testing done

Tested no of active sessions of vmware started reducing

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request addresses critical bugs in VMware session management by implementing standardized logout calls to prevent session leaks. It fixes improper client caching that breaks authentication, premature client logout, and inconsistent cleanup patterns. The changes introduce deferred functions to capture logout errors and a consistent SDK path constant for better URL management, improving code clarity and reliability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>