### PR TITLE
Added filter on migrations based on current status and current creation time 

### DIFF
--- a/ui/src/components/grid/CustomSearchToolbar.tsx
+++ b/ui/src/components/grid/CustomSearchToolbar.tsx
@@ -1,6 +1,6 @@
 import { Box, IconButton, Tooltip, Typography, Menu, MenuItem } from "@mui/material"
 import { GridToolbarQuickFilter } from "@mui/x-data-grid"
-import { RefreshRounded, FilterList as FilterListIcon } from "@mui/icons-material"
+import { RefreshRounded, FilterList as FilterListIcon, CalendarToday as CalendarIcon } from "@mui/icons-material"
 import { useState } from "react"
 
 interface CustomSearchToolbarProps {
@@ -8,8 +8,10 @@ interface CustomSearchToolbarProps {
   onRefresh?: () => void;
   disableRefresh?: boolean;
   placeholder?: string;
-  onFilterChange?: (filter: string) => void;
-  currentFilter?: string;
+  onStatusFilterChange?: (filter: string) => void;
+  currentStatusFilter?: string;
+  onDateFilterChange?: (filter: string) => void;
+  currentDateFilter?: string;
 }
 
 const CustomSearchToolbar = ({
@@ -17,26 +19,35 @@ const CustomSearchToolbar = ({
   onRefresh,
   disableRefresh = false,
   placeholder = "Search",
-  onFilterChange,
-  currentFilter = 'All'
+  onStatusFilterChange,
+  currentStatusFilter = 'All',
+  onDateFilterChange,
+  currentDateFilter = 'All Time'
 }: CustomSearchToolbarProps) => {
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const open = Boolean(anchorEl);
+  const [statusAnchorEl, setStatusAnchorEl] = useState<null | HTMLElement>(null);
+  const [dateAnchorEl, setDateAnchorEl] = useState<null | HTMLElement>(null);
+  
+  const statusMenuOpen = Boolean(statusAnchorEl);
+  const dateMenuOpen = Boolean(dateAnchorEl);
 
-  const handleFilterClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
+  const statusFilterOptions = ['All', 'In Progress', 'Succeeded', 'Failed'];
+  const dateFilterOptions = ['All Time', 'Last 24 hours', 'Last 7 days', 'Last 30 days'];
+
+  const handleMenuClick = (event: React.MouseEvent<HTMLElement>, menu: 'status' | 'date') => {
+    if (menu === 'status') setStatusAnchorEl(event.currentTarget);
+    if (menu === 'date') setDateAnchorEl(event.currentTarget);
   };
 
-  const handleFilterClose = () => {
-    setAnchorEl(null);
+  const handleMenuClose = () => {
+    setStatusAnchorEl(null);
+    setDateAnchorEl(null);
   };
 
-  const handleFilterSelect = (filter: string) => {
-    onFilterChange?.(filter);
-    handleFilterClose();
+  const handleFilterSelect = (filter: string, menu: 'status' | 'date') => {
+    if (menu === 'status') onStatusFilterChange?.(filter);
+    if (menu === 'date') onDateFilterChange?.(filter);
+    handleMenuClose();
   };
-
-  const filterOptions = ['All', 'In Progress', 'Succeeded', 'Failed'];
 
   return (
     <Box
@@ -55,32 +66,47 @@ const CustomSearchToolbar = ({
             <Tooltip title="Refresh">
               <span>
                 <IconButton
-                  onClick={onRefresh}
-                  disabled={disableRefresh}
-                  size="small"
+                onClick={onRefresh}
+                disabled={disableRefresh}
+                size="small"
                 >
                   <RefreshRounded />
                 </IconButton>
               </span>
             </Tooltip>
           )}
-          {onFilterChange && (
+          {onDateFilterChange && (
             <>
-              <Tooltip title="Filter">
-                <IconButton onClick={handleFilterClick} size="small">
+              <Tooltip title="Filter by creation date">
+                <IconButton onClick={(e) => handleMenuClick(e, 'date')} size="small">
+                  <CalendarIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Menu anchorEl={dateAnchorEl} open={dateMenuOpen} onClose={handleMenuClose}>
+                {dateFilterOptions.map((option) => (
+                  <MenuItem key={option} selected={option === currentDateFilter} onClick={() => handleFilterSelect(option, 'date')}>
+                    {option}
+                  </MenuItem>
+                ))}
+              </Menu>
+            </>
+          )}
+          {onStatusFilterChange && (
+            <>
+              <Tooltip title="Filter by status">
+                <IconButton onClick={(e) => handleMenuClick(e, 'status')} size="small">
                   <FilterListIcon />
                 </IconButton>
               </Tooltip>
               <Menu
-                anchorEl={anchorEl}
-                open={open}
-                onClose={handleFilterClose}
-              >
-                {filterOptions.map((option) => (
+              anchorEl={statusAnchorEl}
+              open={statusMenuOpen}
+              onClose={handleMenuClose}>
+                {statusFilterOptions.map((option) => (
                   <MenuItem
-                    key={option}
-                    selected={option === currentFilter}
-                    onClick={() => handleFilterSelect(option)}
+                  key={option}
+                  selected={option === currentStatusFilter}
+                  onClick={() => handleFilterSelect(option, 'status')}
                   >
                     {option}
                   </MenuItem>
@@ -96,8 +122,8 @@ const CustomSearchToolbar = ({
               sx={{
                 "& .MuiInputBase-input": {
                   textOverflow: "ellipsis",
-                }
-              }}
+                 }
+                }}
             />
           </div>
         </Box>

--- a/ui/src/components/grid/CustomSearchToolbar.tsx
+++ b/ui/src/components/grid/CustomSearchToolbar.tsx
@@ -1,20 +1,43 @@
-import { Box, IconButton, Tooltip, Typography } from "@mui/material"
+import { Box, IconButton, Tooltip, Typography, Menu, MenuItem } from "@mui/material"
 import { GridToolbarQuickFilter } from "@mui/x-data-grid"
-import { RefreshRounded } from "@mui/icons-material"
+import { RefreshRounded, FilterList as FilterListIcon } from "@mui/icons-material"
+import { useState } from "react"
 
 interface CustomSearchToolbarProps {
   title?: string;
   onRefresh?: () => void;
   disableRefresh?: boolean;
   placeholder?: string;
+  onFilterChange?: (filter: string) => void;
+  currentFilter?: string;
 }
 
 const CustomSearchToolbar = ({
   title,
   onRefresh,
   disableRefresh = false,
-  placeholder = "Search"
+  placeholder = "Search",
+  onFilterChange,
+  currentFilter = 'All'
 }: CustomSearchToolbarProps) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleFilterClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleFilterClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleFilterSelect = (filter: string) => {
+    onFilterChange?.(filter);
+    handleFilterClose();
+  };
+
+  const filterOptions = ['All', 'In Progress', 'Succeeded', 'Failed'];
+
   return (
     <Box
       sx={{
@@ -27,19 +50,45 @@ const CustomSearchToolbar = ({
     >
       {title && <Typography variant="h6">{title}</Typography>}
       <Box sx={{ marginLeft: "auto", display: "flex", gap: 1, alignItems: "center" }}>
-        {onRefresh && (
-          <Tooltip title="Refresh">
-            <span>
-              <IconButton
-                onClick={onRefresh}
-                disabled={disableRefresh}
-                size="small"
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          {onRefresh && (
+            <Tooltip title="Refresh">
+              <span>
+                <IconButton
+                  onClick={onRefresh}
+                  disabled={disableRefresh}
+                  size="small"
+                >
+                  <RefreshRounded />
+                </IconButton>
+              </span>
+            </Tooltip>
+          )}
+          {onFilterChange && (
+            <>
+              <Tooltip title="Filter">
+                <IconButton onClick={handleFilterClick} size="small">
+                  <FilterListIcon />
+                </IconButton>
+              </Tooltip>
+              <Menu
+                anchorEl={anchorEl}
+                open={open}
+                onClose={handleFilterClose}
               >
-                <RefreshRounded />
-              </IconButton>
-            </span>
-          </Tooltip>
-        )}
+                {filterOptions.map((option) => (
+                  <MenuItem
+                    key={option}
+                    selected={option === currentFilter}
+                    onClick={() => handleFilterSelect(option)}
+                  >
+                    {option}
+                  </MenuItem>
+                ))}
+              </Menu>
+            </>
+          )}
+        </Box>
         <Box sx={{ maxWidth: "300px" }}>
           <div>
             <GridToolbarQuickFilter


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds status and date filters to the migrations toolbar to improve usability and help users find migrations more efficiently:

Adds a status filter menu with options: All, In Progress, Succeeded, Failed.
Adds a creation date filter menu with relative ranges: All Time, Last 24 hours, Last 7 days, Last 30 days.


## Which issue(s) this PR fixes

fixes #821 

## Testing done
**Based On Current Status:**
<img width="1440" height="434" alt="image" src="https://github.com/user-attachments/assets/b2b131f7-def2-49d6-b1a9-6f98b8cee415" />
<img width="1440" height="522" alt="image" src="https://github.com/user-attachments/assets/1cb8441e-460a-4e8f-83ec-0b88da04e5ff" />
<img width="1440" height="436" alt="image" src="https://github.com/user-attachments/assets/36020e4c-9ddd-4579-82e6-ea6a744a5a96" />
<img width="1440" height="440" alt="image" src="https://github.com/user-attachments/assets/d4279a97-e9ac-4805-af88-c99a1ceaaf6e" />
<img width="1440" height="413" alt="image" src="https://github.com/user-attachments/assets/9a8f9aed-b8d6-437d-b9f2-1cffd22beb32" />

**Based On Current Time:**
<img width="1440" height="437" alt="image" src="https://github.com/user-attachments/assets/be5c2ea5-4758-46ea-a330-32ec31f04a86" />
<img width="1440" height="454" alt="image" src="https://github.com/user-attachments/assets/982242d0-ec82-42f4-9448-7c110d6572b3" />
<img width="1440" height="483" alt="image" src="https://github.com/user-attachments/assets/ee6a8660-a561-4666-8d1d-9c545fd41e44" />
<img width="1440" height="488" alt="image" src="https://github.com/user-attachments/assets/065124aa-913d-4c2b-8e61-b957940470e3" />
<img width="1440" height="485" alt="image" src="https://github.com/user-attachments/assets/738cbdcb-ca38-4ae5-aa30-eda5971523e6" />
