### PR TITLE
feat: Set owner reference for RDM disks to ensure proper deletion with VMwareCreds

### DIFF
--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -1264,22 +1264,21 @@ func syncRDMDisks(ctx context.Context, k3sclient client.Client, vmwcreds *vjailb
 					}
 				}
 
-    // Ensure owner reference is set to VMwareCreds for existing RDM disks
-    ownerRefExists := false
-    for _, ownerRef := range existingDisk.OwnerReferences {
-        if ownerRef.UID == vmwcreds.UID &&
-            ownerRef.Name == vmwcreds.GetName() &&
-            ownerRef.Kind == "VMwareCreds" &&
-            ownerRef.APIVersion == vmwcreds.GetAPIVersion() {
-            ownerRefExists = true
-            break
-        }
-    }
-    if !ownerRefExists {
-        if err := controllerutil.SetOwnerReference(vmwcreds, &existingDisk, k3sclient.Scheme()); err != nil {
-            return fmt.Errorf("failed to set owner reference on existing RDM disk CR '%s': %w", existingDisk.Name, err)
-        }
-    }
+				// Ensure owner reference is set to VMwareCreds for existing RDM disks
+				ownerRefExists := false
+				for _, ownerRef := range existingDisk.OwnerReferences {
+					if ownerRef.UID == vmwcreds.UID &&
+						ownerRef.Name == vmwcreds.GetName() &&
+						ownerRef.Kind == "VMwareCreds" {
+						ownerRefExists = true
+						break
+					}
+				}
+				if !ownerRefExists {
+					if err := controllerutil.SetOwnerReference(vmwcreds, &existingDisk, k3sclient.Scheme()); err != nil {
+						return fmt.Errorf("failed to set owner reference on existing RDM disk CR '%s': %w", existingDisk.Name, err)
+					}
+				}
 
 				err := k3sclient.Update(ctx, &existingDisk)
 				if err != nil {
@@ -1306,7 +1305,7 @@ func syncRDMDisks(ctx context.Context, k3sclient client.Client, vmwcreds *vjailb
 					OpenstackVolumeRef: rdmInfo[i].Spec.OpenstackVolumeRef,
 				},
 			}
-			
+
 			// Set the owner reference to VMwareCreds so RDM disks are deleted when VMwareCreds is deleted
 			if err := controllerutil.SetOwnerReference(vmwcreds, rdmDiskCR, k3sclient.Scheme()); err != nil {
 				return fmt.Errorf("failed to set owner reference on RDM disk CR '%s': %w", rdmDiskCR.Name, err)


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds owner references to RDM disk

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*


fixes https://github.com/platform9/vjailbreak/issues/966

## Special notes for your reviewer


## Testing done

Deployed vjailbreak

1) Verified creds owner reference is added to rdm disk
2) Verified RDM disk is deleted if VmwareCreds is deleted

<img width="724" height="278" alt="Screenshot from 2025-09-30 17-42-45" src="https://github.com/user-attachments/assets/9e92880c-2b89-4be2-a3d8-bcb1d2ebefda" />


_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances RDM disk management by updating owner reference settings to properly link disks to VMwareCreds. The changes improve conditional checks for UID, Name, Kind, and APIVersion attributes, while refining error handling to provide more detailed feedback. This ensures RDM disks are automatically deleted when their parent VMwareCreds resource is removed, preventing orphaned resources and improving system stability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>