### PR TITLE
Update getting_started.mdx

### DIFF
--- a/docs/src/content/docs/introduction/getting_started.mdx
+++ b/docs/src/content/docs/introduction/getting_started.mdx
@@ -84,9 +84,9 @@ Proper DNS resolution for your VMware and OpenStack URLs is required for vJailbr
   ```
   Once the `/etc/hosts` file is modified execute below commands to apply the changes.
   ```
-  kubectl scale deployment migration-controller-manager -n migration-system --replias=0
+  kubectl scale deployment migration-controller-manager -n migration-system --replicas=0
   # Wait for the `migration-controller-manager-xxx` pod to be terminated. After that scale it back using below command
-  kubectl scale deployment migration-controller-manager -n migration-system --replias=1
+  kubectl scale deployment migration-controller-manager -n migration-system --replicas=1
   ```
 
 - **DNS Configuration**: If modifying `/etc/resolv.conf` to use DNS servers instead of static entries, scale down and up the same `migration-controller-manager` deployment as shown above to apply the changes.

--- a/docs/src/content/docs/introduction/getting_started.mdx
+++ b/docs/src/content/docs/introduction/getting_started.mdx
@@ -84,9 +84,7 @@ Proper DNS resolution for your VMware and OpenStack URLs is required for vJailbr
   ```
   Once the `/etc/hosts` file is modified execute below commands to apply the changes.
   ```
-  kubectl scale deployment migration-controller-manager -n migration-system --replicas=0
-  # Wait for the `migration-controller-manager-xxx` pod to be terminated. After that scale it back using below command
-  kubectl scale deployment migration-controller-manager -n migration-system --replicas=1
+  kubectl -n migration-system rollout restart deployment migration-controller-manager
   ```
 
 - **DNS Configuration**: If modifying `/etc/resolv.conf` to use DNS servers instead of static entries, restart the same `migration-controller-manager` deployment as shown above to apply the changes.

--- a/docs/src/content/docs/introduction/getting_started.mdx
+++ b/docs/src/content/docs/introduction/getting_started.mdx
@@ -89,7 +89,7 @@ Proper DNS resolution for your VMware and OpenStack URLs is required for vJailbr
   kubectl scale deployment migration-controller-manager -n migration-system --replicas=1
   ```
 
-- **DNS Configuration**: If modifying `/etc/resolv.conf` to use DNS servers instead of static entries, scale down and up the same `migration-controller-manager` deployment as shown above to apply the changes.
+- **DNS Configuration**: If modifying `/etc/resolv.conf` to use DNS servers instead of static entries, restart the same `migration-controller-manager` deployment as shown above to apply the changes.
 
 ### Launch vJailbreak
 - Connect to the vJailbreak UI using the IP address assigned during VM creation.

--- a/docs/src/content/docs/introduction/getting_started.mdx
+++ b/docs/src/content/docs/introduction/getting_started.mdx
@@ -72,7 +72,7 @@ Proper DNS resolution for your VMware and OpenStack URLs is required for vJailbr
 **Important:** DNS resolution for all ESXi hosts must be properly configured in your environment. This is specifically required during the VM copy phase of migration. Without proper DNS resolution for ESXi hosts, the migration process may fail.
 
 
-- **Static Entries**: If you didn't configure `/etc/hosts` entries during VM creation with cloud-init, you can add them manually. Changes to `/etc/hosts` apply immediately.
+- **Static Entries**: If you didn't configure `/etc/hosts` entries during VM creation with cloud-init, you can add them manually later.
   ```shell
   # Example manual addition to /etc/hosts
   sudo sh -c 'echo "192.168.1.100 vcenter.example.com" >> /etc/hosts'
@@ -82,12 +82,14 @@ Proper DNS resolution for your VMware and OpenStack URLs is required for vJailbr
   sudo sh -c 'echo "192.168.1.101 esxi01.example.com esxi01" >> /etc/hosts'
   sudo sh -c 'echo "192.168.1.102 esxi02.example.com esxi02" >> /etc/hosts'
   ```
-
-- **DNS Configuration**: If modifying `/etc/resolv.conf` to use DNS servers instead of static entries, you must restart the controller pod for changes to take effect
-  ```shell
-  # After modifying resolv.conf
-  kubectl -n vjailbreak rollout restart deployment migration-controller-manager
+  Once the `/etc/hosts` file is modified execute below commands to apply the changes.
   ```
+  kubectl scale deployment migration-controller-manager -n migration-system --replias=0
+  # Wait for the `migration-controller-manager-xxx` pod to be terminated. After that scale it back using below command
+  kubectl scale deployment migration-controller-manager -n migration-system --replias=1
+  ```
+
+- **DNS Configuration**: If modifying `/etc/resolv.conf` to use DNS servers instead of static entries, scale down and up the same `migration-controller-manager` deployment as shown above to apply the changes.
 
 ### Launch vJailbreak
 - Connect to the vJailbreak UI using the IP address assigned during VM creation.


### PR DESCRIPTION
Updated the steps required to load the changes after modifying `/etc/hosts` and /etc/resolv.conf` files within vJailbreak VM.

## What this PR does / why we need it

At present it is mentioned, changes made to the `/etc/hosts` file gets applied immediately. However user have to scale down and up the `migration-controller-manager` deployment to apply the changes.
The command suggested to run after modifying `/etc/resolv.conf` file is incorrect, correcting that as well via this PR.

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #

## Special notes for your reviewer


## Testing done

Yes, testing is done and accordingly the steps/commands are suggested. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR updates the getting_started documentation to fix typographical errors in kubectl scaling commands (changing '--replias' to '--replicas') and clarifies the process for applying changes to host files and DNS configuration. It improves instructions for adding static entries and provides users with a more accurate sequence of steps to implement configuration updates and prevent migration failures.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>