### PR TITLE
feat: Enhance RDM disk info population by validating disk name before updating volume reference

### DIFF
--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -1371,18 +1371,19 @@ func populateRDMDiskInfoFromAttributes(ctx context.Context, baseRDMDisk vjailbre
 			diskName := strings.TrimSpace(parts[1])
 			key := parts[2]
 			value := parts[3]
-
-			// Update fields only if new value is provided
-			if strings.TrimSpace(key) == "volumeRef" && value != "" {
-				splotVolRef := strings.Split(value, "=")
-				if len(splotVolRef) != 2 {
-					return vjailbreakv1alpha1.RDMDisk{}, fmt.Errorf("invalid volume reference format: %s", baseRDMDisk.Spec.OpenstackVolumeRef)
-				}
-				mp := make(map[string]string)
-				mp[splotVolRef[0]] = splotVolRef[1]
-				log.Info("Setting OpenStack Volume Ref for RDM disk:", diskName, "to")
-				baseRDMDisk.Spec.OpenstackVolumeRef = vjailbreakv1alpha1.OpenstackVolumeRef{
-					VolumeRef: mp,
+			if strings.TrimSpace(baseRDMDisk.Spec.DiskName) == diskName {
+				// Update fields only if new value is provided
+				if strings.TrimSpace(key) == "volumeRef" && value != "" {
+					splitVolRef := strings.Split(value, "=")
+					if len(splitVolRef) != 2 {
+						return vjailbreakv1alpha1.RDMDisk{}, fmt.Errorf("invalid volume reference format: %s", baseRDMDisk.Spec.OpenstackVolumeRef)
+					}
+					mp := make(map[string]string)
+					mp[splitVolRef[0]] = splitVolRef[1]
+					log.Info("Setting OpenStack Volume Ref for RDM disk:", diskName, "to", "value: ", mp, "owner VMs: ", baseRDMDisk.Spec.OwnerVMs)
+					baseRDMDisk.Spec.OpenstackVolumeRef = vjailbreakv1alpha1.OpenstackVolumeRef{
+						VolumeRef: mp,
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## What this PR does / why we need it

Change is to add disk name check before updating annotation reference to fix incorrect annotation updation when more than one RDM disk is in cluster 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #983 

## Special notes for your reviewer


## Testing done

<img width="1085" height="604" alt="Screenshot from 2025-10-07 22-30-17" src="https://github.com/user-attachments/assets/d0eb9a31-3ab0-4c92-b803-61a368ed0989" />


<img width="1811" height="1029" alt="Screenshot from 2025-10-07 20-40-12" src="https://github.com/user-attachments/assets/2e863027-a3c8-4f4c-a2ef-b5d48feb559b" />


_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances RDM disk information handling by adding disk name validation before updating volume references. It improves system robustness by ensuring only well-formatted volume references are accepted, while also enhancing logging and refining variables for better diagnostics.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>