### PR TITLE
disabled rdm config in UI (release)

### DIFF
--- a/ui/src/features/migration/VmsSelectionStep.tsx
+++ b/ui/src/features/migration/VmsSelectionStep.tsx
@@ -1546,7 +1546,7 @@ export default function VmsSelectionStep({
     <VmsSelectionStepContainer>
       <Step stepNumber="2" label="Select Virtual Machines to Migrate" />
       <FieldsContainer>
-        {rdmValidation.hasRdmVMs && (
+        {/* {rdmValidation.hasRdmVMs && (
           <Alert severity="info" sx={{ mb: 2 }}>
             <Box>
               <Typography variant="body2" sx={{ fontWeight: 'medium', mb: 1 }}>
@@ -1557,7 +1557,7 @@ export default function VmsSelectionStep({
               </Typography>
             </Box>
           </Alert>
-        )}
+        )} */}
         <FormControl error={!!error} required>
           <Paper sx={{ width: "100%", height: 389 }}>
             <DataGrid


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #


## Testing done

<img width="1440" height="795" alt="image" src="https://github.com/user-attachments/assets/70a51b5c-2cf6-409e-bb35-dc86f0f00237" />
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR disables the RDM configuration feature in the migration UI by commenting out code that renders RDM-related buttons and alerts. These changes streamline the interface by removing unsupported configuration options, resulting in improved clarity and consistency of the migration step.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>