### PR TITLE
bugfix: add limit to log streaming - limit number of bytes

### DIFF
--- a/ui/src/api/kubernetes/pods.ts
+++ b/ui/src/api/kubernetes/pods.ts
@@ -41,18 +41,18 @@ export const streamPodLogs = async (
   options: {
     follow?: boolean
     tailLines?: string
-    limitBytes?: string
+    limitBytes?: number
     signal?: AbortSignal
   } = {}
 ): Promise<Response> => {
-  const { follow = true, tailLines = "100", limitBytes = "500000", signal } = options
+  const { follow = true, tailLines = "100", limitBytes = 500000, signal } = options
   
   const endpoint = `${KUBERNETES_API_BASE_PATH}/namespaces/${namespace}/pods/${podName}/log`
   
   const params = new URLSearchParams({
     follow: follow.toString(),
     tailLines,
-    limitBytes,
+    limitBytes: limitBytes.toString(),
   })
   
   const url = `${endpoint}?${params.toString()}`

--- a/ui/src/hooks/useDeploymentLogs.ts
+++ b/ui/src/hooks/useDeploymentLogs.ts
@@ -54,7 +54,7 @@ export const useDeploymentLogs = ({
     const response = await streamPodLogs(podNamespace, podName, {
       follow: true,
       tailLines: "100",
-      limitBytes: "500000",
+      limitBytes: 500000,
       signal: abortController.signal,
     })
 

--- a/ui/src/hooks/useDirectPodLogs.ts
+++ b/ui/src/hooks/useDirectPodLogs.ts
@@ -54,7 +54,7 @@ export const useDirectPodLogs = ({
       const response = await streamPodLogs(namespace, podName, {
         follow: true,
         tailLines: "100",
-        limitBytes: "500000",
+        limitBytes: 500000,
         signal: abortController.signal,
       })
 


### PR DESCRIPTION
## What this PR does / why we need it

This PR  adds 500KB limit while retrieving logs

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #982 

## Special notes for your reviewer


## Testing done

- Verified only limited logs were getting retrieved

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces a bug fix to regulate log streaming by adding a 500KB limit across the affected components. The API in the pods module has been updated and both deployment and direct pod logs hooks now incorporate the new limitBytes parameter. These changes prevent excessive log retrieval and improve performance. Overall, the update addresses resource overuse and stabilizes the log streaming functionality.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>