### PR TITLE
enable k3s encryption at rest

### DIFF
--- a/image_builder/configs/k3s.env
+++ b/image_builder/configs/k3s.env
@@ -1,3 +1,4 @@
 export IS_MASTER=true
 export MASTER_IP=
 export K3S_TOKEN=
+export INSTALL_K3S_EXEC="server --secrets-encryption"

--- a/image_builder/scripts/install.sh
+++ b/image_builder/scripts/install.sh
@@ -38,6 +38,7 @@ fi
 log "IS_MASTER: ${IS_MASTER}"
 log "MASTER_IP: ${MASTER_IP}"
 log "K3S_TOKEN: ${K3S_TOKEN}"
+log "INSTALL_K3S_EXEC: ${INSTALL_K3S_EXEC}"
 
 set_default_password() {
   
@@ -186,12 +187,14 @@ else
   # Echo K3S_URL and K3S_TOKEN for debugging
   export K3S_URL="https://$MASTER_IP:6443"
   export K3S_TOKEN="$K3S_TOKEN"
+  export INSTALL_K3S_EXEC="$INSTALL_K3S_EXEC"
 
   log "K3S_URL: $K3S_URL"
   log "K3S_TOKEN: $K3S_TOKEN"
+  log "INSTALL_K3S_EXEC: $INSTALL_K3S_EXEC"
 
   # Install K3s worker
-  K3S_URL=$K3S_URL K3S_TOKEN=$K3S_TOKEN INSTALL_K3S_SKIP_DOWNLOAD=true /etc/pf9/k3s-setup/k3s-install.sh
+  K3S_URL=$K3S_URL K3S_TOKEN=$K3S_TOKEN INSTALL_K3S_EXEC=$INSTALL_K3S_EXEC INSTALL_K3S_SKIP_DOWNLOAD=true /etc/pf9/k3s-setup/k3s-install.sh
   check_command "Installing K3s worker"
 
   # wait until ctr becomes responsive


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces changes to enable encryption at rest for K3s installations by updating configuration and installation scripts to support secrets encryption. The modifications include logging enhancements and adjustments to installation commands for proper execution of the encryption feature. However, the implementation has critical issues where master nodes don't use the encryption configuration variable and worker nodes incorrectly receive master-specific flags. Overall, the changes aim to improve security by integrating encryption capabilities into the K3s deployment process.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>