### PR TITLE
removed nonce from CSP

### DIFF
--- a/ui/default.conf
+++ b/ui/default.conf
@@ -3,7 +3,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'nonce-${CSP_NONCE}'; style-src 'self' 'unsafe-inline'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests;" always;
+    add_header Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https:; img-src 'self' data: blob: https:; frame-ancestors 'none'; upgrade-insecure-requests;" always;
     add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), fullscreen=(self)" always;
     error_page 401 =401 /__auth_401;
 

--- a/ui/startup.sh
+++ b/ui/startup.sh
@@ -1,15 +1,5 @@
 #!/bin/sh
 
-# Generate a secure, random nonce
-export CSP_NONCE=$(openssl rand -base64 16)
-
-# Substitute the nonce
-envsubst '${CSP_NONCE}' < /etc/nginx/conf.d/default.conf > /etc/nginx/conf.d/default.conf.temp
-mv -f /etc/nginx/conf.d/default.conf.temp /etc/nginx/conf.d/default.conf
-
-# Inject the nonce
-sed -i "s|<script type=\"module\"|<script nonce=\"${CSP_NONCE}\" type=\"module\"|g" /usr/share/nginx/html/index.html
-
 # Use envsubst to substitute environment variables in the nginx configuration
 VITE_API_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) envsubst < /usr/share/nginx/html/index.html > /usr/share/nginx/html/index.html.temp
 mv -f /usr/share/nginx/html/index.html.temp /usr/share/nginx/html/index.html


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request removes the dynamic nonce mechanism from the Content-Security-Policy configuration and updates the CSP header in the default configuration file. The changes streamline the startup script by eliminating nonce generation and related substitutions. The overall modification simplifies the configuration by removing the complexity of nonce handling while maintaining security headers. These updates resolve potential issues with nonce management in the application.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>