### PR TITLE
Updated default username from ubuntu to admin

### DIFF
--- a/image_builder/scripts/install.sh
+++ b/image_builder/scripts/install.sh
@@ -72,7 +72,7 @@ set_default_password
 check_command "Setting default password for ubuntu user"
 
 # Create /etc/htpasswd with ubuntu user using openssl apr1 hash (airgapped-safe)
-sudo sh -c 'umask 0177; mkdir -p /etc; echo "ubuntu:$(openssl passwd -apr1 password)" > /etc/htpasswd'
+sudo sh -c 'umask 0177; mkdir -p /etc; echo "admin:$(openssl passwd -apr1 password)" > /etc/htpasswd'
 sudo chmod 644 /etc/htpasswd
 sudo chown root:root /etc/htpasswd
 


### PR DESCRIPTION
## What this PR does / why we need it

After setting up the VM, default username will be admin not ubuntu. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request updates the installation script by changing the default username from 'ubuntu' to 'admin' in the htpasswd file creation. The modification addresses deployment requirements for updated default credentials and streamlines the setup process. The change is targeted and limited to configuration adjustments in the authentication script. Overall, this represents a focused update to the credential management system.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>