### PR TITLE
added --no-restart to the utility to vjbctl

### DIFF
--- a/image_builder/scripts/pf9-htpasswd.sh
+++ b/image_builder/scripts/pf9-htpasswd.sh
@@ -161,12 +161,12 @@ list_users() {
 }
 
 _pf9_ht_main() {
-  local no_reboot=0
+  local no_restart=0
   local args=()
   for arg in "$@"; do
     case "$arg" in
       --no-restart)
-        no_reboot=1
+        no_restart=1
         ;;
       *)
         args+=("$arg")
@@ -186,7 +186,7 @@ _pf9_ht_main() {
             prompt_user "$DEFAULT_USER" user
           fi
           create_user "$user"
-          if [[ $no_reboot -eq 0 ]]; then
+          if [[ $no_restart -eq 0 ]]; then
             sudo kubectl -n migration-system rollout restart deployment vjailbreak-ui
           fi
           ;;
@@ -196,7 +196,7 @@ _pf9_ht_main() {
             prompt_user "$DEFAULT_USER" user
           fi
           delete_user "$user"
-          if [[ $no_reboot -eq 0 ]]; then
+          if [[ $no_restart -eq 0 ]]; then
             sudo kubectl -n migration-system rollout restart deployment vjailbreak-ui
           fi
           ;;
@@ -206,13 +206,13 @@ _pf9_ht_main() {
             prompt_user "$DEFAULT_USER" user
           fi
           change_password "$user"
-          if [[ $no_reboot -eq 0 ]]; then
+          if [[ $no_restart -eq 0 ]]; then
             sudo kubectl -n migration-system rollout restart deployment vjailbreak-ui
           fi
           ;;
         list)
           list_users
-          if [[ $no_reboot -eq 0 ]]; then
+          if [[ $no_restart -eq 0 ]]; then
             sudo kubectl -n migration-system rollout restart deployment vjailbreak-ui
           fi
           ;;


### PR DESCRIPTION
## What this PR does / why we need it

While adding or updating user credentials for the vjailbreak ui through vjbctl after every modification running the refresh was needed fixed it so that it will refresh automatically and if we want to stop the utility from refreshing automatically after every modification we may pass a flag --no-restart 