### PR TITLE
Correction Sidebar Slug Name

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -60,7 +60,7 @@ export default defineConfig({
 				{
 					label: 'Concepts',
 					items: [
-						{ label: 'User Credential Management', slug: 'concepts/user-management.md' },
+						{ label: 'User Credential Management', slug: 'concepts/user-management' },
 						{ label: 'Credential Management', slug: 'concepts/credential-management' },
 						{ label: 'Network & Storage Mapping', slug: 'concepts/network-storage-mapping' },
 						{ label: 'Migration Options', slug: 'concepts/migration-options' },


### PR DESCRIPTION
fix - Build Failure
Updated slug name for Concepts section in the sidebar
fixes: #1065 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request updates the sidebar configuration in the documentation by correcting an incorrect slug value for 'User Credential Management'. The change removes the erroneous .md extension from the slug to ensure proper file referencing. This correction addresses a build failure and improves the consistency of URL mappings across the documentation, enhancing both functionality and navigation within the docs.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>