### PR TITLE
bugfix: previous PR introduced a issue where importToCinder was not g…

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -1440,14 +1440,6 @@ func (r *MigrationPlanReconciler) migrateRDMdisks(ctx context.Context, migration
 				if err != nil {
 					return fmt.Errorf("failed to validate RDMDisk CR: %w", err)
 				}
-				// Migration Plan controller only sets ImportToCinder to true and OpenstackVolumeRef,
-				// Another RDM disk controller will handle the rest of the migration,
-				// Will ensure that RDM disk is managed and imported to Cinder
-				if !rdmDiskCR.Spec.ImportToCinder {
-					rdmDiskCR.Spec.ImportToCinder = true
-					rdmDiskCR.Spec.OpenstackVolumeRef.OpenstackCreds = openstackcreds.GetName()
-					rdmDiskCRToBeUpdated = append(rdmDiskCRToBeUpdated, *rdmDiskCR)
-				}
 				allRDMDisks = append(allRDMDisks, rdmDiskCR)
 			}
 		}
@@ -1465,6 +1457,13 @@ func (r *MigrationPlanReconciler) migrateRDMdisks(ctx context.Context, migration
 		}, rdmDisk)
 		if err != nil {
 			return fmt.Errorf("failed to get RDMDisk CR: %w", err)
+		}
+		// Migration Plan controller only sets ImportToCinder to true and OpenstackVolumeRef,
+		// Another RDM disk controller will handle the rest of the migration,
+		// Will ensure that RDM disk is managed and imported to Cinder
+		if !rdmDisk.Spec.ImportToCinder {
+			rdmDisk.Spec.ImportToCinder = true
+			rdmDisk.Spec.OpenstackVolumeRef.OpenstackCreds = openstackcreds.GetName()
 		}
 		if err := r.Update(ctx, rdmDisk); err != nil {
 			return fmt.Errorf("failed to update RDMDisk CR: %w", err)


### PR DESCRIPTION
…etting updated

## What this PR does / why we need it

PR #993  introduced a issue where ImportToCinder was not able to update , this PR fixes it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #992 #1036

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request refactors the migration plan controller by eliminating redundant code and repositioning the logic for setting the ImportToCinder property. The changes remove misleading comments and code blocks that previously handled the disk CR incorrectly. The update ensures that the right control flow and Openstack credential settings are applied, thereby fixing the bug introduced in the previous PR.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>