### PR TITLE
bugfix: fix ImportToCinder to true from migrationplan controller

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -1462,7 +1462,9 @@ func (r *MigrationPlanReconciler) migrateRDMdisks(ctx context.Context, migration
 		if err != nil {
 			return fmt.Errorf("failed to get RDMDisk CR: %w", err)
 		}
-		// Use MergeFrom patch to safely modify fields
+		// Migration Plan controller only sets ImportToCinder to true,
+		// the RDMDisk controller ensures that RDM disk is managed and
+		// imported to Cinder
 		patch := client.MergeFrom(rdmDisk.DeepCopy())
 		if !rdmDisk.Spec.ImportToCinder {
 			rdmDisk.Spec.ImportToCinder = true


### PR DESCRIPTION
## What this PR does / why we need it
This PR fixes incorrect logic of syncing annotations, we do update of RDM disk CR in bulk , but one of the previous PR removed code to collect all RDM disk together

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #992 
fixes #1037

## Special notes for your reviewer


## Testing done
In progress

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the migrationplan controller by correcting the logic for filtering and collecting RDM disk CRs, and replacing the update operation with a patch operation using MergeFrom strategy for safer object modifications. The changes include updating logic and comments related to handling the ImportToCinder flag, replacing outdated comments with detailed explanations of controller responsibilities, and ensuring the flag is correctly toggled. Enhanced logging has been added for better traceability during bulk updates, improving overall system reliability by ensuring all necessary disks are processed correctly and resolving sync issues from previous iterations.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>