### PR TITLE
Fix - blocking port creation if dhcp is selected but VM doesn't have a valid IP

### DIFF
--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -512,7 +512,7 @@ func (osclient *OpenStackClients) CreatePort(network *networks.Network, mac, ip,
 			return nil, fmt.Errorf("failed to get subnet: %s", err)
 		}
 		
-		if subnetID != nil{				
+		if subnet != nil{				
 			fixedIP = append(fixedIP, ports.IP{
 			SubnetID:  subnet.ID,
 			IPAddress: ip,


### PR DESCRIPTION
Migration with VM on different subnet through DHCP failed at the subnet membership check. Updated to ensure non blocking behaviour in such cases. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request resolves a blocking issue in port creation during VM migrations by modifying the subnet membership check in OpenStack network operations. The changes add a fallback condition and properly verify subnet existence, allowing non-blocking behavior when subnet retrieval fails due to DHCP settings. This ensures that VMs on different subnets can proceed with port creation without unnecessary interruption, even when a VM lacks a valid IP in the expected subnet. Overall, it addresses a key bug encountered during migrations and ensures smooth port creation processes.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>