### PR TITLE
Skip CopyingChagedBlocks phase when migration type is cold

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -345,11 +345,6 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 				}
 			}
 
-			if migobj.MigrationType == "cold" {
-                utils.PrintLog("Cold migration: full disk copy complete. Breaking replication loop.")
-                break
-            }
-
 			if adminInitiatedCutover {
 				utils.PrintLog("Admin initiated cutover detected, skipping changed blocks copy")
 				if err := migobj.WaitforAdminCutover(); err != nil {
@@ -380,7 +375,9 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 				}
 
 				if len(changedAreas.ChangedArea) == 0 {
-					migobj.logMessage(fmt.Sprintf("Disk %d: No changed blocks found. Skipping copy", idx))
+					if migobj.MigrationType != "cold" {
+						migobj.logMessage(fmt.Sprintf("Disk %d: No changed blocks found. Skipping copy", idx))
+					}
 				} else {
 					migobj.logMessage(fmt.Sprintf("Disk %d: Blocks have Changed.", idx))
 


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1001 



## Testing done 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the migration controller by adding logic to retrieve the MigrationPlan and check its type before proceeding, while also streamlining the process by removing redundant code and improving error handling. The changes implement conditional processing that skips the copying changed blocks phase when the migration strategy is 'cold', preventing unnecessary operations and improving efficiency. The migration helper now features improved logging and control flow to handle disk copying more efficiently. Overall, these modifications contribute to a more reliable, clear, and performant migration workflow.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>