### PR TITLE
delete firstboot configmap when migration is deleted

### DIFF
--- a/k8s/migration/pkg/utils/migrationplanutils.go
+++ b/k8s/migration/pkg/utils/migrationplanutils.go
@@ -33,6 +33,11 @@ func GetMigrationConfigMapName(vmname string) string {
 	return fmt.Sprintf("migration-config-%s", vmname)
 }
 
+// GetFirstbootConfigMapName generates a config map name for a migration
+func GetFirstbootConfigMapName(vmname string) string {
+	return fmt.Sprintf("firstboot-config-%s", vmname)
+}
+
 // ConvertToK8sName converts a name to be Kubernetes-compatible
 func ConvertToK8sName(name string) (string, error) {
 	// Convert to lowercase

--- a/v2v-helper/pkg/utils/utils.go
+++ b/v2v-helper/pkg/utils/utils.go
@@ -69,6 +69,15 @@ func GetMigrationConfigMapName() (string, error) {
 	return fmt.Sprintf("migration-config-%s", vmK8sName), nil
 }
 
+// GetFirstbootConfigMapName is function that returns the name of the secret
+func GetFirstbootConfigMapName() (string, error) {
+	vmK8sName, err := GetVMwareMachineName()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("firstboot-config-%s", vmK8sName), nil
+}
+
 func GetVMwareMachineName() (string, error) {
 	vmK8sName := os.Getenv("VMWARE_MACHINE_OBJECT_NAME")
 	if vmK8sName == "" {


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1070 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Modifies the CreateFirstbootConfigMap function to accept a migration object instead of a migration plan, improving flexibility in migration handling.</li>

<li>Introduces new utility functions to generate ConfigMap names, ensuring consistency and clarity in naming conventions.</li>

<li>Overall summary: touches on migration handling and ConfigMap naming conventions, introduces changes to improve flexibility and consistency.</li>

</ul>

</div>