### PR TITLE
Remove race condition in credential deletion flow

### DIFF
--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -77,10 +77,8 @@ func (r *VMwareCredsReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	// Always close the scope when exiting this function such that we can persist any vmwarecreds changes.
 	defer func() {
-		if vmwcreds.DeletionTimestamp.IsZero() {
-			if err := scope.Close(); err != nil && reterr == nil {
-				reterr = err
-			}
+		if err := scope.Close(); err != nil && reterr == nil {
+			reterr = err
 		}
 	}()
 

--- a/ui/src/api/helpers.ts
+++ b/ui/src/api/helpers.ts
@@ -26,6 +26,7 @@ import {
 import {
   createOpenstackCredsSecret,
   createVMwareCredsSecret,
+  deleteSecret,
 } from "./secrets/secrets"
 import { createVMwareCredsWithSecret } from "./vmware-creds/vmwareCreds"
 import { VJAILBREAK_DEFAULT_NAMESPACE } from "./constants"
@@ -171,7 +172,9 @@ export const deleteVMwareCredsWithSecretFlow = async (
   namespace = VJAILBREAK_DEFAULT_NAMESPACE
 ) => {
   try {
+    const secretName = `${credName}-vmware-secret`
     await deleteVmwareCredentials(credName, namespace)
+    await deleteSecret(secretName, namespace)
     return { success: true }
   } catch (error) {
     console.error(`Error deleting VMware credential ${credName}:`, error)


### PR DESCRIPTION
## What this PR does / why we need it

This PR fixes a bug where deleting a openstack credential would often fail in the UI with a 404 Not Found error, even though the credential was successfully deleted in the backend.

## Problem:

The error was caused by a race condition. The UI and the Kubernetes controller were both trying to delete the same secret object at the same time.

- **UI:** await deleteOpenstackCredentials(...) THEN await deleteSecret(...).
- **Controller:** Wakes up after deleteOpenstackCredentials and also tries to delete the secret.

Whichever process ran second would get a 404 Not Found because the secret was already gone. When the UI received this 404, it (incorrectly) threw an unhandled exception, causing the delete to fail for the user.

## Fix:

This change completely eliminates the race condition. The UI now only fires one API call, the controller's existing cleanup logic handles the rest.

## Which issue(s) this PR fixes

fixes #1117 

## Testing done

Before deleting the cred (sarikatenant)
<img width="1439" height="777" src="https://github.com/user-attachments/assets/f1c671c4-56e1-438a-88ff-6fb2ff6e7a57" alt="image">

After deleting the cred (sarikatenant)
<img width="1440" height="778" src="https://github.com/user-attachments/assets/fca6642e-8981-4835-90a7-3e476db71aea" alt="image"> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request addresses a critical bug in the credential deletion flow for OpenStack credentials, resolving a race condition that led to 404 errors in the UI.</li>

<li>The changes ensure that the UI and backend processes do not conflict during deletion, allowing the controller to manage cleanup effectively.</li>

<li>Overall, this enhances the reliability of the credential deletion process.</li>

</ul>

</div>