### PR TITLE
add proxy env set by user in controller as well

### DIFF
--- a/deploy/installer.yaml
+++ b/deploy/installer.yaml
@@ -3704,6 +3704,9 @@ spec:
         env:
         - name: MAX_CONCURRENT_RECONCILES
           value: "5"
+        envFrom:
+        - configMapRef:
+            name: pf9-env
         image: quay.io/platform9/vjailbreak-controller:v0.3.5
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/k8s/migration/config/manager/manager.yaml
+++ b/k8s/migration/config/manager/manager.yaml
@@ -63,6 +63,9 @@ spec:
         env:
           - name: MAX_CONCURRENT_RECONCILES
             value: "5"
+        envFrom:
+          - configMapRef:
+              name: pf9-env
         args:
           - --leader-elect=false
           - --health-probe-bind-address=:8081


### PR DESCRIPTION
## What this PR does / why we need it

Adds the envFrom the config map which the user will set.

## Which issue(s) this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1134

## Special notes for your reviewer

## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request introduces enhancements to the environment variable configuration for the controller by adding the envFrom directive to reference a user-defined configMap.</li>

<li>The change allows for greater flexibility in managing environment variables, specifically setting them through the configMap named 'pf9-env'.</li>

<li>The updates are made in both the installer and manager YAML files, ensuring that the controller can utilize these environment variables effectively.</li>

<li>Overall, this pull request introduces enhancements to environment variable configurations in the installer and manager YAML files.</li>

</ul>

</div>