### PR TITLE
fix - Periodic sync values are not being populated in the migration ConfigMap, causing periodic sync to be skipped 

### DIFF
--- a/ui/src/api/migration-plans/helpers.ts
+++ b/ui/src/api/migration-plans/helpers.ts
@@ -32,9 +32,18 @@ export const createMigrationPlanJson = (params) => {
       disconnectSourceNetwork
     },
     virtualMachines: [virtualMachines],
-    fallbackToDHCP,
-    periodicSyncInterval,
-    periodicSyncEnabled
+    fallbackToDHCP
+  }
+
+  const advancedOptions: Record<string, unknown> = {}
+  if (periodicSyncInterval) {
+    advancedOptions.periodicSyncInterval = periodicSyncInterval
+  }
+  if (typeof periodicSyncEnabled === 'boolean') {
+    advancedOptions.periodicSyncEnabled = periodicSyncEnabled
+  }
+  if (Object.keys(advancedOptions).length > 0) {
+    spec.advancedOptions = advancedOptions
   }
 
   // Add firstBootScript  if postMigrationScript is provided


### PR DESCRIPTION
## What this PR does / why we need it

Updated the migrationplan as per the crd to ensure the advanced options selected in the migration form are reflected in the migrationplan and migration configmap.

fixes #1146

## Testing done

<img width="922" height="617" src="https://github.com/user-attachments/assets/4313cbed-44a7-43f1-9f15-218f242fc4fb" alt="image"> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request adds conditional logic to the migration plan configuration to ensure advanced options for periodic sync are correctly populated in the migration ConfigMap.</li>

<li>This change addresses issue #1146, preventing periodic sync from being skipped based on user input.</li>

<li>Overall, the update improves the handling of periodic sync options in the migration plan.</li>

</ul>

</div>