### PR TITLE
[Fix] added APIReader to get RDM

### DIFF
--- a/k8s/migration/cmd/main.go
+++ b/k8s/migration/cmd/main.go
@@ -151,8 +151,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controller.RDMDiskReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		APIReader: mgr.GetAPIReader(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RDMDisk")
 		os.Exit(1)

--- a/k8s/migration/internal/controller/rdmdisk_controller.go
+++ b/k8s/migration/internal/controller/rdmdisk_controller.go
@@ -39,7 +39,8 @@ import (
 // RDMDiskReconciler reconciles a RDMDisk object
 type RDMDiskReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme    *runtime.Scheme
+	APIReader client.Reader
 }
 
 const (
@@ -83,7 +84,7 @@ func (r *RDMDiskReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Get the RDMDisk resource
 	rdmDisk := &vjailbreakv1alpha1.RDMDisk{}
-	if err := r.Get(ctx, req.NamespacedName, rdmDisk); err != nil {
+	if err := r.APIReader.Get(ctx, req.NamespacedName, rdmDisk); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			ctxlog.Error(err, "unable to fetch RDMDisk")
 			return ctrl.Result{}, err


### PR DESCRIPTION
## What this PR does / why we need it
Problem
The RDMDiskReconciler used the cached client (r.Get()) to read RDMDisk resources. When the  controller updates RDMDisk resources (e.g., setting ImportToCinder), the RDMDisk controller could read stale cached data, leading to:

- Reconciliation based on outdated resource state
- Potential inconsistencies in RDM disk management

Solution
Switched the RDMDisk controller to use APIReader instead of the cached client for initial resource reads. APIReader bypasses the cache and reads directly from the API server, ensuring the controller always works with the latest resource state.
Changes:

- Added APIReader client.Reader field to RDMDiskReconciler struct
- Updated Reconcile to use r.APIReader.Get() instead of r.Get() for fetching RDMDisk resources
- Initialized APIReader in controller setup via mgr.GetAPIReader()

## Which issue(s) this PR fixes

fixes #1120

## Special notes for your reviewer

## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request modifies the RDMDisk reconciliation process by replacing the cached client with APIReader for fetching RDMDisk resources, ensuring the controller works with the latest resource state.</li>

<li>The updates include modifications to the RDMDiskReconciler struct and its setup.</li>

<li>Adjustments are made in the Reconcile method to utilize the new APIReader.</li>

<li>Overall, this pull request touches on the RDMDisk reconciliation process, modifying the RDMDiskReconciler struct and Reconcile method to ensure consistency in resource management.</li>

</ul>

</div>