### PR TITLE
Pass user assigned ip to the migrating vm

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -947,19 +947,6 @@ func (r *MigrationPlanReconciler) CreateMigrationConfigMap(ctx context.Context,
 			configMap.Data["ASSIGNED_IP"] = ""
 		}
 
-		// Store NetworkInterfaces for per-NIC IP assignment
-		if len(vmMachine.Spec.VMInfo.NetworkInterfaces) > 0 {
-			nicMappings := []string{}
-			for _, nic := range vmMachine.Spec.VMInfo.NetworkInterfaces {
-				if nic.IPAddress != "" {
-					nicMappings = append(nicMappings, fmt.Sprintf("%s:%s", nic.MAC, nic.IPAddress))
-				}
-			}
-			configMap.Data["NETWORK_INTERFACE_IPS"] = strings.Join(nicMappings, ",")
-		} else {
-			configMap.Data["NETWORK_INTERFACE_IPS"] = ""
-		}
-
 		// Check if target flavor is set
 		if vmMachine.Spec.TargetFlavorID != "" {
 			configMap.Data["TARGET_FLAVOR_ID"] = vmMachine.Spec.TargetFlavorID

--- a/v2v-helper/main.go
+++ b/v2v-helper/main.go
@@ -140,7 +140,6 @@ func main() {
 		TargetFlavorId:         migrationparams.TARGET_FLAVOR_ID,
 		TargetAvailabilityZone: migrationparams.TargetAvailabilityZone,
 		AssignedIP:             migrationparams.AssignedIP,
-		NetworkInterfaceIPs:    migrationparams.NetworkInterfaceIPs,
 		SecurityGroups:         utils.RemoveEmptyStrings(strings.Split(migrationparams.SecurityGroups, ",")),
 		RDMDisks:               utils.RemoveEmptyStrings(strings.Split(migrationparams.RDMDisks, ",")),
 		UseFlavorless:          os.Getenv("USE_FLAVORLESS") == "true",

--- a/v2v-helper/pkg/utils/vcenterutils.go
+++ b/v2v-helper/pkg/utils/vcenterutils.go
@@ -34,7 +34,6 @@ type MigrationParams struct {
 	TARGET_FLAVOR_ID        string
 	TargetAvailabilityZone  string
 	AssignedIP              string
-	NetworkInterfaceIPs     string
 	VMwareMachineName       string
 	DisconnectSourceNetwork bool
 	SecurityGroups          string
@@ -77,7 +76,6 @@ func GetMigrationParams(ctx context.Context, client client.Client) (*MigrationPa
 		TARGET_FLAVOR_ID:        string(configMap.Data["TARGET_FLAVOR_ID"]),
 		TargetAvailabilityZone:  string(configMap.Data["TARGET_AVAILABILITY_ZONE"]),
 		AssignedIP:              string(configMap.Data["ASSIGNED_IP"]),
-		NetworkInterfaceIPs:     string(configMap.Data["NETWORK_INTERFACE_IPS"]),
 		VMwareMachineName:       string(configMap.Data["VMWARE_MACHINE_OBJECT_NAME"]),
 		DisconnectSourceNetwork: string(configMap.Data["DISCONNECT_SOURCE_NETWORK"]) == constants.TrueString,
 		SecurityGroups:          string(configMap.Data["SECURITY_GROUPS"]),

--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -237,7 +237,6 @@ func (vmops *VMOps) GetVMInfo(ostype string, rdmDisks []string) (VMInfo, error) 
 		}
 		rdmDiskSlice = append(rdmDiskSlice, *rdmDisk)
 	}
-	log.Printf("DEBUG IPS %v", ipPerMac)
 	vminfo := VMInfo{
 		CPU:               o.Config.Hardware.NumCPU,
 		Memory:            o.Config.Hardware.MemoryMB,


### PR DESCRIPTION
## What this PR does / why we need it

This PR updates the `handleApplyBulkIPs` function to populate both fields when assigning IPs:

- `spec.vms.networkInterfaces` - per-NIC IP assignments (existing behavior)
- `spec.vms.assignedIp` - comma-separated list of all assigned IPs (new)

For VMs with multiple network interfaces, assignedIp contains all assigned IPs in a comma-separated format. For single-interface VMs, it contains the single IP address.

## Which issue(s) this PR fixes

fixes #1075

## Testing done

- UI:

<img width="2880" height="1582" src="https://github.com/user-attachments/assets/95aec55c-5975-4440-8cb7-4e02685fa67b" alt="image">

- ConfigMap:

<img width="1440" height="575" src="https://github.com/user-attachments/assets/4274899a-a699-4275-b472-622e75250f12" alt="image">

- Logs:

<img width="1440" height="579" src="https://github.com/user-attachments/assets/8df52eb9-f36d-4a12-97f2-9c5bf55ad67b" alt="image">

- Post Migration:

<img width="2412" height="1518" src="https://github.com/user-attachments/assets/6f678118-24aa-4d2a-a3f2-622861f0370d" alt="image"> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request introduces a new feature for assigning IPs to migrating VMs, allowing both per-NIC IP assignments and a new comma-separated list of assigned IPs for VMs with multiple interfaces.</li>

<li>The `handleApplyBulkIPs` function has been updated to support the new field for network interface IPs, enhancing the IP assignment process during VM migrations.</li>

<li>Improvements have been made to the migration plan controller and utility functions, ensuring better configuration management and streamlined migration processes.</li>

<li>Overall, this pull request introduces new features related to IP assignments, updates to the migration controller, and enhancements in configuration management.</li>

</ul>

</div>