### PR TITLE
Added podfailed status check and reordered validation logic 

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -1581,14 +1581,22 @@ func (r *MigrationPlanReconciler) validateMigrationPlanVMs(
 
 	if len(validVMs) == 0 {
 		if len(skippedVMs) > 0 {
-			msg := fmt.Sprintf("Skipped VMs due to unsupported or unknown OS: %v", skippedVMs)
+			skippedVMNames := make([]string, len(skippedVMs))
+			for i, vm := range skippedVMs {
+				skippedVMNames[i] = vm.Spec.VMInfo.Name
+			}
+			msg := fmt.Sprintf("Skipped VMs due to unsupported or unknown OS: %v", skippedVMNames)
 			r.ctxlog.Info(msg)
 		}
 		return nil, skippedVMs, fmt.Errorf("all VMs have unknown or unsupported OS types; no migrations to run")
 	}
 
 	if len(skippedVMs) > 0 {
-		msg := fmt.Sprintf("Skipped VMs due to unsupported or unknown OS: %v", skippedVMs)
+		skippedVMNames := make([]string, len(skippedVMs))
+		for i, vm := range skippedVMs {
+			skippedVMNames[i] = vm.Spec.VMInfo.Name
+		}
+		msg := fmt.Sprintf("Skipped VMs due to unsupported or unknown OS: %v", skippedVMNames)
 		r.ctxlog.Info(msg)
 		if updateErr := r.UpdateMigrationPlanStatus(ctx, migrationplan, corev1.PodPending, msg); updateErr != nil {
 			r.ctxlog.Error(updateErr, "Failed to update migration plan status for skipped VMs")


### PR DESCRIPTION
## What this PR does / why we need it

- Prevents re-reconciliation of already failed migration plans
- Checks if all VMs are invalid before setting status to PodPending
- Only updates to PodPending if there are valid VMs to migrate

## Which issue(s) this PR fixes

fixes #1130

## Testing done 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request adds a check for the 'PodFailed' status in the migration plan logic to prevent unnecessary re-reconciliation of already failed migration plans.</li>

<li>It improves the validation logic for virtual machines, ensuring that the status is only updated to 'PodPending' if there are valid VMs available for migration.</li>

<li>These changes aim to streamline the migration process and avoid unnecessary operations on invalid VMs.</li>

<li>Overall, this pull request introduces enhancements to the migration plan and virtual machine validation logic.</li>

</ul>

</div>