### PR TITLE
added edge cases for blocking plan to reconcile

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -416,8 +416,8 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 			// Checking the failure message to determine which scenario this is
 			// If migrationplan validation failure - should NOT retry
 			// If user-initiated retry - should retry
-			if strings.Contains(migrationplan.Status.MigrationMessage, "validation failed") {
-				r.ctxlog.Info("Migration plan validation failed, skipping retry", 
+			if strings.HasPrefix(migrationplan.Status.MigrationMessage, constants.MigrationPlanValidationFailedPrefix) {
+				r.ctxlog.Info("Migration plan validation failed, skipping retry",
 					"migrationplan", migrationplan.Name, "reason", migrationplan.Status.MigrationMessage)
 				return ctrl.Result{}, nil
 			}

--- a/k8s/migration/pkg/constants/constants.go
+++ b/k8s/migration/pkg/constants/constants.go
@@ -213,6 +213,9 @@ const (
 	// ValidateRDMOwnerVMs is the default value for RDM owner VM validation
 	ValidateRDMOwnerVMs = true
 
+	// MigrationPlan status message prefix
+	MigrationPlanValidationFailedPrefix = "Migration plan validation failed"
+
 	// VjailbreakSettingsConfigMapName is the name of the vjailbreak settings configmap
 	VjailbreakSettingsConfigMapName = "vjailbreak-settings"
 


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
fixes #1169 

## Testing done 
<img width="1440" height="167" alt="image" src="https://github.com/user-attachments/assets/ff5d02fd-95eb-4499-b6e7-2cd4d3a73643" />


<h3>Summary by Bito</h3>

<ul>

<li>This pull request adds checks for existing Migration objects when a migration plan fails, which may introduce risks in migration handling.</li>

<li>It ensures that retries are only attempted under certain conditions, modifying the migration handling logic.</li>

<li>The changes include logging for better traceability of the migration status.</li>

<li>Overall, the pull request introduces checks and logging in the migration handling process, which may introduce risks in migration management.</li>

</ul>

</div>