### PR TITLE
fix: #903 Using format() with timezone offset instead of ISOString() for a…

### DIFF
--- a/ui/src/features/migration/MigrationOptions.tsx
+++ b/ui/src/features/migration/MigrationOptions.tsx
@@ -317,7 +317,9 @@ const TimePicker = ({
 
   const handleTimeChange = useCallback(
     (newValue: dayjs.Dayjs | null, identifier) => {
-      const formattedTime = newValue?.toISOString()
+      // Use format() with timezone offset instead of toISOString() which converts to UTC
+      // This preserves the user's local timezone (e.g., "2025-11-20T12:40:00+05:30" for IST)
+      const formattedTime = newValue?.format()
       onChange(identifier)(String(formattedTime))
     },
     [onChange]

--- a/ui/src/features/migration/MigrationOptionsAlt.tsx
+++ b/ui/src/features/migration/MigrationOptionsAlt.tsx
@@ -537,7 +537,9 @@ const TimePicker = ({
 
   const handleTimeChange = useCallback(
     (newValue: dayjs.Dayjs | null, identifier) => {
-      const formattedTime = newValue?.toISOString()
+      // Use format() with timezone offset instead of toISOString() which converts to UTC
+      // This preserves the user's local timezone (e.g., "2025-11-20T12:40:00+05:30" for IST)
+      const formattedTime = newValue?.format()
       onChange(identifier)(String(formattedTime))
     },
     [onChange]


### PR DESCRIPTION
fixes #903 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request enhances the time formatting in the MigrationOptions and MigrationOptionsAlt components by replacing the use of toISOString() with format() to ensure that the user's local timezone is preserved.</li>

<li>The modification aims to provide a more accurate representation of time for users in different time zones.</li>

<li>Overall, this pull request touches on the MigrationOptions and MigrationOptionsAlt components and aims to improve user experience.</li>

</ul>

</div>