### PR TITLE
#1129 :: Remove duplicate error text on credential creation failure

### DIFF
--- a/ui/src/components/drawers/VMwareCredentialsDrawer.tsx
+++ b/ui/src/components/drawers/VMwareCredentialsDrawer.tsx
@@ -1,440 +1,477 @@
-import { Box } from "@mui/material";
-import { useState, useCallback } from "react";
-import { StyledDrawer, DrawerContent } from "src/components/forms/StyledDrawer";
-import Header from "src/components/forms/Header";
-import Footer from "src/components/forms/Footer";
-import { createVMwareCredsWithSecretFlow, deleteVMwareCredsWithSecretFlow } from "src/api/helpers";
-import axios from "axios";
-import { useVmwareCredentialsQuery } from "src/hooks/api/useVmwareCredentialsQuery";
-import { TextField, FormControl, InputAdornment, IconButton, FormLabel, CircularProgress, FormControlLabel, Switch, Tooltip } from "@mui/material";
-import { Visibility, VisibilityOff } from "@mui/icons-material";
-import CheckIcon from "@mui/icons-material/Check";
-import { isValidName } from "src/utils";
-import { getVmwareCredentials } from "src/api/vmware-creds/vmwareCreds";
-import { useInterval } from "src/hooks/useInterval";
-import { THREE_SECONDS } from "src/constants";
-import { useKeyboardSubmit } from "src/hooks/ui/useKeyboardSubmit";
-import { useErrorHandler } from "src/hooks/useErrorHandler";
-import { useAmplitude } from "src/hooks/useAmplitude";
-import { AMPLITUDE_EVENTS } from "src/types/amplitude";
-import InfoOutlined from "@mui/icons-material/InfoOutlined";
+import { Box } from '@mui/material'
+import { useState, useCallback } from 'react'
+import { StyledDrawer, DrawerContent } from 'src/components/forms/StyledDrawer'
+import Header from 'src/components/forms/Header'
+import Footer from 'src/components/forms/Footer'
+import { createVMwareCredsWithSecretFlow, deleteVMwareCredsWithSecretFlow } from 'src/api/helpers'
+import axios from 'axios'
+import { useVmwareCredentialsQuery } from 'src/hooks/api/useVmwareCredentialsQuery'
+import {
+  TextField,
+  FormControl,
+  InputAdornment,
+  IconButton,
+  FormLabel,
+  CircularProgress,
+  FormControlLabel,
+  Switch,
+  Tooltip,
+  FormHelperText
+} from '@mui/material'
+import { Visibility, VisibilityOff } from '@mui/icons-material'
+import CheckIcon from '@mui/icons-material/Check'
+import { isValidName } from 'src/utils'
+import { getVmwareCredentials } from 'src/api/vmware-creds/vmwareCreds'
+import { useInterval } from 'src/hooks/useInterval'
+import { THREE_SECONDS } from 'src/constants'
+import { useKeyboardSubmit } from 'src/hooks/ui/useKeyboardSubmit'
+import { useErrorHandler } from 'src/hooks/useErrorHandler'
+import { useAmplitude } from 'src/hooks/useAmplitude'
+import { AMPLITUDE_EVENTS } from 'src/types/amplitude'
+import InfoOutlined from '@mui/icons-material/InfoOutlined'
 
 interface VMwareCredentialsDrawerProps {
-    open: boolean;
-    onClose: () => void;
+  open: boolean
+  onClose: () => void
 }
 
-export default function VMwareCredentialsDrawer({
-    open,
-    onClose,
-}: VMwareCredentialsDrawerProps) {
-    const { reportError } = useErrorHandler({ component: "VMwareCredentialsDrawer" });
-    const { track } = useAmplitude({ component: "VMwareCredentialsDrawer" });
-    const [validatingVmwareCreds, setValidatingVmwareCreds] = useState(false);
-    const [vmwareCredsValidated, setVmwareCredsValidated] = useState<boolean | null>(null);
-    const [error, setError] = useState<string | null>(null);
-    const [credNameError, setCredNameError] = useState<string | null>(null);
-    const [submitting, setSubmitting] = useState(false);
-    const [showPassword, setShowPassword] = useState(false);
-    const [createdCredentialName, setCreatedCredentialName] = useState<string | null>(null);
+export default function VMwareCredentialsDrawer({ open, onClose }: VMwareCredentialsDrawerProps) {
+  const { reportError } = useErrorHandler({ component: 'VMwareCredentialsDrawer' })
+  const { track } = useAmplitude({ component: 'VMwareCredentialsDrawer' })
+  const [validatingVmwareCreds, setValidatingVmwareCreds] = useState(false)
+  const [vmwareCredsValidated, setVmwareCredsValidated] = useState<boolean | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [credNameError, setCredNameError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [showPassword, setShowPassword] = useState(false)
+  const [createdCredentialName, setCreatedCredentialName] = useState<string | null>(null)
 
-    const { refetch: refetchVmwareCreds } = useVmwareCredentialsQuery();
+  const { refetch: refetchVmwareCreds } = useVmwareCredentialsQuery()
 
-    const closeDrawer = useCallback(() => {
-        // Check if we have a created credential that hasn't been fully validated (succeeded)
-        if (createdCredentialName) {
-            console.log(`Cleaning up VMware credential on drawer close: ${createdCredentialName}`);
-            try {
-                deleteVMwareCredsWithSecretFlow(createdCredentialName)
-                    .then(() => console.log(`Cancelled credential ${createdCredentialName} deleted successfully`))
-                    .catch(err => console.error(`Error deleting cancelled credential: ${createdCredentialName}`, err));
-            } catch (err) {
-                console.error(`Error initiating deletion of cancelled credential: ${createdCredentialName}`, err);
-            }
+  const closeDrawer = useCallback(() => {
+    // Check if we have a created credential that hasn't been fully validated (succeeded)
+    if (createdCredentialName) {
+      console.log(`Cleaning up VMware credential on drawer close: ${createdCredentialName}`)
+      try {
+        deleteVMwareCredsWithSecretFlow(createdCredentialName)
+          .then(() =>
+            console.log(`Cancelled credential ${createdCredentialName} deleted successfully`)
+          )
+          .catch((err) =>
+            console.error(`Error deleting cancelled credential: ${createdCredentialName}`, err)
+          )
+      } catch (err) {
+        console.error(
+          `Error initiating deletion of cancelled credential: ${createdCredentialName}`,
+          err
+        )
+      }
+    }
+
+    // Reset state
+    setFormValues({
+      credentialName: '',
+      vcenterHost: '',
+      datacenter: '',
+      username: '',
+      password: '',
+      insecure: false
+    })
+    setCreatedCredentialName(null)
+    setValidatingVmwareCreds(false)
+    setVmwareCredsValidated(null)
+    setError(null)
+    setCredNameError(null)
+    setSubmitting(false)
+    setShowPassword(false)
+
+    onClose()
+  }, [createdCredentialName, onClose])
+
+  // Track form values
+  const [formValues, setFormValues] = useState({
+    credentialName: '',
+    vcenterHost: '',
+    datacenter: '',
+    username: '',
+    password: '',
+    insecure: false
+  })
+
+  const isValidCredentialName = isValidName(formValues.credentialName)
+
+  // Define a clear polling condition similar to MigrationForm
+  const shouldPollVmwareCreds = !!createdCredentialName && validatingVmwareCreds
+
+  const handleClickShowPassword = () => {
+    setShowPassword(!showPassword)
+  }
+
+  const handleMouseDownPassword = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+  }
+
+  const handleFormChange = (field: string) => (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = field === 'insecure' ? event.target.checked : event.target.value
+
+    setFormValues((prev) => ({
+      ...prev,
+      [field]: value
+    }))
+
+    // Clear result states when editing inputs
+    setVmwareCredsValidated(null)
+    setError(null)
+
+    if (field === 'credentialName') {
+      if (!isValidName(event.target.value)) {
+        setCredNameError(
+          'Credential name must start with a letter or number, followed by letters, numbers or hyphens, with a maximum length of 253 characters'
+        )
+      } else {
+        setCredNameError(null)
+      }
+    }
+  }
+
+  const handleValidationStatus = (status: string, message?: string) => {
+    if (status === 'Succeeded') {
+      setVmwareCredsValidated(true)
+      setValidatingVmwareCreds(false)
+
+      // Track successful credential validation
+      track(AMPLITUDE_EVENTS.CREDENTIALS_ADDED, {
+        credentialType: 'vmware',
+        credentialName: createdCredentialName,
+        stage: 'validation_success'
+      })
+
+      // Close the drawer after a short delay to show success state
+      setTimeout(() => {
+        refetchVmwareCreds()
+        onClose()
+      }, 1500)
+    } else if (status === 'Failed') {
+      setVmwareCredsValidated(false)
+      setValidatingVmwareCreds(false)
+      setError(message || 'Validation failed')
+
+      // Track credential validation failure
+      track(AMPLITUDE_EVENTS.CREDENTIALS_FAILED, {
+        credentialType: 'vmware',
+        credentialName: createdCredentialName,
+        errorMessage: message || 'Validation failed',
+        stage: 'validation'
+      })
+
+      reportError(
+        new Error(`VMware credential validation failed: ${message || 'Unknown reason'}`),
+        {
+          context: 'vmware-validation-failure',
+          metadata: {
+            credentialName: createdCredentialName,
+            validationMessage: message,
+            action: 'vmware-validation-failed'
+          }
         }
+      )
 
-        // Reset state
-        setFormValues({
-            credentialName: "",
-            vcenterHost: "",
-            datacenter: "",
-            username: "",
-            password: "",
-            insecure: false,
-        });
-        setCreatedCredentialName(null);
-        setValidatingVmwareCreds(false);
-        setVmwareCredsValidated(null);
-        setError(null);
-        setCredNameError(null);
-        setSubmitting(false);
-        setShowPassword(false);
-
-        onClose();
-    }, [createdCredentialName, onClose]);
-
-    // Track form values
-    const [formValues, setFormValues] = useState({
-        credentialName: "",
-        vcenterHost: "",
-        datacenter: "",
-        username: "",
-        password: "",
-        insecure: false,
-    });
-
-    const isValidCredentialName = isValidName(formValues.credentialName);
-
-    // Define a clear polling condition similar to MigrationForm
-    const shouldPollVmwareCreds =
-        !!createdCredentialName &&
-        validatingVmwareCreds;
-
-    const handleClickShowPassword = () => {
-        setShowPassword(!showPassword);
-    };
-
-    const handleMouseDownPassword = (event: React.MouseEvent<HTMLButtonElement>) => {
-        event.preventDefault();
-    };
-
-    const handleFormChange = (field: string) => (event: React.ChangeEvent<HTMLInputElement>) => {
-        const value = field === 'insecure' ? event.target.checked : event.target.value;
-
-        setFormValues(prev => ({
-            ...prev,
-            [field]: value
-        }));
-
-        setVmwareCredsValidated(null);
-        setError(null);
-
-        if (field === 'credentialName') {
-            if (!isValidName(event.target.value)) {
-                setCredNameError("Credential name must start with a letter or number, followed by letters, numbers or hyphens, with a maximum length of 253 characters");
-            } else {
-                setCredNameError(null);
-            }
-        }
-    };
-
-    const handleValidationStatus = (status: string, message?: string) => {
-        if (status === "Succeeded") {
-            setVmwareCredsValidated(true);
-            setValidatingVmwareCreds(false);
-
-            // Track successful credential validation
-            track(AMPLITUDE_EVENTS.CREDENTIALS_ADDED, {
-                credentialType: "vmware",
-                credentialName: createdCredentialName,
-                stage: "validation_success",
-            });
-
-            // Close the drawer after a short delay to show success state
-            setTimeout(() => {
-                refetchVmwareCreds();
-                onClose();
-            }, 1500);
-        } else if (status === "Failed") {
-            setVmwareCredsValidated(false);
-            setValidatingVmwareCreds(false);
-            setError(message || "Validation failed");
-
-            // Track credential validation failure
-            track(AMPLITUDE_EVENTS.CREDENTIALS_FAILED, {
-                credentialType: "vmware",
-                credentialName: createdCredentialName,
-                errorMessage: message || "Validation failed",
-                stage: "validation",
-            });
-
-            reportError(new Error(`VMware credential validation failed: ${message || "Unknown reason"}`), {
-                context: 'vmware-validation-failure',
-                metadata: {
-                    credentialName: createdCredentialName,
-                    validationMessage: message,
-                    action: 'vmware-validation-failed'
-                }
-            });
-
-            // Try to delete the failed credential to clean up
-            if (createdCredentialName) {
-                try {
-                    deleteVMwareCredsWithSecretFlow(createdCredentialName)
-                        .then(() => console.log(`Failed credential ${createdCredentialName} deleted`))
-                        .catch((deleteErr) => console.error(`Error deleting failed credential: ${createdCredentialName}`, deleteErr));
-                } catch (deleteErr) {
-                    console.error(`Error deleting failed credential: ${createdCredentialName}`, deleteErr);
-                    reportError(deleteErr as Error, {
-                        context: 'vmware-credential-deletion',
-                        metadata: {
-                            credentialName: createdCredentialName,
-                            action: 'delete-failed-credential'
-                        }
-                    });
-                }
-            }
-        }
-        setSubmitting(false);
-    };
-
-    useInterval(
-        async () => {
-            try {
-                const response = await getVmwareCredentials(createdCredentialName);
-                if (response?.status?.vmwareValidationStatus) {
-                    handleValidationStatus(
-                        response.status.vmwareValidationStatus,
-                        response.status.vmwareValidationMessage
-                    );
-                }
-            } catch (err) {
-                console.error("Error validating VMware credentials", err);
-                reportError(err as Error, {
-                    context: 'vmware-validation-polling',
-                    metadata: {
-                        credentialName: createdCredentialName,
-                        action: 'vmware-validation-status-polling'
-                    }
-                });
-                setError("Error validating VMware credentials");
-                setValidatingVmwareCreds(false);
-                setSubmitting(false);
-            }
-        },
-        THREE_SECONDS,
-        shouldPollVmwareCreds
-    );
-
-    const handleSubmit = useCallback(async () => {
-        if (!formValues.credentialName || !formValues.vcenterHost || !formValues.datacenter || !formValues.username || !formValues.password) {
-            setError("Please fill in all required fields");
-            return;
-        }
-
-        if (!isValidCredentialName) {
-            setError("Please provide a valid credential name");
-            return;
-        }
-
-        setSubmitting(true);
-        setValidatingVmwareCreds(true);
-
+      // Try to delete the failed credential to clean up
+      if (createdCredentialName) {
         try {
-            const credentialData = {
-                VCENTER_HOST: formValues.vcenterHost,
-                VCENTER_DATACENTER: formValues.datacenter,
-                VCENTER_USERNAME: formValues.username,
-                VCENTER_PASSWORD: formValues.password,
-                ...(formValues.insecure && { VCENTER_INSECURE: true }),
-            };
-
-            const response = await createVMwareCredsWithSecretFlow(
-                formValues.credentialName,
-                credentialData
-            );
-
-            setCreatedCredentialName(response.metadata.name);
-
-            // Track successful credential creation
-            track(AMPLITUDE_EVENTS.CREDENTIALS_ADDED, {
-                credentialType: "vmware",
-                credentialName: formValues.credentialName,
-                vcenterHost: formValues.vcenterHost,
-                namespace: response.metadata.namespace,
-            });
-
-        } catch (error) {
-            console.error("Error creating VMware credentials:", error);
-
-            // Track credential creation failure
-            track(AMPLITUDE_EVENTS.CREDENTIALS_FAILED, {
-                credentialType: "vmware",
-                credentialName: formValues.credentialName,
-                vcenterHost: formValues.vcenterHost,
-                errorMessage: error instanceof Error ? error.message : String(error),
-                stage: "creation",
-            });
-
-            reportError(error as Error, {
-                context: 'vmware-credential-creation',
-                metadata: {
-                    credentialName: formValues.credentialName,
-                    vcenterHost: formValues.vcenterHost,
-                    username: formValues.username,
-                    action: 'create-vmware-credential'
-                }
-            });
-            setVmwareCredsValidated(false);
-            setValidatingVmwareCreds(false);
-            setError(
-                "Error creating VMware credentials: " + (axios.isAxiosError(error) ? error?.response?.data?.message : error)
-            );
-            setSubmitting(false);
+          deleteVMwareCredsWithSecretFlow(createdCredentialName)
+            .then(() => console.log(`Failed credential ${createdCredentialName} deleted`))
+            .catch((deleteErr) =>
+              console.error(`Error deleting failed credential: ${createdCredentialName}`, deleteErr)
+            )
+        } catch (deleteErr) {
+          console.error(`Error deleting failed credential: ${createdCredentialName}`, deleteErr)
+          reportError(deleteErr as Error, {
+            context: 'vmware-credential-deletion',
+            metadata: {
+              credentialName: createdCredentialName,
+              action: 'delete-failed-credential'
+            }
+          })
         }
-    }, [formValues, isValidCredentialName, track]);
+      }
+    }
+    setSubmitting(false)
+  }
 
-    useKeyboardSubmit({
-        open,
-        isSubmitDisabled: submitting || validatingVmwareCreds || !isValidCredentialName ||
-            !formValues.vcenterHost || !formValues.datacenter || !formValues.username || !formValues.password,
-        onSubmit: handleSubmit,
-        onClose: closeDrawer
-    });
+  useInterval(
+    async () => {
+      try {
+        const response = await getVmwareCredentials(createdCredentialName)
+        if (response?.status?.vmwareValidationStatus) {
+          handleValidationStatus(
+            response.status.vmwareValidationStatus,
+            response.status.vmwareValidationMessage
+          )
+        }
+      } catch (err) {
+        console.error('Error validating VMware credentials', err)
+        reportError(err as Error, {
+          context: 'vmware-validation-polling',
+          metadata: {
+            credentialName: createdCredentialName,
+            action: 'vmware-validation-status-polling'
+          }
+        })
+        setError('Error validating VMware credentials')
+        setValidatingVmwareCreds(false)
+        setSubmitting(false)
+      }
+    },
+    THREE_SECONDS,
+    shouldPollVmwareCreds
+  )
 
-    return (
-        <StyledDrawer
-            anchor="right"
-            open={open}
-            onClose={closeDrawer}
-        >
-            <Header title="Add VMware Credentials" />
-            <DrawerContent>
-                <Box sx={{ display: "grid", gap: 3 }}>
-                    <FormControl fullWidth error={!!error || !!credNameError} required>
-                        <TextField
-                            id="credentialName"
-                            label="Enter VMware Credential Name"
-                            variant="outlined"
-                            value={formValues.credentialName}
-                            onChange={handleFormChange('credentialName')}
-                            error={!!error || !!credNameError}
-                            helperText={
-                                credNameError || (error && !credNameError ? error : "")
-                            }
-                            required
-                            fullWidth
-                            size="small"
-                            sx={{ mb: 2 }}
-                        />
+  const handleSubmit = useCallback(async () => {
+    // Clear previous errors
+    setError(null)
 
-                        <TextField
-                            id="vcenterHost"
-                            label="vCenter Server"
-                            variant="outlined"
-                            value={formValues.vcenterHost}
-                            onChange={handleFormChange('vcenterHost')}
-                            error={!!error}
-                            required
-                            fullWidth
-                            size="small"
-                            InputProps={{
-                                endAdornment: (
-                                    <InputAdornment position="end">
-                                        <Tooltip
-                                            title="Enter vCenter Server as http://vCenter-url.com or https://vCenter-url.com or vCenter-fqdn"
-                                            arrow
-                                            placement="left"
-                                        >
-                                            <IconButton size="small" tabIndex={-1}>
-                                                <InfoOutlined fontSize="small" />
-                                            </IconButton>
-                                        </Tooltip>
-                                    </InputAdornment>
-                                ),
-                            }}
-                            sx={{ mb: 2 }}
-                        />
+    if (
+      !formValues.credentialName ||
+      !formValues.vcenterHost ||
+      !formValues.datacenter ||
+      !formValues.username ||
+      !formValues.password
+    ) {
+      setError('Please fill in all required fields')
+      return
+    }
 
-                        <TextField
-                            id="datacenter"
-                            label="Datacenter Name"
-                            variant="outlined"
-                            value={formValues.datacenter}
-                            onChange={handleFormChange('datacenter')}
-                            error={!!error}
-                            required
-                            fullWidth
-                            size="small"
-                            sx={{ mb: 2 }}
-                        />
+    if (!isValidCredentialName) {
+      // Keep name-specific error separate
+      setCredNameError(
+        'Please provide a valid credential name (starts with a letter/number, uses letters/numbers/hyphens).'
+      )
+      return
+    }
 
-                        <TextField
-                            id="username"
-                            label="Username"
-                            variant="outlined"
-                            value={formValues.username}
-                            onChange={handleFormChange('username')}
-                            error={!!error}
-                            required
-                            fullWidth
-                            size="small"
-                            sx={{ mb: 2 }}
-                        />
+    setSubmitting(true)
+    setValidatingVmwareCreds(true)
 
-                        <TextField
-                            id="password"
-                            label="Password"
-                            type={showPassword ? "text" : "password"}
-                            variant="outlined"
-                            value={formValues.password}
-                            onChange={handleFormChange('password')}
-                            error={!!error}
-                            required
-                            fullWidth
-                            size="small"
-                            InputProps={{
-                                endAdornment: (
-                                    <InputAdornment position="end">
-                                        <IconButton
-                                            onClick={handleClickShowPassword}
-                                            onMouseDown={handleMouseDownPassword}
-                                            edge="end"
-                                            size="small"
-                                        >
-                                            {showPassword ? <VisibilityOff /> : <Visibility />}
-                                        </IconButton>
-                                    </InputAdornment>
-                                ),
-                            }}
-                        />
+    try {
+      const credentialData = {
+        VCENTER_HOST: formValues.vcenterHost,
+        VCENTER_DATACENTER: formValues.datacenter,
+        VCENTER_USERNAME: formValues.username,
+        VCENTER_PASSWORD: formValues.password,
+        ...(formValues.insecure && { VCENTER_INSECURE: true })
+      }
 
-                        {/* Insecure Connection Toggle */}
-                        <FormControlLabel
-                            control={
-                                <Switch
-                                    checked={formValues.insecure}
-                                    onChange={handleFormChange('insecure')}
-                                    name="insecure"
-                                    size="small"
-                                />
-                            }
-                            label="Allow insecure connection (skip SSL verification)"
-                            sx={{ mt: 1, mb: 1 }}
-                        />
+      const response = await createVMwareCredsWithSecretFlow(
+        formValues.credentialName,
+        credentialData
+      )
 
-                        {/* VMware Validation Status */}
-                        <Box sx={{ display: "flex", gap: 2, mt: 2, alignItems: "center" }}>
-                            {validatingVmwareCreds && (
-                                <>
-                                    <CircularProgress size={24} />
-                                    <FormLabel>
-                                        Validating  VMware credentials...
-                                    </FormLabel>
-                                </>
-                            )}
-                            {vmwareCredsValidated === true && formValues.credentialName && (
-                                <>
-                                    <CheckIcon color="success" fontSize="small" />
-                                    <FormLabel>VMware credentials created</FormLabel>
-                                </>
-                            )}
-                            {error && !credNameError && (
-                                <FormLabel sx={{ fontSize: "12px" }} color="error">
-                                    {error}
-                                </FormLabel>
-                            )}
-                        </Box>
-                    </FormControl>
-                </Box>
-            </DrawerContent>
-            <Footer
-                submitButtonLabel={validatingVmwareCreds ? "Validating..." : "Create Credentials"}
-                onClose={closeDrawer}
-                onSubmit={handleSubmit}
-                disableSubmit={submitting || validatingVmwareCreds || !isValidCredentialName || !formValues.vcenterHost || !formValues.datacenter || !formValues.username || !formValues.password}
-                submitting={submitting}
+      setCreatedCredentialName(response.metadata.name)
+
+      // Track successful credential creation
+      track(AMPLITUDE_EVENTS.CREDENTIALS_ADDED, {
+        credentialType: 'vmware',
+        credentialName: formValues.credentialName,
+        vcenterHost: formValues.vcenterHost,
+        namespace: response.metadata.namespace
+      })
+    } catch (error) {
+      console.error('Error creating VMware credentials:', error)
+
+      // Track credential creation failure
+      track(AMPLITUDE_EVENTS.CREDENTIALS_FAILED, {
+        credentialType: 'vmware',
+        credentialName: formValues.credentialName,
+        vcenterHost: formValues.vcenterHost,
+        errorMessage: error instanceof Error ? error.message : String(error),
+        stage: 'creation'
+      })
+
+      reportError(error as Error, {
+        context: 'vmware-credential-creation',
+        metadata: {
+          credentialName: formValues.credentialName,
+          vcenterHost: formValues.vcenterHost,
+          username: formValues.username,
+          action: 'create-vmware-credential'
+        }
+      })
+      setVmwareCredsValidated(false)
+      setValidatingVmwareCreds(false)
+      setError(
+        'Error creating VMware credentials: ' +
+          (axios.isAxiosError(error) ? error?.response?.data?.message : error)
+      )
+      setSubmitting(false)
+    }
+  }, [formValues, isValidCredentialName, track])
+
+  useKeyboardSubmit({
+    open,
+    isSubmitDisabled:
+      submitting ||
+      validatingVmwareCreds ||
+      !isValidCredentialName ||
+      !formValues.vcenterHost ||
+      !formValues.datacenter ||
+      !formValues.username ||
+      !formValues.password,
+    onSubmit: handleSubmit,
+    onClose: closeDrawer
+  })
+
+  return (
+    <StyledDrawer anchor="right" open={open} onClose={closeDrawer}>
+      <Header title="Add VMware Credentials" />
+      <DrawerContent>
+        <Box sx={{ display: 'grid', gap: 3 }}>
+          <FormControl fullWidth error={!!credNameError} required>
+            <TextField
+              id="credentialName"
+              label="Enter VMware Credential Name"
+              variant="outlined"
+              value={formValues.credentialName}
+              onChange={handleFormChange('credentialName')}
+              error={!!credNameError}
+              helperText={credNameError || ''}
+              required
+              fullWidth
+              size="small"
+              sx={{ mb: 2 }}
             />
-        </StyledDrawer>
-    );
-} 
+
+            <TextField
+              id="vcenterHost"
+              label="vCenter Server"
+              variant="outlined"
+              value={formValues.vcenterHost}
+              onChange={handleFormChange('vcenterHost')}
+              required
+              fullWidth
+              size="small"
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <Tooltip
+                      title="Enter vCenter Server as http://vCenter-url.com or https://vCenter-url.com or vCenter-fqdn"
+                      arrow
+                      placement="left"
+                    >
+                      <IconButton size="small" tabIndex={-1}>
+                        <InfoOutlined fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </InputAdornment>
+                )
+              }}
+              sx={{ mb: 2 }}
+            />
+
+            <TextField
+              id="datacenter"
+              label="Datacenter Name"
+              variant="outlined"
+              value={formValues.datacenter}
+              onChange={handleFormChange('datacenter')}
+              required
+              fullWidth
+              size="small"
+              sx={{ mb: 2 }}
+            />
+
+            <TextField
+              id="username"
+              label="Username"
+              variant="outlined"
+              value={formValues.username}
+              onChange={handleFormChange('username')}
+              required
+              fullWidth
+              size="small"
+              sx={{ mb: 2 }}
+            />
+
+            <TextField
+              id="password"
+              label="Password"
+              type={showPassword ? 'text' : 'password'}
+              variant="outlined"
+              value={formValues.password}
+              onChange={handleFormChange('password')}
+              required
+              fullWidth
+              size="small"
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      onClick={handleClickShowPassword}
+                      onMouseDown={handleMouseDownPassword}
+                      edge="end"
+                      size="small"
+                    >
+                      {showPassword ? <VisibilityOff /> : <Visibility />}
+                    </IconButton>
+                  </InputAdornment>
+                )
+              }}
+            />
+
+            {/* Insecure Connection Toggle */}
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={formValues.insecure}
+                  onChange={handleFormChange('insecure')}
+                  name="insecure"
+                  size="small"
+                />
+              }
+              label="Allow insecure connection (skip SSL verification)"
+              sx={{ mt: 1, mb: 1 }}
+            />
+
+            {/* VMware Validation Status */}
+            <Box sx={{ display: 'flex', gap: 2, mt: 2, alignItems: 'center' }}>
+              {validatingVmwareCreds && (
+                <>
+                  <CircularProgress size={24} />
+                  <FormLabel>Validating VMware credentials...</FormLabel>
+                </>
+              )}
+              {vmwareCredsValidated === true && formValues.credentialName && (
+                <>
+                  <CheckIcon color="success" fontSize="small" />
+                  <FormLabel>VMware credentials created</FormLabel>
+                </>
+              )}
+            </Box>
+
+            {/* Show one clear place for global/form errors */}
+            {error && (
+              <FormHelperText error sx={{ mt: 1 }}>
+                {error}
+              </FormHelperText>
+            )}
+          </FormControl>
+        </Box>
+      </DrawerContent>
+      <Footer
+        submitButtonLabel={validatingVmwareCreds ? 'Validating...' : 'Create Credentials'}
+        onClose={closeDrawer}
+        onSubmit={handleSubmit}
+        disableSubmit={
+          submitting ||
+          validatingVmwareCreds ||
+          !isValidCredentialName ||
+          !formValues.vcenterHost?.trim() ||
+          !formValues.datacenter?.trim() ||
+          !formValues.username?.trim() ||
+          !formValues.password?.trim()
+        }
+        submitting={submitting}
+      />
+    </StyledDrawer>
+  )
+}


### PR DESCRIPTION
## What this PR does / why we need it
fix: Removed duplicate error text on credential creation failure

## Which issue(s) this PR fixes
- https://github.com/platform9/vjailbreak/issues/1129

## Testing done
<img width="1520" height="737" alt="Screenshot from 2025-11-27 12-08-15" src="https://github.com/user-attachments/assets/05f081e9-d49f-4b92-9cd1-8d7b28df7fc9" />
<img width="1520" height="737" alt="Screenshot from 2025-11-27 11-57-04" src="https://github.com/user-attachments/assets/2808a13d-7926-4079-b1a4-8204a6579003" />
<img width="1520" height="737" alt="image" src="https://github.com/user-attachments/assets/23310dee-aeed-4aef-b48b-34b603d7d44c" /> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Removes duplicate error messages during credential creation failure in the VMwareCredentialsDrawer component, which may improve clarity but does not address underlying issues.</li>

<li>Improvements to validation and submission logic in the VMwareCredentialsDrawer component ensure users receive accurate feedback when errors occur.</li>

<li>Enhances user experience by providing clearer feedback without redundancy in error handling during credential creation.</li>

<li>Overall, the modifications focus on improving error handling and user feedback in the VMwareCredentialsDrawer component.</li>

</ul>

</div>