### PR TITLE
#1175 :: Periodic sync validation requires clicking outside the input box before the Start button becomes enabled/disabled, which leads to start migration enabled even with wrong value sometimes

### DIFF
--- a/ui/src/components/forms/IntervalField.tsx
+++ b/ui/src/components/forms/IntervalField.tsx
@@ -62,11 +62,11 @@ const IntervalField = ({
       const newValidationError = validate(newValue)
       setValidationError(newValidationError)
       if (getErrorsUpdater) {
-        getErrorsUpdater?.(name)(newValidationError || '')
+        getErrorsUpdater(name)(newValidationError || '')
       }
       onChange?.(event)
     },
-    [validate, onChange]
+    [validate, onChange, getErrorsUpdater, name]
   )
 
   return (


### PR DESCRIPTION
## What this PR does / why we need it
- fix: improve validation and error handling in the IntervalField component

## Which issue(s) this PR fixes
- https://github.com/platform9/vjailbreak/issues/1175

## Testing done
[Screencast from 27-11-25 04:59:56 PM IST.webm](https://github.com/user-attachments/assets/da2d80ef-3088-4402-9df5-4a7ba64bdd66) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request introduces state management for validation errors in the IntervalField component.</li>

<li>It updates error messages to provide clearer guidance on input formats.</li>

<li>The changes aim to improve user feedback by ensuring that the Start button is only enabled with valid input values.</li>

<li>Overall, the pull request touches on validation handling and user feedback mechanisms, introducing new state management for errors.</li>

</ul>

</div>