### PR TITLE
In advanced option validation check only for granularoptions ignore rest

### DIFF
--- a/k8s/migration/pkg/utils/migrationplanutils.go
+++ b/k8s/migration/pkg/utils/migrationplanutils.go
@@ -10,7 +10,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"reflect"
 	"regexp"
 	"strings"
 	"unicode"
@@ -81,11 +80,17 @@ func ValidateMigrationPlan(migrationplan *vjailbreakv1alpha1.MigrationPlan) erro
 		return fmt.Errorf("cutover start time is after cutover end time")
 	}
 
-	// If advanced options are set, then there should only be 1 VM in the migrationplan
-	if !reflect.DeepEqual(migrationplan.Spec.AdvancedOptions, vjailbreakv1alpha1.AdvancedOptions{}) &&
+	// Check if granular options (VM-specific) are set
+	hasGranularOptions := len(migrationplan.Spec.AdvancedOptions.GranularVolumeTypes) > 0 ||
+		len(migrationplan.Spec.AdvancedOptions.GranularNetworks) > 0 ||
+		len(migrationplan.Spec.AdvancedOptions.GranularPorts) > 0
+
+	// If granular options are set, then there should only be 1 VM in the migrationplan
+	// Periodic sync options are plan-level and can apply to multiple VMs
+	if hasGranularOptions &&
 		(len(migrationplan.Spec.VirtualMachines) != 1 || len(migrationplan.Spec.VirtualMachines[0]) != 1) {
-		return fmt.Errorf(`advanced options can only be set for a single VM.
-			Please remove advanced options or reduce the number of VMs in the migrationplan`)
+		return fmt.Errorf(`granular options (volumes/networks/ports) can only be set for a single VM.
+			Please remove granular options or reduce the number of VMs in the migrationplan`)
 	}
 	return nil
 }


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1182 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request introduces enhanced validation logic for advanced options in migration plans, ensuring granular options are only applicable to a single VM.</li>

<li>It introduces checks to validate the presence of granular volume types, networks, and ports.</li>

<li>Clear error messages are provided if the validation conditions are not met.</li>

<li>Overall, this change touches on validation logic and error handling, aiming to improve the robustness of the migration process.</li>

</ul>

</div>