### PR TITLE
#1181 :: UI: Move to folder cannot use anyother name, when clearing the vjailbreakedVMs it appears again

### DIFF
--- a/ui/src/features/migration/MigrationOptionsAlt.tsx
+++ b/ui/src/features/migration/MigrationOptionsAlt.tsx
@@ -312,11 +312,11 @@ export default function MigrationOptionsAlt({
                 size="small"
                 label="VM Rename Suffix"
                 disabled={!selectedMigrationOptions.postMigrationAction?.renameVm}
-                value={params.postMigrationAction?.suffix || '_migrated_to_pcd'}
+                value={params.postMigrationAction?.suffix || ''}
                 onChange={(e) => {
                   onChange('postMigrationAction')({
                     ...params.postMigrationAction,
-                    suffix: e.target.value
+                    suffix: e.target.value?.trim() || undefined
                   })
                 }}
                 placeholder="_migrated_to_pcd"
@@ -356,11 +356,11 @@ export default function MigrationOptionsAlt({
                 size="small"
                 label="Folder Name"
                 disabled={!selectedMigrationOptions.postMigrationAction?.moveToFolder}
-                value={params.postMigrationAction?.folderName || 'vjailbreakedVMs'}
+                value={params.postMigrationAction?.folderName || ''}
                 onChange={(e) => {
                   onChange('postMigrationAction')({
                     ...params.postMigrationAction,
-                    folderName: e.target.value
+                    folderName: e.target.value?.trim() || undefined
                   })
                 }}
                 placeholder="vjailbreakedVMs"


### PR DESCRIPTION
## What this PR does / why we need it
Updated the logic for 'Move to Folder in VMware' and 'Rename VMware VM' to enable clearing and passing new values.

## Which issue(s) this PR fixes
- https://github.com/platform9/vjailbreak/issues/1181

## Testing done
<img width="1533" height="750" alt="Screenshot from 2025-11-28 11-13-14" src="https://github.com/user-attachments/assets/b47c530b-21bd-4d55-9801-ae2dae169d3a" />

[Screencast from 28-11-25 11:14:13 AM IST.webm](https://github.com/user-attachments/assets/6801b89d-1e6d-41f5-a470-4bdcf3d19098) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request enhances the migration options in the UI by allowing users to clear the 'VM Rename Suffix' and 'Folder Name' fields.</li>

<li>The changes ensure that when these fields are cleared, they do not revert to default values, thus improving user experience.</li>

<li>Overall, this update provides more flexibility in managing VM migration settings.</li>

</ul>

</div>