### PR TITLE
Added check to fallback to 5m if interval is less than 5m

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -355,10 +355,6 @@ func (migobj *Migrate) getSyncDuration() time.Duration {
 		migobj.logMessage(fmt.Sprintf("WARNING: Failed to parse interval %s, using default interval (%s)", interval, defaultInterval))
 		interval = defaultInterval
 		waitTime, _ = time.ParseDuration(interval)
-	if err != nil {
-		migobj.logMessage(fmt.Sprintf("WARNING: Failed to parse interval %s, using default interval (%s)", interval, defaultInterval))
-		interval = defaultInterval
-		waitTime, _ = time.ParseDuration(interval)
 	} else if waitTime < 5*time.Minute {
 		migobj.logMessage(fmt.Sprintf("WARNING: Interval %s is less than 5 minutes, falling back to 5m", interval))
 		waitTime = 5 * time.Minute


### PR DESCRIPTION
## What this PR does / why we need it

fix - Bug: Edited the sync interval to lesser than 5mins to 3mins code accepted it.

fixes #1185 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request introduces a bug fix that ensures the synchronization interval does not fall below 5 minutes.</li>

<li>A new check was added to log a warning and adjust the interval if it is set to a value less than 5 minutes.</li>

<li>This change addresses an issue where the system could operate with an insufficient wait time, potentially leading to performance problems.</li>

<li>Overall, this update modifies the synchronization interval handling to prevent performance issues.</li>

</ul>

</div>