### PR TITLE
#1192 :: Bug: Migration Submit button is disabled when triggering admin cutover with periodic sync

### DIFF
--- a/ui/src/components/forms/IntervalField.tsx
+++ b/ui/src/components/forms/IntervalField.tsx
@@ -56,26 +56,29 @@ const IntervalField = ({
     return undefined
   }, [])
 
-  const handleInputChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const newValue = event.target.value
+  const updateValidationError = useCallback(
+    (newValue: string) => {
       const newValidationError = validate(newValue)
       setValidationError(newValidationError)
       if (getErrorsUpdater) {
         getErrorsUpdater(name)(newValidationError || '')
       }
+    },
+    [validate, getErrorsUpdater, name]
+  )
+
+  const handleInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = event.target.value
+      updateValidationError(newValue)
       onChange?.(event)
     },
-    [validate, onChange, getErrorsUpdater, name]
+    [updateValidationError, onChange]
   )
 
   useEffect(() => {
-    const newValidationError = validate(value)
-    setValidationError(newValidationError)
-    if (getErrorsUpdater) {
-      getErrorsUpdater(name)(newValidationError || '')
-    }
-  }, [value, validate, getErrorsUpdater, name])
+    updateValidationError(value)
+  }, [value, updateValidationError])
 
   return (
     <Box display="flex" flexDirection="column" gap={0.5}>


### PR DESCRIPTION
## What this PR does / why we need it
- Add validation effect to update error state on value change

## Which issue(s) this PR fixes
- https://github.com/platform9/vjailbreak/issues/1192

## Testing done
[Screencast from 01-12-25 12:13:52 PM IST.webm](https://github.com/user-attachments/assets/e881ec65-4e6e-4e1a-9a21-679d172c4fc9) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request adds a useEffect hook in the IntervalField component that updates the validation error state whenever the input value changes.</li>

<li>The changes aim to provide immediate feedback to users, addressing the issue of the Migration Submit button being disabled during admin cutover with periodic sync.</li>

<li>Overall, the changes significantly improve user experience by ensuring real-time validation feedback.</li>

</ul>

</div>