### PR TITLE
Prebaked Openstack Cli inside the vjailbreak VM

### DIFF
--- a/image_builder/vjailbreak-image.pkr.hcl
+++ b/image_builder/vjailbreak-image.pkr.hcl
@@ -127,6 +127,8 @@ build {
     "sudo df -h",
     "echo '@reboot root /etc/pf9/install.sh' | sudo tee -a /etc/crontab", 
     "sudo bash /tmp/user_setup_daemon.sh",
+    "sudo apt update",
+    "sudo apt install python3-openstackclient -y",
     ]
   }
 }


### PR DESCRIPTION
## What this PR does / why we need it

Added the openstack cli inside the vjailbreak vm while the qcow2 is being created

fixes #998 

## Special notes for your reviewer


## Testing done
<img width="1273" height="482" alt="image" src="https://github.com/user-attachments/assets/fc2ff14e-626b-47d4-abe6-a14664757cfa" />
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request introduces the OpenStack CLI into the vjailbreak VM during the creation of the qcow2 image.</li>

<li>It adds necessary commands to update the package list and install the OpenStack client, enhancing the VM's capabilities.</li>

<li>This change addresses issue #998 and aims to streamline the setup process for users.</li>

<li>Overall, this update introduces new capabilities to the vjailbreak VM by integrating the OpenStack CLI and related commands.</li>

</ul>

</div>