### PR TITLE
fix - Migration controller logs are being flooded

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -1245,6 +1245,7 @@ func (r *MigrationPlanReconciler) TriggerMigration(ctx context.Context,
 
 			baseFlavor, err := utils.FindHotplugBaseFlavor(osClients.ComputeClient)
 			if err != nil {
+				// added constant prefix for the filter in reconciler
 				if err := r.UpdateMigrationPlanStatus(ctx, migrationplan, corev1.PodFailed, fmt.Sprintf("%s to discover base flavor for flavorless migration", constants.MigrationPlanValidationFailedPrefix)); err != nil {
 					return errors.Wrap(err, "failed to update migration plan status after flavor discovery failure")
 				}


### PR DESCRIPTION
## What this PR does / why we need it

This PR ensures that the reconciler does not retry if failure happens in "Hotplug-Enabled Flavors", hence avoiding the flooding of logs in controller.

## Which issue(s) this PR fixes

fixes #1200 

## Special notes for your reviewer


## Testing done
**Skipping Retries**
<img width="1905" height="443" alt="image" src="https://github.com/user-attachments/assets/abe3547a-ac02-4a37-92af-9b904697cb5f" />

**Migrationplan in failed state**
<img width="664" height="112" alt="image" src="https://github.com/user-attachments/assets/f9abb92c-8763-46d7-9dc5-f3263635e260" />

**Migrationplan Error message**
<img width="1100" height="610" alt="image" src="https://github.com/user-attachments/assets/a886c9df-dc31-4bd6-af09-e2181983cabf" /> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Modifies the reconciler's behavior in the migration controller to avoid retries on failures related to hotplug-enabled flavors, addressing excessive logging.</li>

<li>Enhances the logic for updating the migration plan status to ensure updates only occur when necessary, aiming to reduce log clutter.</li>

<li>Overall summary: modifies the migration controller's reconciler behavior and migration plan status logic to reduce log clutter and improve efficiency.</li>

</ul>

</div>