### PR TITLE
Fix batch script to properly write self-delete logic to the generated startup script

### DIFF
--- a/scripts/firstboot/windows/vmware-tools-deletion.bat
+++ b/scripts/firstboot/windows/vmware-tools-deletion.bat
@@ -201,5 +201,5 @@ echo REG DELETE "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\VMwareCAFC
 echo REG DELETE "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\VMwareCAFManagementAgentHost" /f >> "%startupScriptPath%"
 echo echo "Deleted all entries" >> "%startupScriptPath%"
 echo timeout /t 60 >> "%startupScriptPath%"
-echo start /b "" cmd /c del "%~f0"&exit /b >> "%startupScriptPath%"
+echo start /b "" cmd /c del "%%~f0"^&exit /b >> "%startupScriptPath%"
 echo Script execution completed.


### PR DESCRIPTION
## What this PR does / why we need it
Fixes an issue where the batch script unintentionally executed the `del "%~f0"` command during generation instead of writing it into the generated startup script.
The fix escapes `%`and `&` (`%%~f0` and `^&`) so the full command is correctly written to the output script (startup script) without being executed prematurely.

fixes #1252 

## Special notes for your reviewer
Add the contents of updated vmware-tools-deletion.bat and append the disk-check.bat file contents in post-check field in the migration form
link to disk-check: https://github.com/amar-chand/vjailbreak/blob/main/scripts/firstboot/windows/check-disks.bat


## Testing done
1. Added VMware-tools-deletion script and appended disk-check script in the migration form, Verified that the script no longer executes the delete command prematurely, which was earlier causing the script to break.
2. The generated startup script contains the correct del "%~f0"&exit /b line.
3. The startup Script got deleted from the startup folder (`%ProgramData%\Microsoft\Windows\Start Menu\Programs\Startup\`) post execution
4. Disk-check step executes successfully after this fix. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Fixes a bug in the VMware tools deletion batch script by ensuring the self-delete command is correctly written to the generated startup script instead of being executed during script generation.</li>

<li>Involves escaping certain characters to prevent premature execution of the command.</li>

<li>Testing confirmed that the startup script now functions as intended, with the correct command included and the script executing successfully.</li>

<li>Overall summary: addresses a bug in the VMware tools deletion batch script, ensuring correct command execution and preventing premature execution.</li>

</ul>

</div>