### PR TITLE
#1202 :: Bug :: Single migrationtemplate object should be created for one migrationplan (Use Dynamic Hotplug-Enabled Flavors is the advance option making post calls)

### DIFF
--- a/ui/src/features/migration/MigrationForm.tsx
+++ b/ui/src/features/migration/MigrationForm.tsx
@@ -314,12 +314,16 @@ export default function MigrationFormDrawer({
         console.error('Error syncing migration template', err)
         getFieldErrorsUpdater('migrationTemplate')(
           'Error syncing migration template: ' +
-            (axios.isAxiosError(err) ? err?.response?.data?.message : err)
+            (axios.isAxiosError(err)
+              ? err?.response?.data?.message
+              : err instanceof Error
+                ? err.message
+                : String(err))
         )
       }
     }
 
-    void syncMigrationTemplate()
+    syncMigrationTemplate()
   }, [
     vmwareCredsValidated,
     openstackCredsValidated,


### PR DESCRIPTION
## What this PR does / why we need it
- Refactored migration template handling in MigrationForm: Introduced sync logic to update existing templates or create new ones based on validation checks. 
- Improved error handling for template synchronization.

## Fixes 
- Rather than creating a new migration template object with each change, the updated approach will create the migration template object only once and then patch or synchronize it whenever there are updates.

## Which issue(s) this PR fixes
- https://github.com/platform9/vjailbreak/issues/1202

## Testing done
[Screencast from 02-12-25 08:44:54 PM IST.webm](https://github.com/user-attachments/assets/13c897a3-6b6e-435c-accd-39356ab8e873) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request introduces synchronization logic in the MigrationForm component to update existing migration templates or create new ones based on validation checks, preventing unnecessary object creation.</li>

<li>Refactors the migration template handling in the MigrationForm component, enhancing error handling during the synchronization process and providing better feedback in case of failures.</li>

<li>Overall summary: touches on migration template handling, error handling, and synchronization logic; introduces improvements in efficiency and feedback.</li>

</ul>

</div>