### PR TITLE
fix - Password set in cloud init is not being reflected

### DIFF
--- a/image_builder/scripts/user_setup_daemon.sh
+++ b/image_builder/scripts/user_setup_daemon.sh
@@ -12,8 +12,13 @@ ExecStart=/bin/bash -c '\
     echo "Creating user ubuntu..."; \
     useradd -m -s /bin/bash ubuntu; \
   fi; \
-  echo "ubuntu:password" | chpasswd; \
-  passwd --expire ubuntu && echo "Password expired for ubuntu — must change on first login"; \
+  if grep -iq '^password:' /var/lib/cloud/instance/user-data.txt* 2>/dev/null; then \
+      echo "Yes – password was set via cloud-init!"; \
+  else \
+    echo "Setting default password for ubuntu..."; \
+    echo "ubuntu:password" | chpasswd; \
+    passwd --expire ubuntu && echo "Password expired for ubuntu — must change on first login"; \
+  fi; \
 '
 ExecStartPost=/bin/touch /var/lib/setup-ubuntu-user.done
 RemainAfterExit=yes


### PR DESCRIPTION
## What this PR does / why we need it

Ensuring the cloud - init password persists and if nothing is set then it falls back to "password"

fixes #1225 

**if cloud init is not setting the password**

<img width="1440" height="859" alt="image" src="https://github.com/user-attachments/assets/fb2d88d6-22db-4192-9dee-d7ae54c193d2" />

**if the password is set in cloud init**

<img width="895" height="543" alt="image" src="https://github.com/user-attachments/assets/b52f2a5d-3c69-4c9e-b6c3-9299ed968f8e" />

 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Mitigates security risks by ensuring the password set during cloud-init for the 'ubuntu' user is applied if specified in the configuration.</li>

<li>Defaults to 'password' if no password is specified in the cloud-init configuration, addressing a critical issue in user initialization.</li>

<li>Ensures proper user initialization in cloud environments.</li>

<li>Overall summary: addresses cloud-init configurations for the 'ubuntu' user, mitigates security risks.</li>

</ul>

</div>