### PR TITLE
add more aggressive cleaning in v2v-helper

### DIFF
--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -28,7 +28,13 @@ FROM fedora:42
 WORKDIR /tmp/rpms
 COPY v2v-helper/nbdkit/*.rpm /tmp/rpms/
 
+# Install runtime dependencies with size optimizations:
+# - --nodocs: Skip documentation files
+# - --setopt=install_weak_deps=False: Skip weak dependencies
+# - Clean up aggressively after install
 RUN dnf install -y \
+    --nodocs \
+    --setopt=install_weak_deps=False \
     ./libnbd-1.22.2-1.fc42.x86_64.rpm \
     ./nbdkit-server-1.42.4-1.fc42.x86_64.rpm \
     ./nbdkit-basic-plugins-1.42.4-1.fc42.x86_64.rpm \
@@ -42,14 +48,20 @@ RUN dnf install -y \
     ./virt-v2v-2.7.13-1.fc42.x86_64.rpm \
     ./nbdkit-selinux-1.42.4-1.fc42.noarch.rpm && \
     dnf clean all && \
-    rm -rf /var/cache/dnf /tmp/rpms/
+    rm -rf /var/cache/dnf /var/cache/yum /tmp/rpms/ && \
+    rm -rf /usr/share/doc /usr/share/man /usr/share/info /usr/share/locale && \
+    find /var/log -type f -delete
 
-#version lock 
-RUN dnf versionlock add nbdkit-1.42.4-1.fc42 nbdkit-vddk-plugin-1.42.4-1.fc42 \
+# Version lock to prevent accidental upgrades
+# Install versionlock plugin without docs to save space
+RUN dnf install -y --nodocs --setopt=install_weak_deps=False python3-dnf-plugin-versionlock && \
+    dnf versionlock add nbdkit-1.42.4-1.fc42 nbdkit-vddk-plugin-1.42.4-1.fc42 \
     libnbd-1.22.2-1.fc42 nbdkit-server-1.42.4-1.fc42 nbdkit-basic-plugins-1.42.4-1.fc42 \ 
     nbdkit-basic-filters-1.42.4-1.fc42 nbdkit-curl-plugin-1.42.4-1.fc42 \
     nbdkit-ssh-plugin-1.42.4-1.fc42 nbdkit-python-plugin-1.42.4-1.fc42 \
-    nbdkit-nbd-plugin-1.42.4-1.fc42 virt-v2v-2.7.13-1.fc42.x86_64 nbdkit-selinux-1.42.4-1.fc42.noarch
+    nbdkit-nbd-plugin-1.42.4-1.fc42 virt-v2v-2.7.13-1.fc42.x86_64 nbdkit-selinux-1.42.4-1.fc42.noarch && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf /var/cache/yum
 
 # Copy the binary from builder stage to the runtime environment
 COPY --from=builder /workspace/manager /home/fedora/manager


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1238 

## Special notes for your reviewer


## Testing done


<img width="1137" height="319" alt="Screenshot 2025-12-09 at 2 52 26 PM" src="https://github.com/user-attachments/assets/1b98d54e-6fe0-4833-acbb-4597fe059cb3" />

<ul>

<li>This pull request introduces more aggressive cleanup steps in the Dockerfile for the v2v-helper, which may impact the build process.</li>

<li>It removes unnecessary files and skips documentation during installation, potentially affecting the completeness of the Docker image.</li>

<li>The changes optimize the installation of runtime dependencies, aiming to streamline the build process.</li>

<li>Overall, the pull request touches on the Dockerfile and installation process, introducing risks related to build completeness and efficiency.</li>

</ul>

</div>