### PR TITLE
Docs - Cloud Init password Setup for Vjailbreak VM 

### DIFF
--- a/docs/src/content/docs/introduction/getting_started.mdx
+++ b/docs/src/content/docs/introduction/getting_started.mdx
@@ -62,7 +62,7 @@ Cloud-init can be used during VM creation to automate initial configuration incl
   ```
 - You can provide this cloud-init configuration when creating the VM through the OpenStack dashboard or CLI.
 
-**Note:** If you do not set a password for the `ubuntu` user using cloud-init, the default password for the `ubuntu` user will be set to "password." After the first login, you will be prompted to change the password and if the password is set using cloud - init you will not be prompted to change the password at first login.
+**Note:** If you do not set a password for the `ubuntu` user using cloud-init, the default password for the `ubuntu` user will be set to "password." After the first login, you will be prompted to change the password and if the password is set using cloud-init you will not be prompted to change the password at first login.
 
 
 


### PR DESCRIPTION
## What this PR does / why we need it

Added a special note for password setup for the vjailbreak `ubuntu` user 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Adds a crucial note about the password setup for the 'ubuntu' user when using cloud-init, clarifying that if no password is set, the default will be 'password'.</li>

<li>Improves user experience and security awareness by informing users they will be prompted to change the default password upon first login.</li>

<li>Overall summary: touches on documentation for vJailbreak VM, introduces security awareness regarding password setup.</li>

</ul>

</div>