### PR TITLE
Reduced log verbosity for disk copy

### DIFF
--- a/v2v-helper/nbd/nbdops.go
+++ b/v2v-helper/nbd/nbdops.go
@@ -177,9 +177,8 @@ func (nbdserver *NBDServer) CopyDisk(ctx context.Context, dest string, diskindex
 		scanner := bufio.NewScanner(progressRead)
 		
 		lastLoggedProgress := -1
-		logInterval := 5
-		
-		lastChannelProgress := 0 
+		const logInterval = 5
+		lastChannelProgress := 0
 
 		for scanner.Scan() {
 			progressInt, _, err := utils.ParseFraction(scanner.Text())
@@ -189,7 +188,7 @@ func (nbdserver *NBDServer) CopyDisk(ctx context.Context, dest string, diskindex
 			}
 			msg := fmt.Sprintf("Copying disk %d, Completed: %d%%", diskindex, progressInt)
 
-			if progressInt > lastLoggedProgress && progressInt % logInterval == 0 {
+			if progressInt == 0 || progressInt == 100 || (progressInt > lastLoggedProgress && progressInt%logInterval == 0) {
 				utils.PrintLog(msg)
 				lastLoggedProgress = progressInt
 			}
@@ -424,7 +423,7 @@ func (nbdserver *NBDServer) CopyChangedBlocks(ctx context.Context, changedAreas 
 	go func() {
 		copiedsize := int64(0)
 		lastLoggedPct := -1
-		logInterval := 5
+		const logInterval = 5
 		startTime := time.Now()
 		nbdserver.StartTime = startTime
 		nbdserver.TotalSize = totalsize
@@ -432,16 +431,16 @@ func (nbdserver *NBDServer) CopyChangedBlocks(ctx context.Context, changedAreas 
 			copiedsize += progress
 			nbdserver.CopiedSize = copiedsize
 			nbdserver.Duration = time.Since(startTime)
-			
+
 			currentPct := int(float64(copiedsize) / float64(totalsize) * 100.0)
 
-			prog := fmt.Sprintf("Progress: %.2f%%", float64(copiedsize)/float64(totalsize)*100.0)
-			
-			if currentPct > lastLoggedPct && currentPct % logInterval == 0 {
+			prog := fmt.Sprintf("Progress: %d%%", currentPct)
+
+			if currentPct == 0 || currentPct == 100 || (currentPct > lastLoggedPct && currentPct%logInterval == 0) {
 				utils.PrintLog(prog)
 				lastLoggedPct = currentPct
 			}
-			
+
 			nbdserver.progresschan <- prog
 		}
 	}()


### PR DESCRIPTION
## What this PR does / why we need it

- In CopyDisk:
      Logs are generated at 5% intervals (0%, 5%, 10%...).

- In CopyChangedBlocks:
      Applied the same 5% logic to prevent incremental copy logs from flooding the system during large transfers.

## Which issue(s) this PR fixes
fixes #


## Testing done

<img width="1211" height="746" alt="image" src="https://github.com/user-attachments/assets/23750a30-5c4f-485e-ae65-27761c013cb2" />
<img width="1341" height="191" alt="image" src="https://github.com/user-attachments/assets/dd38ae7d-e503-44fa-8b3b-6f31db2b5231" />
 
debug logs 
<img width="1440" height="369" alt="image" src="https://github.com/user-attachments/assets/7e50081c-f5aa-4be3-866b-8370b0dcf062" />

<h3>Summary by Bito</h3>

<ul>

<li>This pull request introduces a logging interval of 5% during disk copy operations to prevent excessive log entries, particularly during large transfers.</li>

<li>The changes apply to both the CopyDisk and CopyChangedBlocks functions, ensuring a more manageable logging output.</li>

<li>Overall, this update modifies the logging mechanism for disk copy operations, introducing a logging interval to reduce verbosity.</li>

</ul>

</div>