### PR TITLE
reflect current default migration method in migration form

### DIFF
--- a/ui/src/features/migration/MigrationOptionsAlt.tsx
+++ b/ui/src/features/migration/MigrationOptionsAlt.tsx
@@ -86,10 +86,11 @@ export default function MigrationOptionsAlt({
 
   // Iniitialize fields
   useEffect(() => {
-    onChange('dataCopyMethod')('cold')
+    const defaultMethod = globalConfigMap?.data?.DEFAULT_MIGRATION_METHOD || 'cold'
+    onChange('dataCopyMethod')(defaultMethod)
     onChange('cutoverOption')(CUTOVER_TYPES.IMMEDIATE)
     refetchConfigMap()
-  }, [refetchConfigMap])
+  }, [refetchConfigMap, globalConfigMap])
 
   const getMinEndTime = useCallback(() => {
     let minDate = params.cutoverStartTime


### PR DESCRIPTION
## What this PR does / why we need it
Currently the default migration method in the migration form was hardcoded to 'cold'
This PR changes that based on the DEFAULT_MIGRATION_METHOD setting in the `vjailbreak-settings` configmap

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #

## Special notes for your reviewer


## Testing done
<img width="1104" height="513" alt="Screenshot 2025-12-11 at 8 09 53 PM" src="https://github.com/user-attachments/assets/d48d952e-19a2-4046-8bec-6aff1258d771" />
<img width="1244" height="212" alt="Screenshot 2025-12-11 at 8 10 12 PM" src="https://github.com/user-attachments/assets/5ddffd7b-8fdf-4a78-bd1c-ce922a88a6c0" />
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Updates the default migration method from a hardcoded value to a configurable one based on the DEFAULT_MIGRATION_METHOD setting in the vjailbreak-settings configmap, enhancing flexibility.</li>

<li>Modifies the useEffect hook to reflect the new default migration method, ensuring correct application behavior based on the configuration.</li>

<li>Overall summary: touches the vjailbreak-settings configmap and the migration form, introduces flexibility in the migration process.</li>

</ul>

</div>