### PR TITLE
Implement Session Timeout (18 hours inactivity) for UI 

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -19,8 +19,11 @@ COPY tsconfig.json .
 
 RUN yarn build
 
-# Use a lightweight Nginx image to serve the built app
-FROM nginx:1.24-alpine3.17-slim
+# Use OpenResty image with Lua module support
+FROM openresty/openresty:alpine
+
+# Install envsubst (gettext package)
+RUN apk add --no-cache gettext
 
 # Copy built assets from the build stage
 COPY --from=builder /usr/src/app/dist /usr/share/nginx/html
@@ -29,7 +32,7 @@ COPY --from=builder /usr/src/app/dist /usr/share/nginx/html
 COPY public /usr/share/nginx/html
 
 # Copy the Nginx configuration file
-COPY default.conf /etc/nginx/conf.d/default.conf
+COPY default.conf /usr/local/openresty/nginx/conf/nginx.conf
 
 # Copy the startup script
 COPY startup.sh /usr/local/bin/start.sh

--- a/ui/default.conf
+++ b/ui/default.conf
@@ -1,14 +1,74 @@
-server {
-    error_page 401 =401 /__auth_401;
+events {
+    worker_connections 1024;
+}
 
-    location = /__auth_401 {
-        default_type text/plain;
-        return 401 "Authentication failed. Please provide valid credentials.";
-    }
-    location / {
-        auth_basic "Restricted Resources"; 
-        auth_basic_user_file /etc/nginx/shadow;
-        root /usr/share/nginx/html;
-        try_files $uri $uri/ /index.html;
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile      on;
+    keepalive_timeout  65;
+
+    server {
+        # Custom 401 page (optional, you can keep it or remove)
+        error_page 401 =401 /__auth_401;
+        location = /__auth_401 {
+            default_type text/plain;
+            return 401 "Authentication required";
+        }
+
+        location / {
+            # -------------------------------
+            # 1. Lua block runs on every request
+            # -------------------------------
+            access_by_lua_block {
+                local SESSION_TIMEOUT = 64800 -- seconds (sliding)
+
+                local cookie = ngx.var.cookie_auth_session
+                local now = ngx.time()
+
+                -- If we have a valid non-expired session cookie → skip Basic Auth entirely
+                if cookie then
+                    local session_ts = tonumber(cookie)
+                    if session_ts and (now - session_ts <= SESSION_TIMEOUT) then
+                        ngx.log(ngx.ERR,"Session Stable Renewing the session")
+                        ngx.header["Set-Cookie"] = "auth_session=" .. now 
+                            .. "; Path=/; HttpOnly; Secure; SameSite=Strict"
+                        return
+                    else
+                        -- Expired or invalid cookie → treat as no session
+                        ngx.log(ngx.ERR, "Session expired or invalid, forcing re-auth")
+                        ngx.header["Set-Cookie"] = "auth_session=; Path=/; Max-Age=0; HttpOnly; Secure"
+			ngx.req.clear_header("Authorization")
+                    end
+                end
+                -- Let Nginx's auth_basic module validate the credentials
+                -- We temporarily turn it on just for this request
+                ngx.auth_request = true  -- internal flag used by auth_basic
+            }
+
+            # -------------------------------
+            # 2. Normal Basic Auth (still required for validation)
+            # -------------------------------
+            auth_basic           "Restricted Area";
+            auth_basic_user_file /etc/nginx/shadow;
+
+            # -------------------------------
+            # 3. If auth_basic succeeded → set/refresh session cookie
+            # -------------------------------
+            header_filter_by_lua_block {
+                local cookie = ngx.var.cookie_auth_session 
+                if ngx.status == 200 and not cookie then
+                    local now = ngx.time()
+                    ngx.header["Set-Cookie"] = "auth_session=" .. now 
+                        .. "; Path=/; HttpOnly; Secure; SameSite=Strict"
+                    ngx.log(ngx.ERR, "Login successful - session cookie set/renewed to ", now)
+                end
+            }
+
+            # Your actual application
+            root   /usr/share/nginx/html;
+            try_files $uri $uri/ /index.html;
+        }
     }
 }
+

--- a/ui/startup.sh
+++ b/ui/startup.sh
@@ -4,5 +4,5 @@
 VITE_API_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) envsubst < /usr/share/nginx/html/index.html > /usr/share/nginx/html/index.html.temp
 mv -f /usr/share/nginx/html/index.html.temp /usr/share/nginx/html/index.html
 
-# Start Nginx
-nginx -g 'daemon off;'
+# Start OpenResty
+/usr/local/openresty/bin/openresty -g 'daemon off;'


### PR DESCRIPTION
## What this PR does / why we need it

This PR introduces an explicit 18-hour inactivity-based session expiration mechanism for the UI that uses Basic Authentication. Previously, Basic Auth sessions could persist indefinitely or be governed by less explicit browser/OS behavior. To enhance security and resource management, a Lua script has been integrated into the Nginx configuration. This script explicitly tracks user activity and invalidates the session credential after 18 hours of continuous inactivity, forcing the user to re-authenticate and thereby ensuring that access is revoked for dormant sessions.

fixes #1263

## Testing done

https://github.com/user-attachments/assets/abf6c2d2-3a11-4ce7-9f84-59f47b635a16


_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Implements an 18-hour inactivity-based session expiration mechanism for the UI, enhancing security by ensuring that sessions are invalidated after a period of inactivity.</li>

<li>Replaces the existing Nginx setup with OpenResty, allowing for Lua scripting to track user activity.</li>

<li>Updates to the Dockerfile, Nginx configuration, and the startup script to support the new session management functionality.</li>

<li>Overall, the changes enhance security through session management improvements and involve updates to configurations in the Dockerfile and Nginx setup.</li>

</ul>

</div>