### PR TITLE
install vjbctl binary system wide

### DIFF
--- a/image_builder/scripts/install.sh
+++ b/image_builder/scripts/install.sh
@@ -74,7 +74,7 @@ sudo chmod 644 /etc/htpasswd
 sudo chown root:root /etc/htpasswd
 
 # Install vjbctl as a system-wide command in /usr/local/bin so it's available to all users (including root)
-cat > /usr/local/bin/vjbctl << 'EOF'
+sudo tee /usr/local/bin/vjbctl > /dev/null << 'EOF'
 #!/bin/bash
 # Source the main script to load all functions (user management, support-bundle, etc.)
 source /etc/pf9/pf9-htpasswd.sh


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1268 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request introduces the installation of the vjbctl binary as a system-wide command by modifying the existing install script.</li>

<li>It modifies the existing install script to include the necessary commands for setting up vjbctl.</li>

<li>The changes ensure proper permissions for the htpasswd file.</li>

<li>It ensures that the necessary permissions are set for the vjbctl binary, enhancing the installation process and permissions management.</li>

<li>Overall, the changes facilitate the use of vjbctl as a system-wide utility.</li>

<li>Overall, the changes touch on the installation process and permissions management, introducing the vjbctl command as a system-wide utility.</li>

</ul>

</div>