### PR TITLE
Reset currenState to initial in case of error and success

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -505,7 +505,6 @@ func (migobj *Migrate) WaitforAdminCutover(ctx context.Context, vminfo vm.VMInfo
 			migobj.logMessage(fmt.Sprintf("Periodic Sync: Starting sync cycle (interval: %s)", syncInterval))
 			start := time.Now()
 			if currentState == initial {
-
 				err := utils.DoRetryWithExponentialBackoff(ctx, func() error {
 					return vmops.CleanUpSnapshots(false)
 				}, maxRetries, capInterval)
@@ -530,10 +529,10 @@ func (migobj *Migrate) WaitforAdminCutover(ctx context.Context, vminfo vm.VMInfo
 			if currentState == TookSnapshot {
 				if err := migobj.SyncCBT(ctx, vminfo); err != nil {
 					migobj.logMessage(fmt.Sprintf("Periodic Sync: Failed to sync Changed Block Tracking (CBT): %v", err))
+					currentState = initial // Reset state on failure so we retry from start next loop
 					continue
-				} else {
-					currentState = initial
 				}
+				currentState = initial // Reset on success as well.
 			}
 			elapsed = time.Since(start)
 		}


### PR DESCRIPTION
## What this PR does / why we need it
If SyncCBT fails, we should consider that sync cycle failed and discard the current progress. The currentState should be reset to initial. This ensures that the next iteration will:
Clean up the old/failed snapshot.
Take a fresh snapshot (capturing the latest data).
Attempt to sync the new data. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1403 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_