### PR TITLE
Add VM power status check after poweroff

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -568,9 +568,17 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 			return vminfo, errors.Wrap(err, "failed to power off VM")
 		}
 		// Verify VM is actually powered off
-		currState, stateErr := vmops.GetVMObj().PowerState(ctx)
-		if stateErr == nil && currState != types.VirtualMachinePowerStatePoweredOff {
-			return vminfo, fmt.Errorf("VM power-off command completed but VM is still in state: %s", currState)
+		if err := utils.DoRetryWithExponentialBackoff(ctx, func() error {
+			currState, stateErr := vmops.GetVMObj().PowerState(ctx)
+			if stateErr != nil {
+				return stateErr
+			}
+			if currState != types.VirtualMachinePowerStatePoweredOff {
+				return fmt.Errorf("VM power-off command completed but VM is still in state: %s", currState)
+			}
+			return nil
+		}, constants.MaxPowerOffRetryLimit, constants.PowerOffRetryCap); err != nil {
+			return vminfo, errors.Wrap(err, "failed to verify VM power state after power off")
 		}
 	}
 
@@ -663,9 +671,17 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 					return vminfo, errors.Wrap(err, "failed to power off VM")
 				}
 				// Verify VM is actually powered off
-				currState, stateErr := vmops.GetVMObj().PowerState(ctx)
-				if stateErr == nil && currState != types.VirtualMachinePowerStatePoweredOff {
-					return vminfo, fmt.Errorf("VM power-off command completed but VM is still in state: %s", currState)
+				if err := utils.DoRetryWithExponentialBackoff(ctx, func() error {
+					currState, stateErr := vmops.GetVMObj().PowerState(ctx)
+					if stateErr != nil {
+						return stateErr
+					}
+					if currState != types.VirtualMachinePowerStatePoweredOff {
+						return fmt.Errorf("VM power-off command completed but VM is still in state: %s", currState)
+					}
+					return nil
+				}, constants.MaxPowerOffRetryLimit, constants.PowerOffRetryCap); err != nil {
+					return vminfo, errors.Wrap(err, "failed to verify VM power state after power off")
 				}
 			}
 			if err := migobj.WaitforCutover(); err != nil {
@@ -752,9 +768,17 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 					return vminfo, errors.Wrap(err, "failed to power off VM")
 				}
 				// Verify VM is actually powered off
-				currState, stateErr := vmops.GetVMObj().PowerState(ctx)
-				if stateErr == nil && currState != types.VirtualMachinePowerStatePoweredOff {
-					return vminfo, fmt.Errorf("VM power-off command completed but VM is still in state: %s", currState)
+				if err := utils.DoRetryWithExponentialBackoff(ctx, func() error {
+					currState, stateErr := vmops.GetVMObj().PowerState(ctx)
+					if stateErr != nil {
+						return stateErr
+					}
+					if currState != types.VirtualMachinePowerStatePoweredOff {
+						return fmt.Errorf("VM power-off command completed but VM is still in state: %s", currState)
+					}
+					return nil
+				}, constants.MaxPowerOffRetryLimit, constants.PowerOffRetryCap); err != nil {
+					return vminfo, errors.Wrap(err, "failed to verify VM power state after power off")
 				}
 				final = true
 			}

--- a/v2v-helper/pkg/constants/constants.go
+++ b/v2v-helper/pkg/constants/constants.go
@@ -183,4 +183,10 @@ echo "$(date '+%Y-%m-%d %H:%M:%S') - Network fix script completed" >> "$LOG_FILE
 
 	// StorageCopyMethod is the default value for storage copy method
 	StorageCopyMethod = "StorageAcceleratedCopy"
+
+	// MaxPowerOffRetryLimit is the max number of retries for power off status check
+	MaxPowerOffRetryLimit = 3
+
+	// PowerOffRetryCap is the max retry interval for power off status check
+	PowerOffRetryCap = 5 * time.Minute
 )


### PR DESCRIPTION
## What this PR does / why we need it
This PR adds a check after poweroff call to check if vm status is powered off, or else we fail the migration. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #943 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_