### PR TITLE
add info about disk copy speed limitations

### DIFF
--- a/docs/src/content/docs/introduction/prerequisites.md
+++ b/docs/src/content/docs/introduction/prerequisites.md
@@ -140,9 +140,6 @@ vJailbreak uses nbdkit to transfer disk data from VMware ESXi hosts via the NFC 
 - Monitor network utilization to optimize the number of concurrent migrations
 - Consider scheduling large VM migrations during maintenance windows
 
-#### Alternative Protocols
-
-VMware vSphere 8.0 and later supports **UDT (Unified Data Transport)** protocol, which offers significantly better performance than NFC. However, vJailbreak currently uses NFC via nbdkit for compatibility with a wider range of vSphere versions.
 
 **References:**
 - [Veeam Forum: 1Gbit/s per VMDK Limit](https://forums.veeam.com/vmware-vsphere-f24/1gbit-s-per-vmdk-limit-t66468.html)


### PR DESCRIPTION
## What this PR does / why we need it
There are known limitations on copy speed of ndbcopy. Its affected by number factors including bandwidth, number of migrations, vcenter limitations, etc. Need a doc discussing all these details

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1427 

## Special notes for your reviewer


## Testing done
N/A