### PR TITLE
Prioritizing Cold Migration in case of cutover options selected with cold migration

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -580,10 +580,16 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 
 	cutoverLabelPresent, cutoverLabelValue := migobj.CheckCutoverOptions()
 	// if the cutover immediately is selected with cold migration type then the migration will happen like cold migration
-
+	var currentCutoverOption string
 	if migobj.MigrationType == "cold" {
 		if cutoverLabelValue != "" {
-			migobj.logMessage("Cold Migration with cutover options selected, proceeding with cold migration")
+			if cutoverLabelValue == "yes" {
+
+				currentCutoverOption = "Immediately After Data Copy"
+			} else if cutoverLabelValue == "no" {
+				currentCutoverOption = "Admin Initiated Cutover"
+			}
+			migobj.logMessage(fmt.Sprintf("Migration Type : %s | Cutover Option %s", migobj.MigrationType, currentCutoverOption))
 		}
 		if err := vmops.VMPowerOff(); err != nil {
 			return vminfo, errors.Wrap(err, "failed to power off VM")


### PR DESCRIPTION
## What this PR does / why we need it

When the user selects cold migration with cutover option as cutover immediately after data copy, the migration used to behave like a hot migration without turning off the source vm, In this pr the priority is given to cold migration if cutover options are selected. So the VM will be turned off but it will wait for the cutover as per the trigger selected

fixes #1442 


Detecting The given case 

<img width="848" height="231" alt="image" src="https://github.com/user-attachments/assets/6a13bdb4-1fb8-4f0e-b30b-b8869e379ffd" />


