### PR TITLE
increase QPS for kubernetes client in proxy pod

### DIFF
--- a/pkg/vpwned/server/vjailbreak_proxy.go
+++ b/pkg/vpwned/server/vjailbreak_proxy.go
@@ -385,6 +385,9 @@ func CreateInClusterClient() (client.Client, error) {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(vjailbreakv1alpha1.AddToScheme(scheme))
 
+	config.QPS = 100
+	config.Burst = 200
+
 	clientset, err := client.New(config, client.Options{
 		Scheme: scheme,
 	})


### PR DESCRIPTION
## What this PR does / why we need it
This PR relaxes the client side throttling done by the kubernetes client while updating the vmwaremachines inventory (when done by proxy)

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1431 

## Special notes for your reviewer


## Testing done
TBD