### PR TITLE
Added s3 URL artifact to build outputs (release)

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -45,6 +45,8 @@ env:
   NIGHTLY_RELEASE: ${{ github.event.inputs.is_nightly }}
   AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
   BUGSNAG_API_KEY: ${{ secrets.BUGSNAG_API_KEY }}
+  S3_BUCKET_PROD: vjailbreak
+  S3_BUCKET_DEV: vjailbreak-dev
 
 
 jobs:
@@ -461,7 +463,7 @@ jobs:
       - name: Download ubuntu base image from S3
         if: env.release_found == 'true' || env.is_nightly == 'true'
         env:
-          S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
+          S3_BUCKET: ${{ env.S3_BUCKET_PROD }}
           BASE_IMAGE_PATH: "base-image/ubuntu-base-prebaked.qcow2"
         run: |
           if aws s3 ls "s3://$S3_BUCKET/$BASE_IMAGE_PATH"; then
@@ -578,8 +580,6 @@ jobs:
       - name: Determine S3 path and upload artifacts
         run: |
           set -e
-          S3_BUCKET_PROD=vjailbreak
-          S3_BUCKET_DEV=vjailbreak-dev
           TAG=${{ needs.determine-release.outputs.tag }}
           DATE_FOLDER=$(date -u +"%Y-%m-%d")
 


### PR DESCRIPTION
## What this PR does / why we need it
Updated nightly builds to use dev AWS credentials and bucket, restructured S3 paths to date/tag/qcow2 format, removed tag files, and added a dedicated artifact containing S3 URLs for uploaded images. Simplified base image handling to avoid redundant downloads.

## Which issue(s) this PR fixes
fixes #1463 


## Testing done
<img width="1254" height="518" alt="image" src="https://github.com/user-attachments/assets/271de226-d147-4e11-a38d-296a3a2108ee" />
<img width="1561" height="62" alt="image" src="https://github.com/user-attachments/assets/8f5ae3b4-7e18-44a8-8f72-9b17e081e236" />
