### PR TITLE
Added downloadable s3 url for qcow2 images

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -618,7 +618,7 @@ jobs:
             echo "Latest QCOW2 uploaded: ${QCOW2_HTTP_LATEST_URL}" | tee -a s3-urls.txt
           fi
 
-      - name: S3 image URL
+      - name: S3 URL
         if: env.release_found == 'true' || env.is_nightly == 'true'
         run: cat s3-urls.txt
 


### PR DESCRIPTION
## What this PR does / why we need it
Changed S3 upload echoes to HTTPS URLs (https://bucket.s3.region.amazonaws.com/key) and wrote to s3-urls.txt artifact.
## Testing done

<img width="1119" height="134" alt="image" src="https://github.com/user-attachments/assets/6c253c9d-6de8-453f-aa04-d75248ef3dd3" />
