### PR TITLE
Removed extra logging

### DIFF
--- a/v2v-helper/nbd/nbdops.go
+++ b/v2v-helper/nbd/nbdops.go
@@ -438,7 +438,7 @@ func (nbdserver *NBDServer) CopyChangedBlocks(ctx context.Context, changedAreas 
 
 			prog := fmt.Sprintf("Progress: %d%%", currentPct)
 
-			if currentPct == 0 || currentPct == 100 || (currentPct > lastLoggedPct && currentPct%logInterval == 0) {
+			if (currentPct == 0 && lastLoggedPct != 0) || currentPct == 100 || (currentPct > lastLoggedPct && currentPct%logInterval == 0) {
 				utils.PrintLog(prog)
 				lastLoggedPct = currentPct
 			}


### PR DESCRIPTION
## What this PR does / why we need it
Fix excessive "Progress: 0%" logging during periodic sync
Modified progress only once at the start, while preserving normal progress updates and 100% completion logs.

## Which issue(s) this PR fixes
fixes #1437 

## Testing done
