### PR TITLE
regenerate initramfs

### DIFF
--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -465,7 +465,7 @@ func RunCommandInGuest(path string, command string, write bool) (string, error) 
 		"-i")
 	cmd.Stdin = strings.NewReader(command)
 	log.Printf("Executing %s", cmd.String()+" "+command)
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to run command (%s): %v: %s", command, err, strings.TrimSpace(string(out)))
 	}


### PR DESCRIPTION
## What this PR does / why we need it
RCA - The VM was landing into emergency mode because the initramfs did not have virtio drivers installed, so it could not find the disk to boot even though it was attached.
Fix - This PR adds script to re-generate the initramfs within `generate-mount-persistence.sh` script

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*


## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches boot-critical system state by modifying `/etc/fstab`/udev and now regenerating initramfs and rewriting GRUB config; failures could leave guests unbootable on certain distros/boot setups.
> 
> **Overview**
> **Improves post-migration boot reliability** by extending `generate-mount-persistence.sh --apply` to regenerate the guest initramfs (via `dracut`, `mkinitramfs`, or `mkinitrd`) and attempt to update GRUB configuration across common BIOS/UEFI paths, with warnings when tooling/updates fail.
> 
> Also switches `RunCommandInGuest` to use `CombinedOutput()` instead of `Output()` so `guestfish` stderr is captured in errors/logging for easier debugging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2767b73d9bfe0cceefa3d3c8c4dbfda272d23413. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->