### PR TITLE
Script OS compatibility

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -1236,7 +1236,7 @@ func (r *MigrationPlanReconciler) CreateFirstbootConfigMap(ctx context.Context,
 		scriptType := utils.DetectScriptOSType(scriptContent)
 		isCompatible := utils.IsScriptCompatibleWithOS(scriptContent, vmOSFamily)
 		
-		if !isCompatible && scriptType != "unknown" {
+		if !isCompatible && scriptType != utils.ScriptOSTypeUnknown {
 			r.ctxlog.Info(fmt.Sprintf(
 				"Skipping incompatible firstboot script for VM '%s': script type '%s' does not match VM OS '%s'",
 				vm, scriptType, vmOSFamily,

--- a/k8s/migration/pkg/utils/migrationplanutils_test.go
+++ b/k8s/migration/pkg/utils/migrationplanutils_test.go
@@ -15,13 +15,13 @@ func TestDetectScriptOSType(t *testing.T) {
 			script: `#!/bin/bash
 echo "Hello World"
 apt-get update`,
-			expected: "linux",
+			expected: ScriptOSTypeLinux,
 		},
 		{
 			name: "Linux sh script with shebang",
 			script: `#!/bin/sh
 echo "Hello"`,
-			expected: "linux",
+			expected: ScriptOSTypeLinux,
 		},
 		{
 			name: "Windows batch script",
@@ -29,37 +29,37 @@ echo "Hello"`,
 REM This is a comment
 echo Hello World
 ipconfig`,
-			expected: "windows",
+			expected: ScriptOSTypeWindows,
 		},
 		{
 			name: "PowerShell script",
 			script: `param($Name)
 $env:PATH
 Get-Service`,
-			expected: "windows",
+			expected: ScriptOSTypeWindows,
 		},
 		{
 			name: "Linux script with common commands",
 			script: `echo "Starting"
 systemctl start service
 chmod 755 /tmp/file`,
-			expected: "linux",
+			expected: ScriptOSTypeLinux,
 		},
 		{
 			name: "Windows script with paths",
 			script: `set PATH=C:\Windows\System32
 echo %PROGRAMFILES%`,
-			expected: "windows",
+			expected: ScriptOSTypeWindows,
 		},
 		{
 			name: "Empty script",
 			script: "",
-			expected: "unknown",
+			expected: ScriptOSTypeUnknown,
 		},
 		{
 			name: "Ambiguous script",
 			script: `echo "Hello"`,
-			expected: "unknown",
+			expected: ScriptOSTypeUnknown,
 		},
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it
This PR fixes a bug where firstboot scripts were not OS-aware, leading to Windows-specific scripts failing on Linux VMs and vice versa. It introduces OS-based filtering to ensure that Windows scripts only run on Windows VMs and Linux scripts only run on Linux VMs.

## Which issue(s) this PR fixes
fixes #

## Special notes for your reviewer
- Added `DetectScriptOSType()` and `IsScriptCompatibleWithOS()` functions in `migrationplanutils.go` to determine script type and compatibility.
- Modified `CreateFirstbootConfigMap()` in `migrationplan_controller.go` to perform OS compatibility checks.
- Incompatible scripts are replaced with a no-op script and a warning is logged.
- Unknown script types are allowed for backward compatibility.

## Testing done
Unit tests were added for script OS type detection (Windows batch, PowerShell, Linux bash) and all tests pass. The code compiles successfully.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-005347e3-74e3-4132-82cd-0a80c932fee2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-005347e3-74e3-4132-82cd-0a80c932fee2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

