### PR TITLE
Linter error resolution

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -1236,7 +1236,7 @@ func (r *MigrationPlanReconciler) CreateFirstbootConfigMap(ctx context.Context,
 		scriptType := utils.DetectScriptOSType(scriptContent)
 		isCompatible := utils.IsScriptCompatibleWithOS(scriptContent, vmOSFamily)
 		
-		if !isCompatible && scriptType != "unknown" {
+		if !isCompatible && scriptType != utils.ScriptOSTypeUnknown {
 			r.ctxlog.Info(fmt.Sprintf(
 				"Skipping incompatible firstboot script for VM '%s': script type '%s' does not match VM OS '%s'",
 				vm, scriptType, vmOSFamily,

--- a/k8s/migration/pkg/utils/migrationplanutils_test.go
+++ b/k8s/migration/pkg/utils/migrationplanutils_test.go
@@ -15,13 +15,13 @@ func TestDetectScriptOSType(t *testing.T) {
 			script: `#!/bin/bash
 echo "Hello World"
 apt-get update`,
-			expected: "linux",
+			expected: ScriptOSTypeLinux,
 		},
 		{
 			name: "Linux sh script with shebang",
 			script: `#!/bin/sh
 echo "Hello"`,
-			expected: "linux",
+			expected: ScriptOSTypeLinux,
 		},
 		{
 			name: "Windows batch script",
@@ -29,37 +29,37 @@ echo "Hello"`,
 REM This is a comment
 echo Hello World
 ipconfig`,
-			expected: "windows",
+			expected: ScriptOSTypeWindows,
 		},
 		{
 			name: "PowerShell script",
 			script: `param($Name)
 $env:PATH
 Get-Service`,
-			expected: "windows",
+			expected: ScriptOSTypeWindows,
 		},
 		{
 			name: "Linux script with common commands",
 			script: `echo "Starting"
 systemctl start service
 chmod 755 /tmp/file`,
-			expected: "linux",
+			expected: ScriptOSTypeLinux,
 		},
 		{
 			name: "Windows script with paths",
 			script: `set PATH=C:\Windows\System32
 echo %PROGRAMFILES%`,
-			expected: "windows",
+			expected: ScriptOSTypeWindows,
 		},
 		{
 			name: "Empty script",
 			script: "",
-			expected: "unknown",
+			expected: ScriptOSTypeUnknown,
 		},
 		{
 			name: "Ambiguous script",
 			script: `echo "Hello"`,
-			expected: "unknown",
+			expected: ScriptOSTypeUnknown,
 		},
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it
This PR resolves goconst linter warnings by introducing constants for script OS types (`ScriptOSTypeWindows`, `ScriptOSTypeLinux`, `ScriptOSTypeUnknown`).

Additionally, it integrates script OS compatibility detection and validation logic. This ensures firstboot scripts are compatible with the target VM's OS, replacing incompatible ones with safe no-op scripts and adding relevant logging.

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #

## Special notes for your reviewer
The core changes, including the introduction of constants and the script OS compatibility logic, were cherry-picked from PR #1529 "Script OS compatibility" to address the reported linter errors and enhance script handling.

## Testing done

_please add testing details (logs, screenshots, etc.)_
- Linter: 0 issues reported.
- Unit tests for script OS detection: All passing.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-49b3f8ee-083a-4662-8d6d-eb8ced78a4b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49b3f8ee-083a-4662-8d6d-eb8ced78a4b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

