### PR TITLE
Pull request comments

### DIFF
--- a/deploy/05controller-deployment.yaml
+++ b/deploy/05controller-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         envFrom:
         - configMapRef:
             name: pf9-env
-        image: quay.io/platform9/vjailbreak-controller:-bd4bfed1
+        image: quay.io/platform9/vjailbreak-controller:origin/1410-vmware-tool-removal-script-d4c0b1af
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/deploy/06vpwned-deployment.yaml
+++ b/deploy/06vpwned-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: pf9-env
-        image: quay.io/platform9/vjailbreak-vpwned:-bd4bfed1
+        image: quay.io/platform9/vjailbreak-vpwned:origin/1410-vmware-tool-removal-script-d4c0b1af
         imagePullPolicy: IfNotPresent
         name: vpwned
         ports:

--- a/deploy/07ui-deployment.yaml
+++ b/deploy/07ui-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: migration-controller-manager
       containers:
         - name: vjailbreak-ui-container
-          image: quay.io/platform9/vjailbreak-ui:-bd4bfed1
+          image: quay.io/platform9/vjailbreak-ui:origin/1410-vmware-tool-removal-script-d4c0b1af
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80

--- a/deploy/installer.yaml
+++ b/deploy/installer.yaml
@@ -4373,7 +4373,7 @@ spec:
         envFrom:
         - configMapRef:
             name: pf9-env
-        image: quay.io/platform9/vjailbreak-controller:-bd4bfed1
+        image: quay.io/platform9/vjailbreak-controller:origin/1410-vmware-tool-removal-script-d4c0b1af
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4456,7 +4456,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: pf9-env
-        image: quay.io/platform9/vjailbreak-vpwned:-bd4bfed1
+        image: quay.io/platform9/vjailbreak-vpwned:origin/1410-vmware-tool-removal-script-d4c0b1af
         imagePullPolicy: IfNotPresent
         name: vpwned
         ports:
@@ -4534,7 +4534,7 @@ spec:
       serviceAccountName: migration-controller-manager
       containers:
         - name: vjailbreak-ui-container
-          image: quay.io/platform9/vjailbreak-ui:-bd4bfed1
+          image: quay.io/platform9/vjailbreak-ui:origin/1410-vmware-tool-removal-script-d4c0b1af
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80

--- a/k8s/migration/config/addons/kustomization.yaml
+++ b/k8s/migration/config/addons/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: vpwned
   newName: quay.io/platform9/vjailbreak-vpwned
-  newTag: -bd4bfed1
+  newTag: origin/1410-vmware-tool-removal-script-d4c0b1af

--- a/k8s/migration/config/manager/kustomization.yaml
+++ b/k8s/migration/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/platform9/vjailbreak-controller
-  newTag: -bd4bfed1
+  newTag: origin/1410-vmware-tool-removal-script-d4c0b1af

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -569,6 +569,13 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 	if len(vmsToValidate) > 0 {
 		// Validate VM OS types before proceeding with migration
 		validVMs, _, validationErr = r.validateMigrationPlanVMs(ctx, migrationplan, migrationtemplate, vmwcreds)
+		
+		// Additionally check for mixed OS types with firstboot scripts
+		if validationErr == nil && len(validVMs) > 0 {
+			if mixedOSErr := utils.ValidateMixedOSWithFirstboot(migrationplan, validVMs); mixedOSErr != nil {
+				validationErr = mixedOSErr
+			}
+		}
 	}
 
 	if validationErr != nil {


### PR DESCRIPTION
## What this PR does / why we need it
This PR addresses previous review comments by replacing the error-prone auto-detection of firstboot script types with a robust backend validation. It prevents users from enabling firstboot scripts when a migration plan includes both Windows and Linux VMs, providing a clearer and more reliable approach.

## Which issue(s) this PR fixes
fixes #

## Special notes for your reviewer
- Implemented `ValidateMixedOSWithFirstboot()` in `migrationplanutils.go` to check for mixed OS types (Windows/Linux) when a firstboot script is present.
- The `migrationplan_controller.go` now calls this validation during migration plan processing.
- A user-friendly error message is provided, guiding users to either remove the script or separate their migration plans by OS type.

## Testing done
- Code compiles successfully.
- All tests passed.
- Linter shows 0 issues.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-2af100ba-322d-4432-b42a-142171b2d7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2af100ba-322d-4432-b42a-142171b2d7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

