### PR TITLE
fix: scope VM validation to non-terminal states and harden post-migration actions

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -2078,7 +2078,8 @@ func (r *MigrationPlanReconciler) validateMigrationPlanVMs(
 	vmsToValidate []string,
 ) ([]*vjailbreakv1alpha1.VMwareMachine, []*vjailbreakv1alpha1.VMwareMachine, error) {
 	if len(vmsToValidate) == 0 {
-		return nil, nil, fmt.Errorf("no VMs to migrate in migration plan")
+		r.ctxlog.Info("No VMs left to validate; all in terminal states or plan complete")
+		return nil, nil, nil
 	}
 
 	validVMs := make([]*vjailbreakv1alpha1.VMwareMachine, 0, len(vmsToValidate))


### PR DESCRIPTION
## What this PR does / why we need it

- Targeted Validation: Only validates non-terminal (pending) VMs, preventing "not found" errors for already migrated or renamed VMs.
- Resilient Post-Actions: Adds "not found" error handling in renameVM and moveVMToFolder to skip already-processed VMs gracefully.
- Panic Prevention: Adds nil checks for Datacenter objects to ensure stable folder auto-detection.
- Plan Stability: Ensures post-migration actions (rename/move) don't trigger "ValidationFailed" or block remaining VMs in the plan.

## Which issue(s) this PR fixes

fixes #1556 

## Testing done

<img width="1435" height="831" alt="image" src="https://github.com/user-attachments/assets/7d860047-54da-4bc6-a50a-1b9e662eb8c1" />