### PR TITLE
UI: Fix rdm configure tab in migration form

### DIFF
--- a/ui/src/features/migration/VmsSelectionStep.tsx
+++ b/ui/src/features/migration/VmsSelectionStep.tsx
@@ -94,6 +94,7 @@ const CustomToolbarWithActions = (props) => {
     hasRdmVMs,
     onAssignRdmConfiguration,
     selectedCount,
+    rdmVMsCount,
     ...toolbarProps
   } = props
 
@@ -110,14 +111,14 @@ const CustomToolbarWithActions = (props) => {
             <Button variant="text" color="primary" onClick={onAssignFlavor} size="small">
               Assign Flavor ({rowSelectionModel.length})
             </Button>
-            {hasRdmVMs && (
+            {hasRdmVMs && rdmVMsCount > 0 && (
               <Button
                 variant="text"
                 color="secondary"
                 onClick={onAssignRdmConfiguration}
                 size="small"
               >
-                Configure RDM ({rowSelectionModel.length})
+                Configure RDM ({rdmVMsCount})
               </Button>
             )}
             {selectedCount > 0 && (
@@ -1783,6 +1784,11 @@ function VmsSelectionStep({
                       hasRdmVMs={rdmValidation.hasRdmVMs}
                       onAssignIP={handleOpenBulkIPAssignment}
                       selectedCount={rowSelectionModelArray.length}
+                      rdmVMsCount={
+                        rowSelectionModelArray.filter((vmName) =>
+                          rdmDisks.some((disk) => disk.spec.ownerVMs.includes(vmName as string))
+                        ).length
+                      }
                     />
                   )
                 },

--- a/ui/src/features/migration/components/RdmDiskConfigurationPanel.tsx
+++ b/ui/src/features/migration/components/RdmDiskConfigurationPanel.tsx
@@ -108,9 +108,11 @@ export const RdmDiskConfigurationPanel: React.FC<RdmDiskConfigurationPanelProps>
           Selected VMs:
         </Typography>
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-          {selectedVMs.map((vmName) => (
-            <Chip key={vmName} label={vmName} size="small" color="primary" variant="outlined" />
-          ))}
+          {selectedVMs
+            .filter((vmName) => rdmDisks.some((disk) => disk.spec.ownerVMs.includes(vmName)))
+            .map((vmName) => (
+              <Chip key={vmName} label={vmName} size="small" color="primary" variant="outlined" />
+            ))}
         </Box>
       </Box>
 


### PR DESCRIPTION
## What this PR does / why we need it
This PR Make sures only VM's with rdm are shown in the configure button. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1551 

## Special notes for your reviewer


## Testing done
<img width="1147" height="582" alt="image" src="https://github.com/user-attachments/assets/b7d4c811-482e-460b-9af6-8187aaa91ff2" />
<img width="949" height="802" alt="image" src="https://github.com/user-attachments/assets/ab9eebe0-b1a7-4126-b48c-5ff54464421d" />


_please add testing details (logs, screenshots, etc.)_