### PR TITLE
fix: custom IP is not applied for no preserve IP and no preserve MAC

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -2038,11 +2038,9 @@ func (migobj *Migrate) ReservePortsForVM(ctx context.Context, vminfo *vm.VMInfo)
 			}
 			if !preserveMAC {
 				utils.PrintLog(fmt.Sprintf("NIC[%d]: preserveMAC=false for MAC %s — OpenStack will generate a new MAC", idx, mac))
-				if preserveIP {
-					// Copy IPs from original MAC key to "" key so GetCreateOpts still uses them
-					// when no MAC is specified (OpenStack generates one).
-					vminfo.IPperMac[""] = vminfo.IPperMac[mac]
-				}
+				// Always copy IPs (preserved, custom, or empty-non-nil) to the "" key so
+				// GetCreateOpts uses them when no MAC is specified (OpenStack generates one).
+				vminfo.IPperMac[""] = vminfo.IPperMac[mac]
 				mac = ""
 			}
 


### PR DESCRIPTION
## What this PR does / why we need it
There's a bug in the No Preserve IP + No Preserve MAC + Custom IP scenario, the custom IP was being ignored and a DHCP address was assigned instead. Root cause was a one-line logic error where the custom IP wasn't being passed through when MAC preservation was disabled. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1595 

## Special notes for your reviewer
## Testing done

2026/02/28 01:42:08 User-Assigned IP[0] for MAC 00:50:56:95:4d:b1: 10.96.3.75
2026/02/28 01:42:08 NIC[0]: preserveIP=false, using user-assigned custom IP for MAC 00:50:56:95:4d:b1
2026/02/28 01:42:08 NIC[0]: preserveMAC=false for MAC 00:50:56:95:4d:b1 — OpenStack will generate a new MAC
2026/02/28 01:42:08 Using IPs for MAC 00:50:56:95:4d:b1: [10.96.3.75]
2026/02/28 01:42:08 OPENSTACK API: Creating port for network ed734610-831e-4117-a139-a354b1735a31, authurl https://pcd-community.pf9.io/keystone/v3, tenant service with MAC address  and IP addresses [{10.96.3.75 0}]
2026/02/28 01:42:09 Port with MAC address  does not exist, creating new port, trying with same IP address: [{10.96.3.75 0}]
2026/02/28 01:42:09 Subnet 1912bc2f-898e-4710-862c-9f14fc10cac9 contains IP 10.96.3.75
2026/02/28 01:42:09 IP 10.96.3.75 is in subnet 1912bc2f-898e-4710-862c-9f14fc10cac9
2026/02/28 01:42:09 Port created successfully: MAC:fa:16:3e:8d:6a:e9 IP:[10.96.3.75] and Security Groups:[]