### PR TITLE
Include resourceVersion when updating ESXi SSH credentials

### DIFF
--- a/ui/src/api/esxi-ssh-creds/esxiSshCreds.ts
+++ b/ui/src/api/esxi-ssh-creds/esxiSshCreds.ts
@@ -60,7 +60,8 @@ export const updateESXiSSHCreds = async (
   secretName: string,
   username = 'root',
   namespace = VJAILBREAK_DEFAULT_NAMESPACE,
-  forceReconcileToken?: string
+  forceReconcileToken?: string,
+  resourceVersion?: string
 ): Promise<ESXiSSHCreds> => {
   const endpoint = `${VJAILBREAK_API_BASE_PATH}/namespaces/${namespace}/esxisshcreds/${name}`
 
@@ -69,7 +70,8 @@ export const updateESXiSSHCreds = async (
     kind: 'ESXiSSHCreds',
     metadata: {
       name,
-      namespace
+      namespace,
+      ...(resourceVersion && { resourceVersion })
     },
     spec: {
       secretRef: {
@@ -100,30 +102,14 @@ export const upsertESXiSSHCreds = async (
       // Already exists - fetch current resource to get resourceVersion, then update
       const existing = await getESXiSSHCredsItem(name, namespace)
       const token = new Date().toISOString()
-      
-      const endpoint = `${VJAILBREAK_API_BASE_PATH}/namespaces/${namespace}/esxisshcreds/${name}`
-      const payload: ESXiSSHCreds = {
-        apiVersion: 'vjailbreak.k8s.pf9.io/v1alpha1',
-        kind: 'ESXiSSHCreds',
-        metadata: {
-          name,
-          namespace,
-          resourceVersion: existing.metadata.resourceVersion
-        },
-        spec: {
-          secretRef: {
-            name: secretName,
-            namespace
-          },
-          username,
-          forceReconcileToken: token
-        }
-      }
-      
-      return axios.put<ESXiSSHCreds>({
-        endpoint,
-        data: payload
-      })
+      return await updateESXiSSHCreds(
+        name,
+        secretName,
+        username,
+        namespace,
+        token,
+        existing.metadata.resourceVersion
+      )
     }
     throw error
   }


### PR DESCRIPTION
## What this PR does / why we need it
When updating an existing ESXi SSH key from the UI, the update operation
was failing with the error:
"esxisshcreds.vjailbreak.k8s.pf9.io "esxi-ssh-key" is invalid: 
metadata.resourceVersion: Invalid value: 0x0: must be specified for an update"
 
The upsertESXiSSHCreds function was calling updateESXiSSHCreds without
providing the resourceVersion field, which is required by Kubernetes for
update operations to implement optimistic concurrency control.
 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1588 

## Special notes for your reviewer


## Testing done

https://github.com/user-attachments/assets/85920d2b-d7aa-4ba9-bd2b-caa63741f2cf


_please add testing details (logs, screenshots, etc.)_