### PR TITLE
Disable github hook on pre-release commit

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -52,6 +52,10 @@ jobs:
             echo "changes=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Disable git hooks
+        if: steps.changes.outputs.changes == 'true'
+        run: git config core.hooksPath /dev/null
+
       - name: Create Pull Request
         if: steps.changes.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
## What this PR does / why we need it
Disabled the github pre-commit hook before creating the pr for updating crd

## Which issue(s) this PR fixes

fixes #

## Testing done
<img width="1440" height="809" alt="image" src="https://github.com/user-attachments/assets/0f6a376e-eddc-47a6-af57-98cf30d9315a" />
