### PR TITLE
Simplify S3 QCOW2 upload paths by removing date folders

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -545,26 +545,25 @@ jobs:
         run: |
           set -e
           TAG=${{ needs.determine-release.outputs.tag }}
-          DATE_FOLDER=$(date -u +"%Y-%m-%d")
           REGION="${S3_REGION}"
 
           if [[ "${{ github.event_name }}" == "release" ]]; then
             S3_BUCKET=${S3_BUCKET_PROD}
-            S3_PATH_PREFIX="releases/${DATE_FOLDER}/${TAG}"
-            S3_LATEST_PATH_PREFIX="releases/latest/${TAG}"
+            S3_PATH_PREFIX="releases/${TAG}"
+            S3_LATEST_PATH_PREFIX="releases/latest"
             QCOW2_FILENAME="vjailbreak.qcow2"
             DO_LATEST=true
 
           elif [[ "${{ github.event.inputs.is_nightly }}" == "true" ]]; then
             S3_BUCKET=${S3_BUCKET_DEV}
-            S3_PATH_PREFIX="nightly/${DATE_FOLDER}/${TAG}"
-            S3_LATEST_PATH_PREFIX="nightly/latest/${TAG}"
+            S3_PATH_PREFIX="nightly/${TAG}"
+            S3_LATEST_PATH_PREFIX="nightly/latest"
             QCOW2_FILENAME="vjailbreak.qcow2"
             DO_LATEST=true
 
           else
             S3_BUCKET=${S3_BUCKET_DEV}
-            S3_PATH_PREFIX="dev/${DATE_FOLDER}/${TAG}"
+            S3_PATH_PREFIX="dev/${TAG}"
             QCOW2_FILENAME="vjailbreak.qcow2"
             DO_LATEST=false
           fi


### PR DESCRIPTION
## What this PR does / why we need it
Removes date-based folder structure from S3 upload paths for release, nightly, and dev builds. Updates paths to use tag-only for specific versions and direct file placement in latest folders, eliminating the need for date-related code.

## Testing done

dev builds before:
<img width="635" height="77" alt="image" src="https://github.com/user-attachments/assets/a2e8fa2a-5c8c-43b2-b739-fb4b41070ca8" />
dev build after:
<img width="587" height="81" alt="image" src="https://github.com/user-attachments/assets/0d64bd1b-6c3f-4f03-84aa-1a2767c59994" />



nightly builds before:
<img width="672" height="83" alt="image" src="https://github.com/user-attachments/assets/01a0e908-b86b-413d-9803-274c2c12cd83" />
nightly builds after:
<img width="667" height="77" alt="image" src="https://github.com/user-attachments/assets/fb907d15-1c02-4ad7-aa6a-64c27dbeb048" />
