### PR TITLE
#1575, #1577 : Start Migration is not getting disabled

### DIFF
--- a/ui/src/features/migration/MigrationForm.tsx
+++ b/ui/src/features/migration/MigrationForm.tsx
@@ -150,6 +150,8 @@ export interface SelectedMigrationOptionsType {
   cutoverStartTime: boolean
   cutoverEndTime: boolean
   postMigrationScript: boolean
+  useGPU?: boolean
+  useFlavorless?: boolean
   periodicSyncEnabled?: boolean
   postMigrationAction?: {
     suffix?: boolean
@@ -169,6 +171,8 @@ const defaultMigrationOptions = {
   cutoverStartTime: false,
   cutoverEndTime: false,
   postMigrationScript: false,
+  useGPU: false,
+  useFlavorless: false,
   postMigrationAction: {
     suffix: false,
     folderName: false,
@@ -934,6 +938,10 @@ export default function MigrationFormDrawer({
       if (key === 'periodicSyncEnabled' && selectedMigrationOptions.periodicSyncEnabled) {
         return params?.periodicSyncInterval !== '' && fieldErrors['periodicSyncInterval'] === ''
       }
+      if (key === 'dataCopyStartTime' && selectedMigrationOptions.dataCopyStartTime) {
+        const value = String(params?.dataCopyStartTime ?? '').trim()
+        return value !== '' && !fieldErrors['dataCopyStartTime']
+      }
       if (selectedMigrationOptions[key as keyof typeof selectedMigrationOptions]) {
         return params?.[key as keyof typeof params] !== undefined && !fieldErrors[key]
       }
@@ -1226,6 +1234,8 @@ export default function MigrationFormDrawer({
       Boolean(selectedMigrationOptions.dataCopyStartTime) ||
       Boolean(selectedMigrationOptions.cutoverOption) ||
       Boolean(selectedMigrationOptions.postMigrationScript) ||
+      Boolean(selectedMigrationOptions.useGPU) ||
+      Boolean(selectedMigrationOptions.useFlavorless) ||
       Boolean(selectedMigrationOptions.periodicSyncEnabled) ||
       postMigrationActionSelected
     )
@@ -1273,6 +1283,10 @@ export default function MigrationFormDrawer({
       !selectedMigrationOptions.postMigrationScript ||
       (Boolean(params.postMigrationScript) && !fieldErrors['postMigrationScript'])
 
+    const pcdOptionsOk =
+      (!selectedMigrationOptions.useGPU || typeof params.useGPU === 'boolean') &&
+      (!selectedMigrationOptions.useFlavorless || typeof params.useFlavorless === 'boolean')
+
     const postMigrationAction = selectedMigrationOptions.postMigrationAction
     const postMigrationActionSelected = Boolean(
       postMigrationAction &&
@@ -1298,6 +1312,7 @@ export default function MigrationFormDrawer({
       cutoverOk &&
       periodicSyncOk &&
       postMigrationScriptOk &&
+      pcdOptionsOk &&
       postMigrationActionOk
     )
   }, [
@@ -1309,12 +1324,19 @@ export default function MigrationFormDrawer({
     params.cutoverEndTime,
     params.periodicSyncInterval,
     params.postMigrationScript,
+    params.useGPU,
+    params.useFlavorless,
     params.postMigrationAction,
     fieldErrors
   ])
 
   const step5Complete = Boolean(
-    touchedSections.options && areSelectedMigrationOptionsConfigured && !step5HasErrors
+    touchedSections.options &&
+      (areSelectedMigrationOptionsConfigured ||
+        Boolean(
+          params.disconnectSourceNetwork || params.fallbackToDHCP || params.networkPersistence
+        )) &&
+      !step5HasErrors
   )
 
   const sectionNavItems = useMemo<SectionNavItem[]>(

--- a/ui/src/features/migration/MigrationOptionsAlt.tsx
+++ b/ui/src/features/migration/MigrationOptionsAlt.tsx
@@ -548,9 +548,7 @@ export default function MigrationOptionsAlt({
                       updateSelectedMigrationOptions('postMigrationAction')({
                         ...selectedMigrationOptions.postMigrationAction,
                         renameVm: isChecked,
-                        suffix: isChecked
-                          ? true
-                          : selectedMigrationOptions.postMigrationAction?.suffix
+                        suffix: isChecked ? true : false
                       })
                       onChange('postMigrationAction')({
                         ...params.postMigrationAction,
@@ -593,9 +591,7 @@ export default function MigrationOptionsAlt({
                       updateSelectedMigrationOptions('postMigrationAction')({
                         ...selectedMigrationOptions.postMigrationAction,
                         moveToFolder: isChecked,
-                        folderName: isChecked
-                          ? true
-                          : selectedMigrationOptions.postMigrationAction?.folderName
+                        folderName: isChecked ? true : false
                       })
                       onChange('postMigrationAction')({
                         ...params.postMigrationAction,

--- a/ui/src/features/migration/RollingMigrationForm.tsx
+++ b/ui/src/features/migration/RollingMigrationForm.tsx
@@ -100,6 +100,11 @@ interface FormValues extends Record<string, unknown> {
   cutoverEndTime?: string
   postMigrationScript?: string
   osFamily?: string
+  useGPU?: boolean
+  useFlavorless?: boolean
+  disconnectSourceNetwork?: boolean
+  fallbackToDHCP?: boolean
+  networkPersistence?: boolean
   storageCopyMethod?: 'normal' | 'StorageAcceleratedCopy'
 }
 
@@ -119,6 +124,8 @@ export interface SelectedMigrationOptionsType extends Record<string, unknown> {
   cutoverEndTime: boolean
   postMigrationScript: boolean
   osFamily: boolean
+  useGPU?: boolean
+  useFlavorless?: boolean
   postMigrationAction?: {
     suffix?: boolean
     folderName?: boolean
@@ -136,6 +143,8 @@ const defaultMigrationOptions: SelectedMigrationOptionsType = {
   cutoverEndTime: false,
   postMigrationScript: false,
   osFamily: false,
+  useGPU: false,
+  useFlavorless: false,
   postMigrationAction: {
     suffix: false,
     folderName: false,
@@ -1508,14 +1517,20 @@ export default function RollingMigrationFormDrawer({
       Boolean(selectedMigrationOptions.cutoverOption) ||
       Boolean(selectedMigrationOptions.postMigrationScript) ||
       Boolean(selectedMigrationOptions.osFamily) ||
+      Boolean(selectedMigrationOptions.useGPU) ||
+      Boolean(selectedMigrationOptions.useFlavorless) ||
       postMigrationActionSelected
 
     const dataCopyMethodOk =
       !selectedMigrationOptions.dataCopyMethod || Boolean(params.dataCopyMethod)
 
+    const dataCopyStartTimeValue = String(params.dataCopyStartTime ?? '').trim()
     const dataCopyStartTimeOk =
       !selectedMigrationOptions.dataCopyStartTime ||
-      (Boolean(params.dataCopyStartTime) && !fieldErrors['dataCopyStartTime'])
+      (Boolean(dataCopyStartTimeValue) &&
+        dataCopyStartTimeValue !== 'undefined' &&
+        dataCopyStartTimeValue !== 'null' &&
+        !fieldErrors['dataCopyStartTime'])
 
     const cutoverOk = !selectedMigrationOptions.cutoverOption
       ? true
@@ -1534,6 +1549,10 @@ export default function RollingMigrationFormDrawer({
       (Boolean(params.postMigrationScript) && !fieldErrors['postMigrationScript'])
 
     const osFamilyOk = !selectedMigrationOptions.osFamily || Boolean(params.osFamily)
+
+    const pcdOptionsOk =
+      (!selectedMigrationOptions.useGPU || typeof params.useGPU === 'boolean') &&
+      (!selectedMigrationOptions.useFlavorless || typeof params.useFlavorless === 'boolean')
 
     const postMigrationActionOk = !postMigrationActionSelected
       ? true
@@ -1555,6 +1574,7 @@ export default function RollingMigrationFormDrawer({
         cutoverOk &&
         postMigrationScriptOk &&
         osFamilyOk &&
+        pcdOptionsOk &&
         postMigrationActionOk)
 
     // PCD host config validation - not needed anymore since validation is handled by esxHostConfigValid
@@ -1747,6 +1767,8 @@ export default function RollingMigrationFormDrawer({
       Boolean(selectedMigrationOptions.cutoverOption) ||
       Boolean(selectedMigrationOptions.postMigrationScript) ||
       Boolean(selectedMigrationOptions.osFamily) ||
+      Boolean(selectedMigrationOptions.useGPU) ||
+      Boolean(selectedMigrationOptions.useFlavorless) ||
       postMigrationActionSelected
     )
   }, [selectedMigrationOptions])
@@ -1754,9 +1776,13 @@ export default function RollingMigrationFormDrawer({
   const areSelectedMigrationOptionsConfigured = useMemo(() => {
     if (!hasAnyMigrationOptionSelected) return false
 
+    const dataCopyStartTimeValue = String(params.dataCopyStartTime ?? '').trim()
     const dataCopyStartTimeOk =
       !selectedMigrationOptions.dataCopyStartTime ||
-      (Boolean(params.dataCopyStartTime) && !fieldErrors['dataCopyStartTime'])
+      (Boolean(dataCopyStartTimeValue) &&
+        dataCopyStartTimeValue !== 'undefined' &&
+        dataCopyStartTimeValue !== 'null' &&
+        !fieldErrors['dataCopyStartTime'])
 
     const cutoverOk = !selectedMigrationOptions.cutoverOption
       ? true
@@ -1775,6 +1801,10 @@ export default function RollingMigrationFormDrawer({
       (Boolean(params.postMigrationScript) && !fieldErrors['postMigrationScript'])
 
     const osFamilyOk = !selectedMigrationOptions.osFamily || Boolean(params.osFamily)
+
+    const pcdOptionsOk =
+      (!selectedMigrationOptions.useGPU || typeof params.useGPU === 'boolean') &&
+      (!selectedMigrationOptions.useFlavorless || typeof params.useFlavorless === 'boolean')
 
     const postMigrationAction = selectedMigrationOptions.postMigrationAction
     const postMigrationActionSelected = Boolean(
@@ -1801,6 +1831,7 @@ export default function RollingMigrationFormDrawer({
       cutoverOk &&
       postMigrationScriptOk &&
       osFamilyOk &&
+      pcdOptionsOk &&
       postMigrationActionOk
     )
   }, [
@@ -1812,6 +1843,8 @@ export default function RollingMigrationFormDrawer({
     params.cutoverEndTime,
     params.postMigrationScript,
     params.osFamily,
+    params.useGPU,
+    params.useFlavorless,
     params,
     fieldErrors
   ])
@@ -1883,7 +1916,14 @@ export default function RollingMigrationFormDrawer({
         description: 'Scheduling and advanced behavior',
         status: step6HasErrors
           ? 'attention'
-          : touchedSections.options && areSelectedMigrationOptionsConfigured && !step6HasErrors
+          : touchedSections.options &&
+              (areSelectedMigrationOptionsConfigured ||
+                Boolean(
+                  params.disconnectSourceNetwork ||
+                    params.fallbackToDHCP ||
+                    params.networkPersistence
+                )) &&
+              !step6HasErrors
             ? 'complete'
             : 'incomplete'
       }
@@ -1916,7 +1956,10 @@ export default function RollingMigrationFormDrawer({
       step6HasErrors,
       hasAnyMigrationOptionSelected,
       areSelectedMigrationOptionsConfigured,
-      touchedSections
+      touchedSections,
+      params.disconnectSourceNetwork,
+      params.fallbackToDHCP,
+      params.networkPersistence
     ]
   )
 


### PR DESCRIPTION
## What this PR does / why we need it
- Improved dataCopyStartTime validation to check for non-empty trimmed values
- Fixed step completion logic to consider network options (disconnectSourceNetwork, fallbackToDHCP, networkPersistence)


## Which issue(s) this PR fixes
fixes #1577 
fixes #1575 

## Testing done
[Screencast from 05-03-26 06:19:37 PM IST.webm](https://github.com/user-attachments/assets/7328b0e9-628a-488f-a8f9-9f7c2bc7b1fd)
