### PR TITLE
fix: Wait for network IP and default route before installing K3s master and worker

### DIFF
--- a/image_builder/scripts/install.sh
+++ b/image_builder/scripts/install.sh
@@ -48,7 +48,7 @@ wait_for_network() {
       log "Waiting for network: missing global IPv4 address..."
     fi
 
-    sleep 5
+    sleep 60
   done
 }
 


### PR DESCRIPTION

## What this PR does / why we need it
When we launch vjb VM on L2 only VM, k3s installation fails because of no default route available, since it needs a ip and routes to function correctly. This PR basically adds wait function for a ip and routes to become available and then proceed with the installation of master and worker. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1643 

## Special notes for your reviewer


## Testing done
<img width="1349" height="571" alt="image" src="https://github.com/user-attachments/assets/6f1a699e-7c27-4a49-bb8c-9beb73d3af7c" />
<img width="1204" height="641" alt="image" src="https://github.com/user-attachments/assets/413fe25d-67e7-4c6f-af8a-0a6b699a6b1b" />
<img width="1038" height="649" alt="image" src="https://github.com/user-attachments/assets/c2d1a881-3225-40a3-9662-7c7a6e880dc5" />
<img width="769" height="458" alt="image" src="https://github.com/user-attachments/assets/ee699717-02ce-43fb-8755-14e7a3343aa6" />


_please add testing details (logs, screenshots, etc.)_