### PR TITLE
Updated the vjailbreak installation guide in documentation

### DIFF
--- a/docs/src/content/docs/introduction/getting_started.mdx
+++ b/docs/src/content/docs/introduction/getting_started.mdx
@@ -45,7 +45,7 @@ For older versions, download directly using wget:
 wget https://vjailbreak.s3.us-west-2.amazonaws.com/releases/<version>/vjailbreak.qcow2
 ```
 
-This will download the vJailbreak qcow2 image locally in the same directory named `vjailbreak.qcow2`.
+These will download the vJailbreak qcow2 image locally in the same directory named `vjailbreak.qcow2`.
 
 Note: This direct download method is supported starting from v0.3.2 and later versions.
 


### PR DESCRIPTION
## What this PR does / why we need it
This updates the documentation with the latest URLs of vjailbreak image on both quay and s3

## Which issue(s) this PR fixes

fixes #


## Testing done
<img width="1088" height="933" alt="image" src="https://github.com/user-attachments/assets/88fb0f12-0d53-4473-a6ee-1d526b8c9a97" />