### PR TITLE
Merging redundant information about network persistence

### DIFF
--- a/docs/src/content/docs/concepts/migration-options.md
+++ b/docs/src/content/docs/concepts/migration-options.md
@@ -80,3 +80,14 @@ An optional parameter. Renames the source VM in VMware to have a specific suffix
 
 ### Move to folder
 An optional parameter. Moves the source VM in VMware to a specific folder, good option to group migrated VMs and keep it out of the hands of the user.
+## Network persistence
+
+### Persist source network interfaces
+When enabled, vJailbreak preserves the source VM's network interface names on the destination VM (for example, `eth0` or `ens3`). This prevents breaking guest configurations—such as firewall rules or legacy scripts—that depend on specific interface names.
+
+For statically configured interfaces, vJailbreak also preserves routes defined in configuration files, ensuring the guest retains its original network behavior after migration.
+
+To enable this behavior, check **Persist source network interfaces** under **Migration Options** in the migration form.
+
+
+For more information, refer to the [Network Persistence](../network-persistence/) documentation.

--- a/docs/src/content/docs/concepts/network-persistence.md
+++ b/docs/src/content/docs/concepts/network-persistence.md
@@ -29,7 +29,7 @@ The Linux network persistence mechanism operates on the first boot post-migratio
 |   OpenSuse     | Supported | Yes |
 |   RHEL         | Supported | Yes |
 |   CentOS       | Supported | Yes |
-|   Rocky        | Supported | Yes |
+|   Rocky        | Supported | No |
 
 ## Windows Network Persistence
 


### PR DESCRIPTION
## What this PR does / why we need it

Removed content from migration-options about network persistence and added a separate page for network persistence