### PR TITLE
Add exponential backoff auto-reconnect for migration pod log streams

### DIFF
--- a/ui/src/hooks/useDirectPodLogs.ts
+++ b/ui/src/hooks/useDirectPodLogs.ts
@@ -16,6 +16,9 @@ interface UseDirectPodLogsReturn {
 }
 
 const MAX_LOG_LINES = 5000
+const INITIAL_RECONNECT_DELAY_MS = 5000
+const MAX_RECONNECT_DELAY_MS = 30000
+const MAX_RETRIES = 5
 
 export const useDirectPodLogs = ({
   podName,
@@ -28,6 +31,7 @@ export const useDirectPodLogs = ({
   const [error, setError] = useState<string | null>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const retryCountRef = useRef(0)
   const hasInitiallyLoadedRef = useRef(false)
   const previousPodRef = useRef<string>('')
   const seenLogsRef = useRef<Set<string>>(new Set())
@@ -41,11 +45,38 @@ export const useDirectPodLogs = ({
       clearTimeout(reconnectTimeoutRef.current)
       reconnectTimeoutRef.current = null
     }
+    retryCountRef.current = 0
   }, [])
 
   const connect = useCallback(async () => {
     if (!enabled || !podName || !namespace) {
       return
+    }
+
+    const queueReconnect = (transientError = true) => {
+      if (!enabled || !podName || !namespace || !transientError) {
+        return
+      }
+      if (retryCountRef.current >= MAX_RETRIES) {
+        setError('Max retries exceeded. Please reconnect manually.')
+        return
+      }
+
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current)
+      }
+
+      const delay = Math.min(
+        INITIAL_RECONNECT_DELAY_MS * Math.pow(2, retryCountRef.current),
+        MAX_RECONNECT_DELAY_MS
+      )
+      retryCountRef.current += 1
+
+      reconnectTimeoutRef.current = setTimeout(() => {
+        reconnectTimeoutRef.current = null
+        retryCountRef.current -= 1
+        connect()
+      }, delay)
     }
 
     cleanup()
@@ -59,7 +90,7 @@ export const useDirectPodLogs = ({
       const shouldFetchHistory = !hasInitiallyLoadedRef.current
       const response = await streamPodLogs(namespace, podName, {
         follow: true,
-        tailLines: shouldFetchHistory ? '2000' : undefined,
+        tailLines: shouldFetchHistory ? '2000' : '200',
         limitBytes: 8 * 1024 * 1024,
         signal: abortController.signal
       })
@@ -69,6 +100,7 @@ export const useDirectPodLogs = ({
       }
 
       setIsLoading(false)
+      retryCountRef.current = 0
 
       const reader = response.body?.getReader()
       if (!reader) {
@@ -98,6 +130,8 @@ export const useDirectPodLogs = ({
                 return newLogs
               })
             }
+
+            queueReconnect()
             return
           }
 
@@ -147,7 +181,10 @@ export const useDirectPodLogs = ({
 
       const errorMessage =
         err instanceof Error ? err.message : 'Failed to connect to pod logs stream'
+      
+      const isTransient = !errorMessage.includes('not found') && !errorMessage.includes('unauthorized')
       setError(errorMessage)
+      queueReconnect(isTransient)
     }
   }, [enabled, podName, namespace, cleanup])
 
@@ -155,6 +192,7 @@ export const useDirectPodLogs = ({
     setLogs([])
     hasInitiallyLoadedRef.current = false
     seenLogsRef.current.clear()
+    retryCountRef.current = 0
     connect()
   }, [connect])
 
@@ -162,6 +200,7 @@ export const useDirectPodLogs = ({
     setLogs([])
     hasInitiallyLoadedRef.current = false
     seenLogsRef.current.clear()
+    retryCountRef.current = 0
   }, [sessionKey])
 
   useEffect(() => {
@@ -170,6 +209,7 @@ export const useDirectPodLogs = ({
       setLogs([])
       hasInitiallyLoadedRef.current = false
       seenLogsRef.current.clear()
+      retryCountRef.current = 0
     }
     previousPodRef.current = currentPodKey
 


### PR DESCRIPTION
## What this PR does / why we need it
Enhances the log streaming auto-reconnect mechanism to handle frequent disconnects gracefully

## Which issue(s) this PR fixes
fixes #1636 


## Testing done


https://github.com/user-attachments/assets/2bdb4d9f-4168-414a-ac78-f43dbf800dbe
