### PR TITLE
Fix UI RBAC permissions for pod operations

### DIFF
--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -4554,6 +4554,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - configmaps/status
   - pods/status
   verbs:

--- a/deploy/installer.yaml
+++ b/deploy/installer.yaml
@@ -4755,6 +4755,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - configmaps/status
   - pods/status
   verbs:

--- a/ui/deploy/ui.yaml
+++ b/ui/deploy/ui.yaml
@@ -166,6 +166,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - configmaps/status
   - pods/status
   verbs:


### PR DESCRIPTION
## What this PR does / why we need it
Added RBAC rule for pods resource with required verbs under ui-manager-role rules section.

## Which issue(s) this PR fixes

fixes #1662


## Testing done
<img width="815" height="815" alt="image" src="https://github.com/user-attachments/assets/e401d654-fba9-42a2-a3f6-c48ea93eff53" />
