### PR TITLE
Added failure checks in vjbctl

### DIFF
--- a/image_builder/scripts/pf9-htpasswd.sh
+++ b/image_builder/scripts/pf9-htpasswd.sh
@@ -226,8 +226,8 @@ _pf9_ht_main() {
             prompt_user "$DEFAULT_USER" user
           fi
           create_user "$user"
-          if [[ $no_restart -eq 0 ]]; then
-            sudo kubectl -n migration-system rollout restart deployment vjailbreak-ui
+          if [[ $? -eq 0 && $no_restart -eq 0 ]]; then
+            restart_vjailbreak_ui
           fi
           ;;
         delete)
@@ -236,8 +236,8 @@ _pf9_ht_main() {
             prompt_user "$DEFAULT_USER" user
           fi
           delete_user "$user"
-          if [[ $no_restart -eq 0 ]]; then
-            sudo kubectl -n migration-system rollout restart deployment vjailbreak-ui
+          if [[ $? -eq 0 && $no_restart -eq 0 ]]; then
+            restart_vjailbreak_ui
           fi
           ;;
         change-password)
@@ -246,8 +246,8 @@ _pf9_ht_main() {
             prompt_user "$DEFAULT_USER" user
           fi
           change_password "$user"
-          if [[ $no_restart -eq 0 ]]; then
-            sudo kubectl -n migration-system rollout restart deployment vjailbreak-ui
+          if [[ $? -eq 0 && $no_restart -eq 0 ]]; then
+            restart_vjailbreak_ui
           fi
           ;;
         list)


### PR DESCRIPTION
## What this PR does / why we need it

Added checks so that the pod doesn't restart when the subcommand fails


fixes #1671

## Special notes for your reviewer


## Testing done

Post Fix 
```
root@vjb-geet-11mar:~# vjbctl user change-password geet
Enter current password for 'geet':
Enter new password:
Password too small
Enter new password:
Password too small
Enter new password:
Password too small
Error setting up the password
root@vjb-geet-11mar:~#
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes restart behavior for `vjbctl user` commands and introduces a new `restart_vjailbreak_ui` call path; failures could now skip needed restarts or error at runtime if the helper isn’t available.
> 
> **Overview**
> Updates `vjbctl` (`pf9-htpasswd.sh`) so `user create`, `user delete`, and `user change-password` **only restart** the `vjailbreak-ui` deployment when the underlying subcommand succeeds (`$? -eq 0`) and `--no-restart` is not set.
> 
> The direct `kubectl rollout restart` is replaced with a `restart_vjailbreak_ui` invocation for these paths, reducing unnecessary pod restarts on validation/password failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c83b0694163485a4e27508638f727ac23763a1e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->