### PR TITLE
Optimise VMware tool removal

### DIFF
--- a/scripts/firstboot/store/vmware-tools-deletion.ps1
+++ b/scripts/firstboot/store/vmware-tools-deletion.ps1
@@ -10,6 +10,10 @@ param(
 
 $ErrorActionPreference = "SilentlyContinue"
 
+$ProgressPreference = 'SilentlyContinue'
+$VerbosePreference  = 'SilentlyContinue'
+$InformationPreference = 'SilentlyContinue'
+
 function Write-Log {
     param([string]$Message,[string]$Level="INFO")
     $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
@@ -58,11 +62,11 @@ function Remove-VMwareServices {
 
     foreach($svc in $services){
 
-        sc.exe query $svc | Out-Null
+        sc.exe query $svc *> $null
 
         if($LASTEXITCODE -eq 0){
             try {
-                sc.exe delete $svc | Out-Null
+                sc.exe delete $svc *> $null
                 Write-Log "Deleted service $svc"
             }
             catch {
@@ -75,6 +79,9 @@ function Remove-VMwareServices {
 function Remove-VMwareDrivers {
 
     Write-Log "Removing VMware drivers"
+
+    sc stop VMMemCtl *> $null
+    sc delete VMMemCtl *> $null
 
     $drivers=@(
     "vmci.sys","vm3dmp.sys","vm3dmp_loader.sys",
@@ -115,7 +122,7 @@ function Remove-DriverStore {
 
     Write-Log "Cleaning DriverStore VMware entries"
 
-    $drivers=pnputil /enum-drivers
+    $drivers = pnputil /enum-drivers *> $null
 
     $published=""
     $provider=""
@@ -136,7 +143,7 @@ function Remove-DriverStore {
 
                 Write-Log "Removing driverstore $published"
 
-                pnputil /delete-driver $published /uninstall /force | Out-Null
+                pnputil /delete-driver $published /force *> $null
             }
 
             $published=""
@@ -274,59 +281,79 @@ function Remove-VMwareResiduals {
 
     if(Test-Path $vmwarePath){
 
-        Write-Host "VMware folder detected, attempting cleanup..."
+        Write-Log "VMware folder detected, forcing cleanup..."
 
         $devices = Get-WmiObject Win32_PnPEntity | Where-Object { $_.Name -match "VMware" }
 
         foreach ($dev in $devices) {
             $instanceId = $dev.DeviceID
-            Write-Host "Final remove device:" $dev.Name
-            pnputil /remove-device "$instanceId" /force 2>$null
+            Write-Log "Removing device: $($dev.Name)"
+            pnputil /remove-device "$instanceId" /force *> $null
         }
 
         try{
-            takeown /F "$vmwarePath" /R /D Y | Out-Null
-            icacls "$vmwarePath" /grant Administrators:F /T | Out-Null
-            Remove-Item "$vmwarePath" -Recurse -Force -ErrorAction Stop
-            Write-Host "VMware folder removed immediately"
+
+            cmd /c "takeown /F `"$vmwarePath`" /R /D Y" *> $null
+            cmd /c "icacls `"$vmwarePath`" /grant Administrators:F /T" *> $null
+
+            Remove-Item $vmwarePath -Recurse -Force -ErrorAction Stop
+
+            Write-Log "VMware folder removed successfully"
+
+        }catch{
+
+            Write-Log "Initial folder delete failed, retrying..."
+
+            Start-Sleep -Seconds 2
+
+            cmd /c "takeown /F `"$vmwarePath`" /R /D Y" *> $null
+            cmd /c "icacls `"$vmwarePath`" /grant Administrators:F /T" *> $null
+
+            Remove-Item $vmwarePath -Recurse -Force -ErrorAction SilentlyContinue
+
+            if(!(Test-Path $vmwarePath)){
+                Write-Log "VMware folder removed on retry"
+            }else{
+                Write-Log "VMware folder still present"
+            }
         }
-        catch{
 
-            Write-Host "Folder locked, scheduling delete on reboot..."
+    }else{
+        Write-Log "VMware folder not present"
+    }
 
-            $regPath = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager"
 
-            reg delete "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager" /v PendingFileRenameOperations /f 2>$null
+    # VMware driver files
+    $vmDrivers = @(
+        "C:\Windows\System32\drivers\vmmemctl.sys",
+        "C:\Windows\System32\drivers\vmmouse.sys"
+    )
 
-            $dll = "\??\C:\Program Files\VMware\VMware Tools\vmStatsProvider\win64\vmStatsProvider.dll"
+    foreach($drv in $vmDrivers){
 
-            $folder = "\??\C:\Program Files\VMware"
+        if(Test-Path $drv){
 
-            Set-ItemProperty `
-                -Path $regPath `
-                -Name PendingFileRenameOperations `
-                -Value @($dll,"",$folder,"") `
-                -Type MultiString `
-                -Force
+            Write-Log "Removing driver file $drv"
 
-            Write-Host "VMware folder scheduled for deletion at reboot"
+            try{
+
+                cmd /c "takeown /F `"$drv`"" *> $null
+                cmd /c "icacls `"$drv`" /grant Administrators:F" *> $null
+                cmd /c "del /F /Q `"$drv`"" *> $null
+
+                if(!(Test-Path $drv)){
+                    Write-Log "Driver removed successfully: $drv"
+                }else{
+                    Write-Log "Driver removal failed: $drv"
+                }
+
+            }catch{
+                Write-Log "Error removing driver $drv"
+            }
+
+        }else{
+            Write-Log "$drv not present"
         }
-    }
-    else{
-        Write-Host "VMware folder not present"
-    }
-
-
-    # Force remove vmmemctl driver file
-    $drv="C:\Windows\System32\drivers\vmmemctl.sys"
-
-    if(Test-Path $drv){
-
-        Write-Log "Removing vmmemctl driver"
-
-        takeown /F $drv | Out-Null
-        icacls $drv /grant Administrators:F | Out-Null
-        Remove-Item $drv -Force -ErrorAction SilentlyContinue
     }
 
 
@@ -351,12 +378,12 @@ function Remove-VMwareResiduals {
     }
 
 
-    # Force delete VMMemCtl registry key if still present
+    # Remove VMMemCtl registry key
     $key = "HKLM:\SYSTEM\CurrentControlSet\Services\VMMemCtl"
 
     if(Test-Path $key){
 
-        Write-Log "Force removing VMMemCtl service key"
+        Write-Log "Removing VMMemCtl registry key"
 
         try{
 
@@ -373,6 +400,8 @@ function Remove-VMwareResiduals {
             Set-Acl $key $acl
 
             Remove-Item $key -Recurse -Force
+
+            Write-Log "VMMemCtl registry removed"
 
         }catch{
 


### PR DESCRIPTION
## What this PR does:
- Refactors and optimizes the script for better reliability and readability.
- Improves service/driver stop sequences, adds more robust error handling (Try-Catch), and uses forceful deletion attempts (`-Force -Recurse` where possible).
- Adds better version-aware logic to handle differences across Windows Server editions.
- Tested on Windows Server **2012, 2016, 2019, 2022, 2025** (both source VMware and destination post-migration).

**Improvements achieved:**
- Most VMware services, registry entries, and non-locked files/folders are now cleaned up successfully on first boot (elevated).
- Reduced remnants in many cases compared to previous versions.

**Remaining known remnants (on specific versions):**
- **Windows Server 2012 & 2019**:
  - Folder `C:\Program Files\VMware` often remains (partially or fully).
  - Locked file: `C:\Program Files\VMware\VMware Tools\vmStatsProvider\win64\vmStatsProvider.dll` (held by `vmtoolsd.exe` or related processes).
- **Windows Server 2022 & 2025**:
  - Driver file `C:\Windows\System32\drivers\vmmemctl.sys` persists (memory balloon driver).
  - Even after `sc stop VMMemCtl` + `sc delete VMMemCtl`, the file stays locked.
- **Across versions**:
  - Some VMware pointing devices / VMCI Host Device may appear in **error state** in Device Manager (stale driver references).
  - Minor registry or Start Menu shortcuts occasionally linger.

**Why these remnants are still present:**
- The script runs **inside the guest at first boot** (as elevated PowerShell).
- By the time it executes, key VMware components are already loaded/started by Windows:
  - User-mode processes like `vmtoolsd.exe` lock DLLs/files.
  - Kernel drivers (e.g. `vmmemctl.sys`) are loaded early by the OS boot process → file handle remains open even after service delete.
- Windows (especially older editions like 2012/2019) has timing/permission quirks during early boot → `Remove-Item -Force` fails on locked/in-use files.
- Device Manager entries (pointing devices in error) are stale PnP references; deleting driver files alone doesn't always clear them instantly.


## Which issue(s) this PR fixes

fixes #1665 
fixes #1669 

## Testing done

winserver 2012 on source:
<img width="2880" height="1618" alt="image" src="https://github.com/user-attachments/assets/03f0d7af-9b0a-4eee-82b3-e94d85c0eeb3" />

winserver 2012 on destination:
<img width="2880" height="1630" alt="image" src="https://github.com/user-attachments/assets/57794c77-ea28-41cb-88a2-bbcdaa65f0fb" />
<img width="491" height="774" alt="image" src="https://github.com/user-attachments/assets/b7d92ced-5d5c-4bf4-a1f3-5be07ccbe985" />


winserver 2016 on source:
<img width="2880" height="1624" alt="image" src="https://github.com/user-attachments/assets/9dd14178-8425-436d-8ecb-d0424d4aa60c" />

winserver 2016 on destination:
<img width="2866" height="1616" alt="image" src="https://github.com/user-attachments/assets/e07deb09-a463-488c-b339-adc454a18f74" />
<img width="497" height="783" alt="image" src="https://github.com/user-attachments/assets/03b869cd-3ecc-4418-aa04-a3ca413de75c" />


winserver 2019 on source:
<img width="2880" height="1624" alt="image" src="https://github.com/user-attachments/assets/3ee7ce7c-33d4-47d3-a921-2b884da6fb13" />

winserver 2019 on destination:
<img width="2880" height="1632" alt="image" src="https://github.com/user-attachments/assets/2a6e6fc8-6725-465d-9338-f48f37168d3e" />
<img width="492" height="764" alt="image" src="https://github.com/user-attachments/assets/57ad332a-977b-4c87-a448-37674d4351e5" />


winserver 2022 on source:
<img width="2880" height="1616" alt="image" src="https://github.com/user-attachments/assets/25ef01fc-9d44-4ee8-82bb-9bdda798d210" />

winserver 2022 on destination:
<img width="2880" height="1630" alt="image" src="https://github.com/user-attachments/assets/8fd9da55-2417-4863-8227-c8ad96bf009d" />
<img width="495" height="757" alt="image" src="https://github.com/user-attachments/assets/a6333811-b2d2-40de-934f-42c15b00e4d0" />


winserver 2025 on source:
<img width="2880" height="1628" alt="image" src="https://github.com/user-attachments/assets/bea5da88-5da6-4f43-bf2a-0455bbe5f342" />

winserver 2025 on destination:
<img width="2880" height="1614" alt="image" src="https://github.com/user-attachments/assets/617eba86-363b-4422-86c9-440bc227fe9b" />
<img width="491" height="764" alt="image" src="https://github.com/user-attachments/assets/17b33c4d-8cfc-4451-83af-5c337c82274c" />

