### PR TITLE
fix: Version lock ingress version

### DIFF
--- a/image_builder/scripts/download_images.sh
+++ b/image_builder/scripts/download_images.sh
@@ -36,8 +36,8 @@ cert_manager_controller="quay.io/jetstack/cert-manager-controller:${CERT_MANAGER
 cert_manager_webhook="quay.io/jetstack/cert-manager-webhook:${CERT_MANAGER_VERSION}"
 cert_manager_cainjector="quay.io/jetstack/cert-manager-cainjector:${CERT_MANAGER_VERSION}"
 
-ingress_nginx_controller="registry.k8s.io/ingress-nginx/controller@sha256:4eea9a4cc2cb6ddcb7da14d377aaf452e68bd3dbe87fe280755d225c4d5e7e4e"
-kube_webhook_certgen="registry.k8s.io/ingress-nginx/kube-webhook-certgen@sha256:d7e8257f8d8bce64b6df55f81fba92011a6a77269b3350f8b997b152af348dba"
+ingress_nginx_controller="registry.k8s.io/ingress-nginx/controller@sha256:82917be97c0939f6ada1717bb39aa7e66c229d6cfb10dcfc8f1bd42f9efe0f81"
+kube_webhook_certgen="registry.k8s.io/ingress-nginx/kube-webhook-certgen@sha256:7c74a715af2c94cb734785b4d3ea1357b4f02b88e1e123c622a9cb68b62f669c"
 
 # Download cert-manager manifests
 CERT_MANAGER_URL="https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"

--- a/image_builder/vjailbreak-image.pkr.hcl
+++ b/image_builder/vjailbreak-image.pkr.hcl
@@ -29,7 +29,7 @@ variable "helm_version" {
 
 variable "ingress_nginx_version" {
   type    = string
-  default = "4.15.0"
+  default = "4.14.3"
 }
 
 source "qemu" "vjailbreak-image" {


### PR DESCRIPTION
## What this PR does / why we need it
Version lock ingress, so that we prebake image and it won't break in airgapped setups. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1676, #1655 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_