### PR TITLE
Fix: VJailbreakNode CR status was stuck at "CreatingVM" for L2 networks even after the VM joined the K8s cluster. 

### DIFF
--- a/k8s/migration/internal/controller/vjailbreaknode_controller.go
+++ b/k8s/migration/internal/controller/vjailbreaknode_controller.go
@@ -29,9 +29,9 @@ import (
 
 	"github.com/pkg/errors"
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
-	"github.com/platform9/vjailbreak/pkg/common/constants"
 	"github.com/platform9/vjailbreak/k8s/migration/pkg/scope"
 	"github.com/platform9/vjailbreak/k8s/migration/pkg/utils"
+	"github.com/platform9/vjailbreak/pkg/common/constants"
 )
 
 // VjailbreakNodeReconciler reconciles a VjailbreakNode object
@@ -129,19 +129,20 @@ func (r *VjailbreakNodeReconciler) reconcileNormal(ctx context.Context,
 	if uuid != "" {
 		// VM exists, check if we need to update UUID and/or IP
 		if vjNode.Status.OpenstackUUID == "" || vjNode.Status.VMIP == "" {
-			ipSet, err := utils.ReconcileVMStatusAndIP(ctx, r.Client, vjNode, uuid)
+			vmActive, err := utils.ReconcileVMStatusAndIP(ctx, r.Client, vjNode, uuid)
 			if err != nil {
 				log.Error(err, "Failed to reconcile VM status and IP")
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			if !ipSet {
-				// IP not yet available or VM still building, retry
+			if !vmActive {
+				// VM still building or in error state, retry
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 			}
-			// IP was set, requeue quickly to check K8s node status
-			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			// VM is active - for L2 networks IP may be empty (assigned manually)
+			// Fall through to check K8s node status
 		}
-		// VM and UUID already set, check Kubernetes node status
+		// VM is active (UUID set), check Kubernetes node status
+		// For L2 networks, the node may join before IP is set in VjailbreakNode
 		nodeReady, err := utils.ReconcileK8sNodeStatus(ctx, r.Client, vjNode)
 		if err != nil {
 			log.Error(err, "Failed to reconcile K8s node status")

--- a/k8s/migration/pkg/utils/vjailbreaknodeutils.go
+++ b/k8s/migration/pkg/utils/vjailbreaknodeutils.go
@@ -1028,6 +1028,8 @@ func GetVMMigration(ctx context.Context, k3sclient client.Client, vmName string,
 }
 
 // ReconcileVMStatusAndIP handles VM status checking and IP population for a VjailbreakNode
+// Returns true if VM is ACTIVE (ready for K8s node check), false if still building or in error
+// Note: For L2 networks, vmIP may be empty even when VM is ACTIVE (IP is assigned manually)
 func ReconcileVMStatusAndIP(ctx context.Context, k8sClient client.Client, vjNode *vjailbreakv1alpha1.VjailbreakNode, uuid string) (bool, error) {
 	// Get VM status and IP from OpenStack
 	vmStatus, vmIP, err := GetOpenstackVMStatus(ctx, k8sClient, vjNode, uuid)
@@ -1048,13 +1050,13 @@ func ReconcileVMStatusAndIP(ctx context.Context, k8sClient client.Client, vjNode
 		}
 		return false, errors.New("VM is in ERROR state in OpenStack")
 	case "ACTIVE":
-		// VM is active, proceed with IP assignment
+		// VM is active, proceed with IP assignment if available
 		vjNode.Status.Phase = constants.VjailbreakNodePhaseVMCreated
-		if vmIP == "" {
-			// IP not yet available, caller should retry
-			return false, nil
+		// For L2 networks, vmIP may be empty (IP is assigned manually by user)
+		// We still return true to allow K8s node status check to proceed
+		if vmIP != "" {
+			vjNode.Status.VMIP = vmIP
 		}
-		vjNode.Status.VMIP = vmIP
 	default:
 		// VM is still building or in another transitional state
 		vjNode.Status.Phase = constants.VjailbreakNodePhaseVMCreating
@@ -1075,8 +1077,8 @@ func ReconcileVMStatusAndIP(ctx context.Context, k8sClient client.Client, vjNode
 		return false, errors.Wrap(err, "failed to update vjailbreak node status")
 	}
 
-	// Return true if IP was set
-	return vjNode.Status.VMIP != "", nil
+	// Return true when VM is ACTIVE - caller should proceed to check K8s node status
+	return true, nil
 }
 
 // ReconcileK8sNodeStatus checks Kubernetes node status and updates VjailbreakNode phase accordingly
@@ -1102,6 +1104,14 @@ func ReconcileK8sNodeStatus(ctx context.Context, k8sClient client.Client, vjNode
 	// Update phase based on node readiness
 	if nodeReady {
 		vjNode.Status.Phase = constants.VjailbreakNodePhaseNodeReady
+		// For L2 networks, VMIP may not be set from OpenStack (IP is assigned manually)
+		// Get the IP from the K8s node's internal IP annotation if not already set
+		if vjNode.Status.VMIP == "" {
+			nodeIP := GetNodeInternalIP(node)
+			if nodeIP != "" {
+				vjNode.Status.VMIP = nodeIP
+			}
+		}
 	} else if vjNode.Status.Phase != constants.VjailbreakNodePhaseVMCreated {
 		vjNode.Status.Phase = constants.VjailbreakNodePhaseVMCreated
 	}


### PR DESCRIPTION
## What this PR does / why we need it
For L2 network, IP is assigned by the user and this won't be reflected on the port. hence we won't get the ip from pcd, hence once the agent joins the cluster get the ip from k3s apis and update the vjailbreaknode CR's. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1680 

## Special notes for your reviewer
<img width="1353" height="376" alt="image" src="https://github.com/user-attachments/assets/ed17bb77-cce5-46b1-b79f-9c4ded2c4a4b" />


## Testing done

_please add testing details (logs, screenshots, etc.)_