### PR TITLE
#1694 : Extract only first IPv4 address when displaying and editing VM IP addresses

### DIFF
--- a/ui/src/features/migration/RollingMigrationForm.tsx
+++ b/ui/src/features/migration/RollingMigrationForm.tsx
@@ -796,26 +796,25 @@ export default function RollingMigrationFormDrawer({
   }
 
   // IP validation and editing functions
+  const IPV4_MATCH_REGEX =
+    /(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/g
+  const IPV4_FULL_REGEX =
+    /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+
   const extractFirstIPv4 = (value: string): string => {
     if (!value) return ''
-    const matches = value.match(
-      /(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/g
-    )
+    const matches = value.match(IPV4_MATCH_REGEX)
     return matches?.[0] || ''
   }
 
   const hasMultipleIPv4 = (value: string): boolean => {
     if (!value) return false
-    const matches = value.match(
-      /(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/g
-    )
+    const matches = value.match(IPV4_MATCH_REGEX)
     return (matches?.length || 0) > 1
   }
 
   const isValidIPAddress = (ip: string): boolean => {
-    const ipRegex =
-      /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
-    return ipRegex.test(ip)
+    return IPV4_FULL_REGEX.test(ip)
   }
 
   // Modal functions for multi-NIC IP editing removed - using bulk assignment instead

--- a/ui/src/features/migration/VmsSelectionStep.tsx
+++ b/ui/src/features/migration/VmsSelectionStep.tsx
@@ -188,19 +188,18 @@ function VmsSelectionStep({
   const { track } = useAmplitude({ component: 'VmsSelectionStep' })
   const queryClient = useQueryClient()
 
+  const IPV4_REGEX =
+    /(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/g
+
   const extractFirstIPv4 = (value: string): string => {
     if (!value) return ''
-    const matches = value.match(
-      /(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/g
-    )
+    const matches = value.match(IPV4_REGEX)
     return matches?.[0] || ''
   }
 
   const hasMultipleIPv4 = (value: string): boolean => {
     if (!value) return false
-    const matches = value.match(
-      /(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/g
-    )
+    const matches = value.match(IPV4_REGEX)
     return (matches?.length || 0) > 1
   }
 
@@ -1509,7 +1508,7 @@ function VmsSelectionStep({
       Record<number, 'empty' | 'valid' | 'invalid' | 'validating'>
     > = {}
 
-    ;(Array.from(selectedVMs) as string[]).forEach((vmName) => {
+    Array.from(selectedVMs).forEach((vmName) => {
       const vm = vmsWithFlavor.find((v) => v.name === vmName)
       if (!vm) {
         return


### PR DESCRIPTION
## What this PR does / why we need it
In the case of multiple IPs, the additional field for all IPs was added unnecessarily, which created confusion. I have now removed it.

## Which issue(s) this PR fixes
fixes #
- https://github.com/platform9/vjailbreak/issues/1694

## Special notes for your reviewer
For your reference, the migration-system/vmwaremachines API is sending separate entries for each network interface.
<img width="274" height="744" alt="image" src="https://github.com/user-attachments/assets/53900ff5-47a3-496a-8951-f50aef9d9d30" />
<img width="1411" height="743" alt="image" src="https://github.com/user-attachments/assets/c076ab24-57ee-4f38-a9f4-b895ba13ced2" />


## Testing done
[Screencast from 16-03-26 02:11:34 PM IST.webm](https://github.com/user-attachments/assets/16e9267a-d0f9-4f6a-b35f-887acd1e8e59)