### PR TITLE
Added dnsConfig with ndots: 1 for controller,v2v-helper and vpwned pods

### DIFF
--- a/deploy/05controller-deployment.yaml
+++ b/deploy/05controller-deployment.yaml
@@ -75,6 +75,10 @@ spec:
         - mountPath: /etc/hosts
           name: hosts-file
           readOnly: true
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       securityContext:

--- a/deploy/06vpwned-deployment.yaml
+++ b/deploy/06vpwned-deployment.yaml
@@ -42,6 +42,10 @@ spec:
           readOnly: true
         - mountPath: /home/ubuntu
           name: vddk-storage
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/deploy/installer.yaml
+++ b/deploy/installer.yaml
@@ -4480,6 +4480,10 @@ spec:
         - mountPath: /etc/hosts
           name: hosts-file
           readOnly: true
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       securityContext:
@@ -4544,6 +4548,10 @@ spec:
           readOnly: true
         - mountPath: /home/ubuntu
           name: vddk-storage
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/k8s/migration/config/addons/k8s.svc.yaml
+++ b/k8s/migration/config/addons/k8s.svc.yaml
@@ -40,6 +40,10 @@ spec:
         envFrom:
         - configMapRef:
             name: pf9-env
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/k8s/migration/config/manager/manager.yaml
+++ b/k8s/migration/config/manager/manager.yaml
@@ -57,6 +57,10 @@ spec:
         #   type: RuntimeDefault
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       containers:
       - command:
         - /manager

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -1119,7 +1119,15 @@ func (r *MigrationPlanReconciler) CreateJob(ctx context.Context,
 						ServiceAccountName:            "migration-controller-manager",
 						TerminationGracePeriodSeconds: ptr.To(constants.TerminationPeriod),
 						HostNetwork:                   true,
-						DNSPolicy:                     corev1.DNSClusterFirstWithHostNet,
+						DNSPolicy: corev1.DNSClusterFirstWithHostNet,
+						DNSConfig: &corev1.PodDNSConfig{
+							Options: []corev1.PodDNSConfigOption{
+								{
+									Name:  "ndots",
+									Value: ptr.To("1"),
+								},
+							},
+						},
 						Containers: []corev1.Container{
 							{
 								Name:            "fedora",

--- a/pkg/vpwned/deploy/k8s.svc.yaml
+++ b/pkg/vpwned/deploy/k8s.svc.yaml
@@ -46,6 +46,10 @@ spec:
         envFrom:
         - configMapRef:
             name: pf9-env
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
       dnsPolicy: ClusterFirst
       hostNetwork: true
       restartPolicy: Always


### PR DESCRIPTION
## What this PR does / why we need it

Kubernetes pods default to ndots: 5 in their DNS resolver configuration. External FQDNs like poc-regionone.app.staging-pcd.platform9.com contain only 4 dots, so the resolver treats them as relative names and appends internal cluster search domains first (e.g., .migration-system.svc.cluster.local). In proxied environments, these mangled queries return errors before the resolver can try the clean FQDN.

Added dnsConfig with ndots: "1" to all deployments. This tells the resolver to treat any name with at least 1 dot as an absolute FQDN, resolving it directly before trying search domain suffixes.

## Which issue(s) this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1685

## Special notes for your reviewer

## Testing done

Before dns config

```
kubectl exec -it -n migration-system migration-vpwned-sdk-cc7bfd97f-k2wd6  -- sh
~ # cat /etc/resolv.conf 
search migration-system.svc.cluster.local svc.cluster.local cluster.local localdomain
nameserver 10.43.0.10
options ndots:5
```

After dns config

```
~ # cat /etc/resolv.conf 
search migration-system.svc.cluster.local svc.cluster.local cluster.local localdomain
nameserver 10.43.0.10
options ndots:1
```

v2v-helper pod:
Before:

```
kubectl exec -it -n migration-system v2v-helper-ubuntu-lvm-root-vj-test-e8748-ee624-jg54l -- sh
sh-5.2# cat /etc/resolv.conf 
search migration-system.svc.cluster.local svc.cluster.local cluster.local localdomain
nameserver 10.43.0.10
options ndots:5
```

```
kubectl exec -it -n migration-system v2v-helper-centos-7-new-vj-test-a3c65-38d5b-886jk -- sh
sh-5.2# cat /etc/resolv.conf 
search migration-system.svc.cluster.local svc.cluster.local cluster.local localdomain
nameserver 10.43.0.10
options ndots:1
```

_please add testing details (logs, screenshots, etc.)_