### PR TITLE
Disable security group selection for L2-enabled PCD credentials

### DIFF
--- a/ui/src/api/openstack-creds/model.ts
+++ b/ui/src/api/openstack-creds/model.ts
@@ -58,6 +58,7 @@ export interface OpenstackCredsSpec {
   cinderBackendPools?: string[]
   dataCopyMethods?: string[]
   projectName?: string
+  vjbinstanceid?: string
 }
 
 export interface GetOpenstackCredsListMetadata {

--- a/ui/src/features/agents/components/ScaleUpDrawer.tsx
+++ b/ui/src/features/agents/components/ScaleUpDrawer.tsx
@@ -76,6 +76,8 @@ export default function ScaleUpDrawer({ open, onClose, masterNode }: ScaleUpDraw
   const openstackCredsValidated =
     openstackCredentials?.status?.openstackValidationStatus === 'Succeeded'
 
+  const isL2Credential = Boolean(openstackCredentials?.spec?.vjbinstanceid?.trim())
+
   const [volumeTypes, setVolumeTypes] = useState<Array<string>>([])
   const [selectedVolumeType, setSelectedVolumeType] = useState('')
 
@@ -427,7 +429,7 @@ export default function ScaleUpDrawer({ open, onClose, masterNode }: ScaleUpDraw
                 fullWidth
                 size="small"
                 disabled={
-                  !openstackCredsValidated || !openstackCredentials || securityGroups.length === 0
+                  !openstackCredsValidated || !openstackCredentials || securityGroups.length === 0 || isL2Credential
                 }
               >
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
@@ -437,6 +439,7 @@ export default function ScaleUpDrawer({ open, onClose, masterNode }: ScaleUpDraw
                     multiple
                     value={useMasterSecurityGroups ? ['USE_MASTER'] : selectedSecurityGroups}
                     label=""
+                    disabled={isL2Credential}
                     onChange={(e) => {
                       const value = e.target.value as string[]
                       if (value.includes('USE_MASTER')) {


### PR DESCRIPTION
## What this PR does / why we need it
When vJailbreak VM is deployed on a Layer 2 network (indicated by vjbinstanceid in PCD credentials), security group selection is now disabled in the agent scale-up drawer since L2 networks don't support security groups.

## Which issue(s) this PR fixes
fixes #1679 

## Testing done
<img width="1535" height="755" alt="image" src="https://github.com/user-attachments/assets/6c7f6406-74ca-4a86-bb37-80fae14db121" />
