### PR TITLE
Removing the volume attachment delay due to metadata service connectivity

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -281,18 +281,18 @@ jobs:
           path: tmp/gosec-report.json
           retention-days: 90
 
-      - name: Create Pull Request (if vulnerabilities found)
-        if: ${{ github.event_name == 'push' && steps.scan.outputs.gosec_high_found == 'true' }}
-        continue-on-error: true
-        uses: peter-evans/create-pull-request@v5
-        with:
-          commit-message: 'chore: vulnerabilities detected by Gosec (HIGH/CRITICAL)'
-          title: 'Gosec Vulnerability Report for branch ${{ github.ref_name }}'
-          body-path: tmp/pr-body.md
-          branch: auto/gosec-scan/${{ env.SAFE_REF_NAME }}
-          base: ${{ github.ref_name }}
-          delete-branch: true
-          add-paths: tmp/pr-body.md
+      # - name: Create Pull Request (if vulnerabilities found)
+      #   if: ${{ github.event_name == 'push' && steps.scan.outputs.gosec_high_found == 'true' }}
+      #   continue-on-error: true
+      #   uses: peter-evans/create-pull-request@v5
+      #   with:
+      #     commit-message: 'chore: vulnerabilities detected by Gosec (HIGH/CRITICAL)'
+      #     title: 'Gosec Vulnerability Report for branch ${{ github.ref_name }}'
+      #     body-path: tmp/pr-body.md
+      #     branch: auto/gosec-scan/${{ env.SAFE_REF_NAME }}
+      #     base: ${{ github.ref_name }}
+      #     delete-branch: true
+      #     add-paths: tmp/pr-body.md
 
       # Temporarily disabled: fail on vulnerabilities — fixing existing findings before re-enabling
       # - name: Fail Job If Vulnerabilities Found (Push)
@@ -635,18 +635,18 @@ jobs:
           path: tmp/trivy-report.json
           retention-days: 90
 
-      - name: Create Pull Request (if vulnerabilities found)
-        if: ${{ github.event_name == 'push' && steps.scan.outputs.trivy_high_found == 'true' }}
-        continue-on-error: true
-        uses: peter-evans/create-pull-request@v5
-        with:
-          commit-message: 'chore: vulnerabilities detected by Trivy (HIGH/CRITICAL)'
-          title: 'Trivy Vulnerability Report for branch ${{ github.ref_name }}'
-          body-path: tmp/pr-body.md
-          branch: auto/trivy-scan/${{ env.SAFE_REF_NAME }}
-          base: ${{ github.ref_name }}
-          delete-branch: true
-          add-paths: tmp/pr-body.md
+      # - name: Create Pull Request (if vulnerabilities found)
+      #   if: ${{ github.event_name == 'push' && steps.scan.outputs.trivy_high_found == 'true' }}
+      #   continue-on-error: true
+      #   uses: peter-evans/create-pull-request@v5
+      #   with:
+      #     commit-message: 'chore: vulnerabilities detected by Trivy (HIGH/CRITICAL)'
+      #     title: 'Trivy Vulnerability Report for branch ${{ github.ref_name }}'
+      #     body-path: tmp/pr-body.md
+      #     branch: auto/trivy-scan/${{ env.SAFE_REF_NAME }}
+      #     base: ${{ github.ref_name }}
+      #     delete-branch: true
+      #     add-paths: tmp/pr-body.md
 
       # Temporarily disabled: fail on vulnerabilities — fixing existing findings before re-enabling
       # - name: Fail Job If Vulnerabilities Found (Push)

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -67,6 +67,12 @@ func (osclient *OpenStackClients) GetIsSimpleNetwork(ctx context.Context, networ
 
 func GetCurrentInstanceUUID() (string, error) {
 
+	// Use the env var directly if set, avoiding a network round-trip to the
+	// metadata service which may not be reachable in all deployment environments.
+	if id := os.Getenv("CURRENT_INSTANCE_ID"); id != "" {
+		return id, nil
+	}
+
 	// Step 1. Path with a read lock
 	// First Check if the data is already cached. This read lock allows multiple
 	// Goroutines to read the cached data concurrently.
@@ -103,11 +109,6 @@ func GetCurrentInstanceUUID() (string, error) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		currentInstanceUUID := os.Getenv("CURRENT_INSTANCE_ID")
-		if currentInstanceUUID != "" {
-			PrintLog("CURRENT_INSTANCE_ID environment variable is set to: " + currentInstanceUUID)
-			return currentInstanceUUID, nil
-		}
 		return "", fmt.Errorf("failed to get response: %s", err)
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
## What this PR does / why we need it
This PR adds a change to prefer CURRENT_INSTANCE_ID variable if set. This will remove the delay that is added when trying to reach metadata service first.

Other change is to stop GH actions to create PR for trivy scan report every time

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1799 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_