### PR TITLE
ci: skip build-image and lint workflow 

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -14,6 +14,7 @@ jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'pre-release/')"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -54,6 +54,7 @@ env:
 jobs:
   determine-release:
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'pre-release/')"
     outputs:
       is_release: ${{ env.release_found }}
       is_nightly: ${{ github.event.inputs.is_nightly }}
@@ -287,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [determine-release, build-ui, build-v2v-helper, build-controller, build-vpwned]
     if: |
-      always() && 
+      needs.determine-release.result == 'success' &&
       (needs.build-ui.result == 'success' || needs.build-ui.result == 'skipped') && 
       (needs.build-v2v-helper.result == 'success' || needs.build-v2v-helper.result == 'skipped') && 
       (needs.build-controller.result == 'success' || needs.build-controller.result == 'skipped') && 
@@ -373,7 +374,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [determine-release, build-ui, build-v2v-helper, build-controller, build-vpwned, push-images]
     if: |
-      always() && 
+      needs.determine-release.result == 'success' &&
       (needs.build-ui.result == 'success' || needs.build-ui.result == 'skipped') && 
       (needs.build-v2v-helper.result == 'success' || needs.build-v2v-helper.result == 'skipped') && 
       (needs.build-controller.result == 'success' || needs.build-controller.result == 'skipped') && 

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -54,7 +54,6 @@ env:
 jobs:
   determine-release:
     runs-on: ubuntu-latest
-    if: "!startsWith(github.head_ref, 'pre-release/')"
     outputs:
       is_release: ${{ env.release_found }}
       is_nightly: ${{ github.event.inputs.is_nightly }}
@@ -153,6 +152,7 @@ jobs:
 
   build-ui:
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'pre-release/')"
     needs: determine-release
 
     steps:
@@ -184,6 +184,7 @@ jobs:
 
   build-v2v-helper:
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'pre-release/')"
     needs: determine-release
 
     steps:
@@ -218,6 +219,7 @@ jobs:
 
   build-controller:
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'pre-release/')"
     needs: determine-release
 
     steps:
@@ -255,6 +257,7 @@ jobs:
 
   build-vpwned:
     runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'pre-release/')"
     needs: determine-release
 
     steps:
@@ -288,6 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [determine-release, build-ui, build-v2v-helper, build-controller, build-vpwned]
     if: |
+      !startsWith(github.head_ref, 'pre-release/') &&
       needs.determine-release.result == 'success' &&
       (needs.build-ui.result == 'success' || needs.build-ui.result == 'skipped') && 
       (needs.build-v2v-helper.result == 'success' || needs.build-v2v-helper.result == 'skipped') && 
@@ -374,6 +378,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [determine-release, build-ui, build-v2v-helper, build-controller, build-vpwned, push-images]
     if: |
+      !startsWith(github.head_ref, 'pre-release/') &&
       needs.determine-release.result == 'success' &&
       (needs.build-ui.result == 'success' || needs.build-ui.result == 'skipped') && 
       (needs.build-v2v-helper.result == 'success' || needs.build-v2v-helper.result == 'skipped') && 

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -7,6 +7,11 @@ on:
         description: "Release tag (e.g. v0.4.0)"
         required: true
         type: string
+      branch:
+        description: "Branch to use (default: main)"
+        required: false
+        default: "main"
+        type: string
 
 permissions:
   contents: write
@@ -18,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout main branch
+      - name: Checkout branch
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.event.inputs.branch || 'main' }}
           fetch-depth: 0
 
       - name: Setup Go


### PR DESCRIPTION
## What this PR does / why we need it
- Skip the entire workflow when a PR originates from a `pre-release/*` branch, removing the unwanted CI run triggered by the pre-release CRD generation PR.
- Add optional `branch` input (default: `main`) for manual testing via "Run workflow".

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1795 


## Testing done

Can't be tested without merging into main branch