### PR TITLE
validate CURRENT_INSTACE_ID is in the same env

### DIFF
--- a/k8s/migration/go.mod
+++ b/k8s/migration/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/vmware/govmomi v0.51.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/crypto v0.44.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.3
 	k8s.io/apimachinery v0.33.3
@@ -86,7 +87,6 @@ require (
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	golang.org/x/crypto v0.44.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect

--- a/pkg/common/validation/openstack/validate.go
+++ b/pkg/common/validation/openstack/validate.go
@@ -149,6 +149,15 @@ func Validate(ctx context.Context, k8sClient client.Client, openstackcreds *vjai
 	}
 
 	if openstackCredential.VJBInstanceID != "" {
+		// Verify the provided instance ID exists in the OpenStack environment
+		_, err = verifyInstanceExists(providerClient, openstackCredential.RegionName, openstackCredential.VJBInstanceID)
+		if err != nil {
+			return ValidationResult{
+				Valid:   false,
+				Message: fmt.Sprintf("Failed to verify instance ID '%s': %s", openstackCredential.VJBInstanceID, err.Error()),
+				Error:   err,
+			}
+		}
 		return successfulValidationObject
 	}
 
@@ -280,6 +289,47 @@ func verifyCredentialsMatchCurrentEnvironment(providerClient *gophercloud.Provid
 		}
 		return false, fmt.Errorf("failed to verify instance access: %w. "+
 			"Please check if the provided credentials have compute:get_server permission", err)
+	}
+	return true, nil
+}
+
+// verifyInstanceExists checks if the provided instance ID exists in the OpenStack environment
+func verifyInstanceExists(providerClient *gophercloud.ProviderClient, regionName string, instanceID string) (ok bool, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			ok = false
+			err = fmt.Errorf("panic while verifying instance existence: %v", r)
+		}
+	}()
+
+	if providerClient == nil {
+		return false, fmt.Errorf("provider client is nil")
+	}
+	if providerClient.EndpointLocator == nil {
+		return false, fmt.Errorf("OpenStack client is not authenticated (endpoint locator is not initialized)")
+	}
+	if strings.TrimSpace(regionName) == "" {
+		return false, fmt.Errorf("region name is empty")
+	}
+	if strings.TrimSpace(instanceID) == "" {
+		return false, fmt.Errorf("instance ID is empty")
+	}
+
+	computeClient, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{
+		Region: regionName,
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to create OpenStack compute client: %w", err)
+	}
+
+	_, err = servers.Get(context.TODO(), computeClient, instanceID).Extract()
+	if err != nil {
+		if strings.Contains(err.Error(), "Resource not found") ||
+			strings.Contains(err.Error(), "No server with a name or ID") ||
+			strings.Contains(err.Error(), "404") {
+			return false, fmt.Errorf("instance ID '%s' not found in the OpenStack environment. Please verify the instance ID and ensure the credentials are for the correct OpenStack environment", instanceID)
+		}
+		return false, fmt.Errorf("failed to verify instance access: %w. Please check if the provided credentials have compute:get_server permission", err)
 	}
 	return true, nil
 }


### PR DESCRIPTION
## What this PR does / why we need it
This PR prevents user from inputting random strings in "instance ID" section, it will only accept strings that are valid Instance IDs in given openstack environment

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1769 

## Special notes for your reviewer


## Testing done
<img width="1440" height="795" alt="Screenshot 2026-04-15 at 4 35 19 PM" src="https://github.com/user-attachments/assets/db708fed-5464-4e5f-9e6c-0284a336e6bc" />
<img width="1440" height="797" alt="Screenshot 2026-04-15 at 4 37 04 PM" src="https://github.com/user-attachments/assets/e4471b0d-aeaf-4c91-afc1-7474cbba9883" />

