### PR TITLE
fix: update VM identification from name to ID in VmsSelectionStep

### DIFF
--- a/ui/src/features/migration/VmsSelectionStep.tsx
+++ b/ui/src/features/migration/VmsSelectionStep.tsx
@@ -886,10 +886,10 @@ function VmsSelectionStep({
 
     setVmsWithFlavor((prev) =>
       prev.map((vm) => {
-        if (vmOSAssignments && Object.prototype.hasOwnProperty.call(vmOSAssignments, vm.name)) {
+        if (vmOSAssignments && Object.prototype.hasOwnProperty.call(vmOSAssignments, vm.id)) {
           return {
             ...vm,
-            osFamily: vmOSAssignments[vm.name]
+            osFamily: vmOSAssignments[vm.id]
           }
         }
         return vm
@@ -964,7 +964,7 @@ function VmsSelectionStep({
       // Update local state first for immediate UI feedback
       setVmOSAssignments((prev) => ({ ...prev, [vmId]: osFamily }))
 
-      const vm = vmsWithFlavor.find((v) => v.name === vmId)
+      const vm = vmsWithFlavor.find((v) => v.id === vmId)
       if (vm?.vmWareMachineName) {
         await patchVMwareMachine(vm.vmWareMachineName, {
           spec: {


### PR DESCRIPTION
## What this PR does / why we need it
I fixed the migration OS-assignment flow so it consistently uses VM id (not name) when:

- finding the VM to patch after OS selection
- applying local vmOSAssignments back into the selected VM list

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1814 


## Testing done
<img width="906" height="698" alt="image" src="https://github.com/user-attachments/assets/dcf7543b-6766-40cb-a2e4-8f302ab27ffc" />
