### PR TITLE
Virtio installation in windows

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1143,7 +1143,7 @@ func (migobj *Migrate) performDiskConversion(ctx context.Context, vminfo vm.VMIn
 			Script: "Firstboot-Scheduler.ps1",
 			Async:  false,
 		})
-		if strings.ToLower(vminfo.OSType) == constants.OSFamilyWindows && (strings.Contains(strings.ToLower(osRelease), "server 2012") || strings.Contains(strings.ToLower(osRelease), "server2012")) {
+		if strings.ToLower(vminfo.OSType) == constants.OSFamilyWindows {
 			utils.PrintLog("Successfully added VirtIO PowerShell script to guest")
 			firstbootwinscripts = append(firstbootwinscripts, virtv2v.FirstBootWindows{
 				Script: "install-virtio-win12.ps1",


### PR DESCRIPTION
## What this PR does / why we need it

Adding a custom script on first boot  to install the virtio drivers for network adapters manually.
If drivers are absent in such cases it will manually install the drivers.

fixes #1683 

## Special notes for your reviewer


## Testing done
[virtio-install.log](https://github.com/user-attachments/files/26796033/virtio-install.log)

