### PR TITLE
improve bootable partition detection for Grub 2.12 and add script logging

### DIFF
--- a/scripts/get-bootable-partition.sh
+++ b/scripts/get-bootable-partition.sh
@@ -7,25 +7,41 @@
 # Step 1: Identify all disks in guest
 # List block devices (assuming /dev/vda, /dev/sda, etc. are available)
 disks=$(ls /dev/[sv]d[a-z] 2>/dev/null)
+echo "[DEBUG] Step 1: disks found: $(echo $disks | tr '\n' ' ')" >&2
 
 bootdisk=""
 
-# Step 2: Try to find which disk's MBR contains GRUB signature
-#   GRUB stage1 MBRs contain either "GRUB" or "boot" strings near offset 0x3E
+# Step 2: Try to find which disk's MBR contains GRUB signature, or has a bios_grub partition
+#   - MBR-partitioned disks: GRUB stage1 boot code is embedded in the MBR
+#   - GPT-partitioned disks: GRUB uses a dedicated bios_grub partition (no GRUB in MBR)
 for disk in $disks; do
-  # read first 512 bytes
-  sig=$(dd if="$disk" bs=512 count=1 2>/dev/null | strings | grep -E 'GRUB|boot' | head -n1)
-  if [ -n "$sig" ]; then
+  # Check MBR for GRUB signature (works for MBR-partitioned disks)
+  if dd if="$disk" bs=512 count=1 2>/dev/null | grep -aq 'GRUB'; then
+    echo "[DEBUG] Step 2: GRUB signature found in MBR of $disk" >&2
     bootdisk="$disk"
     break
   fi
+  # Check for GPT BIOS boot partition (grub2 with GPT uses bios_grub partition)
+  if command -v parted >/dev/null 2>&1; then
+    if parted -s "$disk" print 2>/dev/null | grep -q 'bios_grub'; then
+      echo "[DEBUG] Step 2: bios_grub partition found on $disk" >&2
+      bootdisk="$disk"
+      break
+    fi
+  fi
 done
+[ -z "$bootdisk" ] && echo "[DEBUG] Step 2: no GRUB/bios_grub found on any disk" >&2
 
 # Step 3: Check for /boot partition in fstab
 if [ -z "$bootdisk" ]; then
-  boot_uuid=$(grep -w '/boot' /etc/fstab | awk '{print $1}' | sed 's/^UUID=//')
-  if [ -n "$boot_uuid" ]; then
-    bootdisk=$(blkid | grep "$boot_uuid" | awk -F: '{sub(/[0-9][0-9]*$/, "", $1); print $1; exit}')
+  boot_entry=$(grep -w '/boot' /etc/fstab 2>/dev/null | awk '{print $1}')
+  # Handle both UUID=xxxx and /dev/disk/by-uuid/xxxx formats
+  boot_uuid=$(echo "$boot_entry" | sed 's/^UUID=//; s|^/dev/disk/by-uuid/||')
+  echo "[DEBUG] Step 3: boot_entry=$boot_entry boot_uuid=$boot_uuid" >&2
+  # Only proceed if result is a bare UUID (not a device path)
+  if [ -n "$boot_uuid" ] && ! echo "$boot_uuid" | grep -q '^/dev/'; then
+    bootdisk=$(blkid 2>/dev/null | grep "$boot_uuid" | awk -F: '{sub(/[0-9][0-9]*$/, "", $1); print $1; exit}')
+    echo "[DEBUG] Step 3: resolved bootdisk=$bootdisk" >&2
   fi
 fi
 
@@ -33,13 +49,15 @@ fi
 if [ -z "$bootdisk" ]; then
   # Check if root is on LVM
   root_dev=$(mount | grep 'on / ' | awk '{print $1}')
+  echo "[DEBUG] Step 4: root_dev=$root_dev" >&2
   if echo "$root_dev" | grep -q '/dev/mapper/\|/dev/.*-vg/'; then
     # Root is on LVM, find physical volumes
-    if command -v pvs >/dev/null 2>&1; then
-      # Get VG name from root device
-      vg_name=$(echo "$root_dev" | sed 's|/dev/mapper/\([^-]*\)-.*|\1|; s|/dev/\([^/]*\)-vg/.*|\1|')
+    if command -v lvs >/dev/null 2>&1; then
+      # Get VG name directly from lvs (avoids parsing device-mapper encoded names like ubuntu--vg)
+      vg_name=$(lvs --noheadings -o vg_name "$root_dev" 2>/dev/null | tr -d ' ')
       # Find PV for this VG
       pv_dev=$(pvs --noheadings -o pv_name,vg_name 2>/dev/null | awk -v vg="$vg_name" '$2 == vg {print $1; exit}')
+      echo "[DEBUG] Step 4: vg_name=$vg_name pv_dev=$pv_dev" >&2
       if [ -n "$pv_dev" ]; then
         # Strip partition number to get disk
         bootdisk=$(echo "$pv_dev" | sed 's/[0-9][0-9]*$//')
@@ -49,10 +67,12 @@ if [ -z "$bootdisk" ]; then
     # Root is on regular partition, strip partition number
     bootdisk=$(echo "$root_dev" | sed 's/[0-9][0-9]*$//')
   fi
+  echo "[DEBUG] Step 4: resolved bootdisk=$bootdisk" >&2
 fi
 
-# Step 5: Check for partitions with bootable flag set
+# Step 5: Check for partitions with bootable or bios_grub flag set
 if [ -z "$bootdisk" ]; then
+  echo "[DEBUG] Step 5: checking bootable/bios_grub partition flags" >&2
   for disk in $disks; do
     # Get partition count for this disk
     partitions=$(ls "${disk}"[0-9]* 2>/dev/null)
@@ -61,7 +81,8 @@ if [ -z "$bootdisk" ]; then
       part_num=$(echo "$part" | sed "s|${disk}||")
       # Check if partition is bootable using parted
       if command -v parted >/dev/null 2>&1; then
-        bootable=$(parted -s "$disk" print 2>/dev/null | awk -v pnum="$part_num" '$1 == pnum && /boot/ {print "true"}')
+        bootable=$(parted -s "$disk" print 2>/dev/null | awk -v pnum="$part_num" '$1 == pnum && (/boot/ || /bios_grub/) {print "true"}')
+        echo "[DEBUG] Step 5: $part (num=$part_num) bootable=$bootable" >&2
         if [ "$bootable" = "true" ]; then
           bootdisk="$disk"
           break 2
@@ -73,7 +94,9 @@ fi
 
 # Step 6: Final fallback - use first disk
 if [ -z "$bootdisk" ]; then
-  bootdisk=$(echo "$disks" | awk '{print $1}')
+  echo "[DEBUG] Step 6: fallback to first disk" >&2
+  bootdisk=$(echo "$disks" | head -1)
 fi
 
+echo "[DEBUG] Result: bootdisk=$bootdisk" >&2
 echo "$bootdisk"

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1016,7 +1016,8 @@ func (migobj *Migrate) handleLinuxOSDetection(vminfo vm.VMInfo, bootVolumeIndex 
 		return -1, "", "", -1, errors.New("empty bootable partition from the script")
 	}
 
-	index, err := virtv2v.RunCommandInGuestAllVolumes(vminfo.VMDisks, "device-index", false, strings.TrimSpace(ans))
+	firstDevice := strings.SplitN(strings.TrimSpace(ans), "\n", 2)[0]
+	index, err := virtv2v.RunCommandInGuestAllVolumes(vminfo.VMDisks, "device-index", false, strings.TrimSpace(firstDevice))
 	if err != nil {
 		fmt.Printf("failed to run command (%s): %v: %s\n", index, err, strings.TrimSpace(index))
 		return -1, "", "", -1, err

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1016,8 +1016,7 @@ func (migobj *Migrate) handleLinuxOSDetection(vminfo vm.VMInfo, bootVolumeIndex 
 		return -1, "", "", -1, errors.New("empty bootable partition from the script")
 	}
 
-	firstDevice := strings.SplitN(strings.TrimSpace(ans), "\n", 2)[0]
-	index, err := virtv2v.RunCommandInGuestAllVolumes(vminfo.VMDisks, "device-index", false, strings.TrimSpace(firstDevice))
+	index, err := virtv2v.RunCommandInGuestAllVolumes(vminfo.VMDisks, "device-index", false, strings.TrimSpace(ans))
 	if err != nil {
 		fmt.Printf("failed to run command (%s): %v: %s\n", index, err, strings.TrimSpace(index))
 		return -1, "", "", -1, err

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -1004,19 +1004,24 @@ func RunGetBootablePartitionScript(disks []vm.VMDisk) (string, error) {
 
 	// Run the script
 	var runErr error
-	var runOutput string
 
-	command = "sh"
-	runOutput, runErr = RunCommandInGuestAllVolumes(disks, command, true, "/tmp/get-bootable-partition.sh")
-
+	cmd := prepareGuestfishCommand(disks, "sh", true, "/tmp/get-bootable-partition.sh")
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	log.Printf("Executing %s", cmd.String())
+	runErr = cmd.Run()
+	if stderrBuf.Len() > 0 {
+		log.Printf("get-bootable-partition.sh debug output:\n%s", strings.TrimSpace(stderrBuf.String()))
+	}
 	if runErr != nil {
-		return "", fmt.Errorf("failed to run get-bootable-partition.sh: %v: %s", runErr, strings.TrimSpace(runOutput))
+		return "", fmt.Errorf("failed to run get-bootable-partition.sh: %v: %s", runErr, strings.TrimSpace(stderrBuf.String()))
 	}
 
 	log.Printf("Successfully executed get-bootable-partition.sh")
-	log.Printf("Script output: %s", strings.TrimSpace(runOutput))
+	log.Printf("Script output: %s", strings.TrimSpace(stdoutBuf.String()))
 
-	return strings.TrimSpace(runOutput), nil
+	return strings.TrimSpace(stdoutBuf.String()), nil
 }
 
 // RunNetworkPersistence mounts the disk locally and runs the network persistence script


### PR DESCRIPTION
## What this PR does / why we need it
This PR handles MBR format with newer GRUB versions. This specific error occurred due to GRUB 2.12 removed the "GRUB" string from the MBR boot code.

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1847 

## Special notes for your reviewer


## Testing done
Successfully migrated Ubuntu 24 VM with bios.