### PR TITLE
Feature: Support pure and netapp FC for SAM.

### DIFF
--- a/pkg/vpwned/sdk/storage/fcutil/fcutil.go
+++ b/pkg/vpwned/sdk/storage/fcutil/fcutil.go
@@ -1,5 +1,5 @@
 // Package fcutil provides helpers for working with Fibre Channel World Wide
-// Names (WWNs) as reported by ESXi hosts and Pure FlashArray storage arrays.
+// Names (WWNs) as reported by ESXi hosts and storage arrays.
 package fcutil
 
 import (

--- a/pkg/vpwned/sdk/storage/fcutil/fcutil.go
+++ b/pkg/vpwned/sdk/storage/fcutil/fcutil.go
@@ -1,0 +1,93 @@
+// Package fcutil provides helpers for working with Fibre Channel World Wide
+// Names (WWNs) as reported by ESXi hosts and Pure FlashArray storage arrays.
+package fcutil
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// fcAdapterRE matches ESXi FC adapter UIDs: fc.<hex16>:<hex16>
+// Group 1 = WWNN, Group 2 = WWPN (both as contiguous lowercase hex).
+var fcAdapterRE = regexp.MustCompile(`(?i)^fc\.([0-9a-f]+):([0-9a-f]+)$`)
+
+// wwnCharsRE validates that a string contains only hex digits.
+var wwnCharsRE = regexp.MustCompile(`^[0-9a-fA-F]+$`)
+
+// ParseFCUID splits an ESXi FC adapter UID (format: "fc.WWNN:WWPN") into its
+// two components. Both values are returned as uppercase hex strings without
+// separators. Returns an error if the input does not match the expected format
+// or contains non-hex characters.
+func ParseFCUID(uid string) (wwnn, wwpn string, err error) {
+	m := fcAdapterRE.FindStringSubmatch(uid)
+	if m == nil {
+		return "", "", fmt.Errorf("fcutil: %q is not a valid ESXi FC adapter UID (expected fc.WWNN:WWPN)", uid)
+	}
+	wwnn, wwpn = strings.ToUpper(m[1]), strings.ToUpper(m[2])
+	if len(wwnn)%2 != 0 {
+		return "", "", fmt.Errorf("fcutil: WWNN %q in %q has odd hex length", wwnn, uid)
+	}
+	if len(wwpn)%2 != 0 {
+		return "", "", fmt.Errorf("fcutil: WWPN %q in %q has odd hex length", wwpn, uid)
+	}
+	return wwnn, wwpn, nil
+}
+
+// StripWWNFormatting removes colons, dashes, and spaces from a WWN string and
+// returns it in uppercase. This produces a canonical form suitable for
+// equality comparison regardless of the source's formatting convention.
+//
+// Pure FlashArray returns WWNs as "20:00:00:90:fa:6e:67:a8".
+// ESXi reports them as contiguous hex "20000090fa6e67a8".
+// Both normalise to "20000090FA6E67A8".
+func StripWWNFormatting(wwn string) string {
+	r := strings.NewReplacer(":", "", "-", "", " ", "")
+	return strings.ToUpper(r.Replace(wwn))
+}
+
+// ColonSeparated inserts a colon between every pair of hex characters in wwn,
+// producing the standard storage-array display format (e.g. "21:00:00:00:00:00:00:01").
+func ColonSeparated(wwn string) string {
+	wwn = strings.ToUpper(wwn)
+	if len(wwn) < 2 {
+		return wwn
+	}
+	pairs := make([]string, 0, len(wwn)/2)
+	for i := 0; i+1 < len(wwn); i += 2 {
+		pairs = append(pairs, wwn[i:i+2])
+	}
+	// Handle trailing odd character (non-standard but defensive)
+	if len(wwn)%2 != 0 {
+		pairs = append(pairs, wwn[len(wwn)-1:])
+	}
+	return strings.Join(pairs, ":")
+}
+
+// WWPNFromFCUID extracts the port name (WWPN) from an ESXi FC adapter UID.
+// The WWPN is returned as an uppercase hex string without separators.
+//
+//	"fc.2000000000000001:2100000000000001" → "2100000000000001", nil
+func WWPNFromFCUID(uid string) (string, error) {
+	_, wwpn, err := ParseFCUID(uid)
+	return wwpn, err
+}
+
+// FormattedWWPNFromFCUID extracts the WWPN and returns it colon-separated,
+// matching the format used by storage array APIs such as Pure FlashArray.
+//
+//	"fc.2000000000000001:2100000000000001" → "21:00:00:00:00:00:00:01", nil
+func FormattedWWPNFromFCUID(uid string) (string, error) {
+	wwpn, err := WWPNFromFCUID(uid)
+	if err != nil {
+		return "", err
+	}
+	return ColonSeparated(wwpn), nil
+}
+
+// EqualWWNs reports whether two WWN strings refer to the same port address.
+// Comparison is case-insensitive and ignores colon, dash, and space separators
+// so that "21:00:00:00:00:00:00:01" and "2100000000000001" are considered equal.
+func EqualWWNs(a, b string) bool {
+	return StripWWNFormatting(a) == StripWWNFormatting(b)
+}

--- a/pkg/vpwned/sdk/storage/fcutil/fcutil_test.go
+++ b/pkg/vpwned/sdk/storage/fcutil/fcutil_test.go
@@ -1,0 +1,631 @@
+package fcutil_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/platform9/vjailbreak/pkg/vpwned/sdk/storage/fcutil"
+)
+
+// ── ParseFCUID ────────────────────────────────────────────────────────────────
+
+func TestParseFCUID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       string
+		wantWWNN    string
+		wantWWPN    string
+		wantErrFrag string // non-empty → expect an error containing this substring
+	}{
+		// ── valid inputs ───────────────────────────────────────────────────────
+		{
+			name:     "standard lowercase",
+			input:    "fc.2000000000000001:2100000000000001",
+			wantWWNN: "2000000000000001",
+			wantWWPN: "2100000000000001",
+		},
+		{
+			name:     "standard uppercase prefix",
+			input:    "fc.AABBCCDDEEFF0011:1122334455667788",
+			wantWWNN: "AABBCCDDEEFF0011",
+			wantWWPN: "1122334455667788",
+		},
+		{
+			name:     "mixed case hex digits are uppercased",
+			input:    "fc.20000090fa6e67a8:21000090fa6e67a8",
+			wantWWNN: "20000090FA6E67A8",
+			wantWWPN: "21000090FA6E67A8",
+		},
+		{
+			name:  "short but even-length wwn (4 chars each)",
+			input: "fc.aabb:ccdd",
+			// short WWNs are unusual but the parser should accept even-length values
+			wantWWNN: "AABB",
+			wantWWPN: "CCDD",
+		},
+		{
+			name:     "all-zeros wwn",
+			input:    "fc.0000000000000000:0000000000000000",
+			wantWWNN: "0000000000000000",
+			wantWWPN: "0000000000000000",
+		},
+		{
+			name:     "all-f wwn",
+			input:    "fc.ffffffffffffffff:ffffffffffffffff",
+			wantWWNN: "FFFFFFFFFFFFFFFF",
+			wantWWPN: "FFFFFFFFFFFFFFFF",
+		},
+
+		// ── invalid inputs ─────────────────────────────────────────────────────
+		{
+			name:        "missing fc. prefix",
+			input:       "2000000000000001:2100000000000001",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+		{
+			name:        "wrong prefix (naa.)",
+			input:       "naa.624a93702000000000000001",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+		{
+			name:        "no colon separator between wwnn and wwpn",
+			input:       "fc.20000000000000012100000000000001",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+		{
+			name:        "non-hex character in wwnn",
+			input:       "fc.2000000000000XYZ:2100000000000001",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+		{
+			name:        "non-hex character in wwpn",
+			input:       "fc.2000000000000001:210000000000000G",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+		{
+			name:        "odd-length wwnn",
+			input:       "fc.200000000000001:2100000000000001",
+			wantErrFrag: "odd hex length",
+		},
+		{
+			name:        "odd-length wwpn",
+			input:       "fc.2000000000000001:210000000000001",
+			wantErrFrag: "odd hex length",
+		},
+		{
+			name:        "empty wwnn",
+			input:       "fc.:2100000000000001",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+		{
+			name:        "empty wwpn",
+			input:       "fc.2000000000000001:",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+		{
+			name:        "three colon-delimited segments",
+			input:       "fc.200000:000000:000001",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+		{
+			name:        "fc. prefix only",
+			input:       "fc.",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+		{
+			name:        "colon-formatted wwnn (not contiguous hex)",
+			input:       "fc.20:00:00:00:00:00:00:01:21:00:00:00:00:00:00:01",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotWWNN, gotWWPN, err := fcutil.ParseFCUID(tc.input)
+
+			if tc.wantErrFrag != "" {
+				if err == nil {
+					t.Fatalf("ParseFCUID(%q) expected error containing %q, got nil (wwnn=%q wwpn=%q)",
+						tc.input, tc.wantErrFrag, gotWWNN, gotWWPN)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrFrag) {
+					t.Fatalf("ParseFCUID(%q) error = %q, want it to contain %q", tc.input, err.Error(), tc.wantErrFrag)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParseFCUID(%q) unexpected error: %v", tc.input, err)
+			}
+			if gotWWNN != tc.wantWWNN {
+				t.Errorf("ParseFCUID(%q) WWNN = %q, want %q", tc.input, gotWWNN, tc.wantWWNN)
+			}
+			if gotWWPN != tc.wantWWPN {
+				t.Errorf("ParseFCUID(%q) WWPN = %q, want %q", tc.input, gotWWPN, tc.wantWWPN)
+			}
+		})
+	}
+}
+
+// ── StripWWNFormatting ────────────────────────────────────────────────────────
+
+func TestStripWWNFormatting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "colon-separated Pure FlashArray format",
+			input: "21:00:00:90:fa:6e:67:a8",
+			want:  "21000090FA6E67A8",
+		},
+		{
+			name:  "contiguous hex ESXi format",
+			input: "21000090fa6e67a8",
+			want:  "21000090FA6E67A8",
+		},
+		{
+			name:  "dash-separated",
+			input: "21-00-00-90-fa-6e-67-a8",
+			want:  "21000090FA6E67A8",
+		},
+		{
+			name:  "space-separated",
+			input: "21 00 00 90 fa 6e 67 a8",
+			want:  "21000090FA6E67A8",
+		},
+		{
+			name:  "mixed separators",
+			input: "21:00-00 90:fa:6e:67:a8",
+			want:  "21000090FA6E67A8",
+		},
+		{
+			name:  "already uppercase and stripped",
+			input: "21000090FA6E67A8",
+			want:  "21000090FA6E67A8",
+		},
+		{
+			name:  "all-zeros",
+			input: "00:00:00:00:00:00:00:00",
+			want:  "0000000000000000",
+		},
+		{
+			name:  "uppercase colon-separated",
+			input: "21:00:00:90:FA:6E:67:A8",
+			want:  "21000090FA6E67A8",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "single byte",
+			input: "ff",
+			want:  "FF",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := fcutil.StripWWNFormatting(tc.input)
+			if got != tc.want {
+				t.Errorf("StripWWNFormatting(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// ── ColonSeparated ────────────────────────────────────────────────────────────
+
+func TestColonSeparated(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "standard 16-char wwn",
+			input: "2100000000000001",
+			want:  "21:00:00:00:00:00:00:01",
+		},
+		{
+			name:  "lowercase input is uppercased",
+			input: "21000090fa6e67a8",
+			want:  "21:00:00:90:FA:6E:67:A8",
+		},
+		{
+			name:  "all-zeros",
+			input: "0000000000000000",
+			want:  "00:00:00:00:00:00:00:00",
+		},
+		{
+			name:  "all-f",
+			input: "ffffffffffffffff",
+			want:  "FF:FF:FF:FF:FF:FF:FF:FF",
+		},
+		{
+			name:  "4-char wwn",
+			input: "aabb",
+			want:  "AA:BB",
+		},
+		{
+			name:  "2-char wwn",
+			input: "ab",
+			want:  "AB",
+		},
+		{
+			name:  "single character (less than 2)",
+			input: "a",
+			want:  "A",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "odd-length input (defensive handling)",
+			input: "abc",
+			want:  "AB:C",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := fcutil.ColonSeparated(tc.input)
+			if got != tc.want {
+				t.Errorf("ColonSeparated(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// ── WWPNFromFCUID ─────────────────────────────────────────────────────────────
+
+func TestWWPNFromFCUID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       string
+		want        string
+		wantErrFrag string
+	}{
+		{
+			name:  "returns wwpn portion uppercase",
+			input: "fc.2000000000000001:2100000000000001",
+			want:  "2100000000000001",
+		},
+		{
+			name:  "lowercase hex uppercased",
+			input: "fc.20000090fa6e67a8:21000090fa6e67a8",
+			want:  "21000090FA6E67A8",
+		},
+		{
+			name:  "all-zeros wwpn",
+			input: "fc.ffffffffffffffff:0000000000000000",
+			want:  "0000000000000000",
+		},
+		{
+			name:        "invalid uid returns error",
+			input:       "not-an-fc-uid",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+		{
+			name:        "odd wwpn length returns error",
+			input:       "fc.2000000000000001:210000000000001",
+			wantErrFrag: "odd hex length",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := fcutil.WWPNFromFCUID(tc.input)
+
+			if tc.wantErrFrag != "" {
+				if err == nil {
+					t.Fatalf("WWPNFromFCUID(%q) expected error, got nil (result=%q)", tc.input, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrFrag) {
+					t.Fatalf("WWPNFromFCUID(%q) error = %q, want substring %q", tc.input, err.Error(), tc.wantErrFrag)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("WWPNFromFCUID(%q) unexpected error: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("WWPNFromFCUID(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// ── FormattedWWPNFromFCUID ────────────────────────────────────────────────────
+
+func TestFormattedWWPNFromFCUID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       string
+		want        string
+		wantErrFrag string
+	}{
+		{
+			name:  "typical real-world fc uid",
+			input: "fc.20000090fa6e67a8:21000090fa6e67a8",
+			want:  "21:00:00:90:FA:6E:67:A8",
+		},
+		{
+			name:  "all-zeros wwpn",
+			input: "fc.2000000000000001:0000000000000000",
+			want:  "00:00:00:00:00:00:00:00",
+		},
+		{
+			name:  "all-f wwpn",
+			input: "fc.2000000000000001:ffffffffffffffff",
+			want:  "FF:FF:FF:FF:FF:FF:FF:FF",
+		},
+		{
+			name:        "invalid uid returns error",
+			input:       "iqn.1998-01.com.vmware:host-123",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+		{
+			name:        "empty string returns error",
+			input:       "",
+			wantErrFrag: "not a valid ESXi FC adapter UID",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := fcutil.FormattedWWPNFromFCUID(tc.input)
+
+			if tc.wantErrFrag != "" {
+				if err == nil {
+					t.Fatalf("FormattedWWPNFromFCUID(%q) expected error, got nil (result=%q)", tc.input, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrFrag) {
+					t.Fatalf("FormattedWWPNFromFCUID(%q) error = %q, want substring %q",
+						tc.input, err.Error(), tc.wantErrFrag)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("FormattedWWPNFromFCUID(%q) unexpected error: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("FormattedWWPNFromFCUID(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// ── EqualWWNs ─────────────────────────────────────────────────────────────────
+
+func TestEqualWWNs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		// ── should be equal ────────────────────────────────────────────────────
+		{
+			name: "colon-separated vs contiguous hex",
+			a:    "21:00:00:90:fa:6e:67:a8",
+			b:    "21000090fa6e67a8",
+			want: true,
+		},
+		{
+			name: "dash-separated vs colon-separated",
+			a:    "21-00-00-90-fa-6e-67-a8",
+			b:    "21:00:00:90:fa:6e:67:a8",
+			want: true,
+		},
+		{
+			name: "space-separated vs contiguous",
+			a:    "21 00 00 90 fa 6e 67 a8",
+			b:    "21000090fa6e67a8",
+			want: true,
+		},
+		{
+			name: "uppercase vs lowercase",
+			a:    "21000090FA6E67A8",
+			b:    "21000090fa6e67a8",
+			want: true,
+		},
+		{
+			name: "Pure array format vs ESXi contiguous",
+			a:    "20:00:00:90:FA:6E:67:A8",
+			b:    "20000090fa6e67a8",
+			want: true,
+		},
+		{
+			name: "identical stripped strings",
+			a:    "2100000000000001",
+			b:    "2100000000000001",
+			want: true,
+		},
+		{
+			name: "mixed separator formats",
+			a:    "21:00-00 90:fa:6e:67:a8",
+			b:    "21000090FA6E67A8",
+			want: true,
+		},
+		{
+			name: "all-zeros equal",
+			a:    "00:00:00:00:00:00:00:00",
+			b:    "0000000000000000",
+			want: true,
+		},
+		{
+			name: "both empty",
+			a:    "",
+			b:    "",
+			want: true,
+		},
+
+		// ── should not be equal ────────────────────────────────────────────────
+		{
+			name: "different wwns",
+			a:    "21000090fa6e67a8",
+			b:    "21000090fa6e67a9",
+			want: false,
+		},
+		{
+			name: "wwnn vs wwpn of same hba (different values)",
+			a:    "20000090fa6e67a8",
+			b:    "21000090fa6e67a8",
+			want: false,
+		},
+		{
+			name: "completely different wwns",
+			a:    "2100000000000001",
+			b:    "2100000000000002",
+			want: false,
+		},
+		{
+			name: "all-zeros vs all-ones",
+			a:    "00:00:00:00:00:00:00:00",
+			b:    "1111111111111111",
+			want: false,
+		},
+		{
+			name: "empty vs non-empty",
+			a:    "",
+			b:    "2100000000000001",
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := fcutil.EqualWWNs(tc.a, tc.b)
+			if got != tc.want {
+				t.Errorf("EqualWWNs(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+			// Commutativity: EqualWWNs(a, b) == EqualWWNs(b, a)
+			if rev := fcutil.EqualWWNs(tc.b, tc.a); rev != tc.want {
+				t.Errorf("EqualWWNs(%q, %q) [reversed] = %v, want %v", tc.b, tc.a, rev, tc.want)
+			}
+		})
+	}
+}
+
+// ── Integration: full fc.WWNN:WWPN → Pure array WWN comparison ───────────────
+// This is the real-world path: ESXi reports an adapter UID, Pure returns
+// a host WWN list.  We need them to match despite different formatting.
+
+func TestFCUIDToPureWWNComparison(t *testing.T) {
+	t.Parallel()
+
+	// Simulate: ESXi adapter "fc.20000090fa6e67a8:21000090fa6e67a8"
+	// Pure host record stores WWPN as "21:00:00:90:fa:6e:67:a8"
+	esxiUID := "fc.20000090fa6e67a8:21000090fa6e67a8"
+	pureHostWWN := "21:00:00:90:fa:6e:67:a8"
+
+	wwpn, err := fcutil.WWPNFromFCUID(esxiUID)
+	if err != nil {
+		t.Fatalf("WWPNFromFCUID(%q): %v", esxiUID, err)
+	}
+	if !fcutil.EqualWWNs(wwpn, pureHostWWN) {
+		t.Errorf("ESXi adapter WWPN %q does not match Pure host WWN %q (EqualWWNs returned false)", wwpn, pureHostWWN)
+	}
+
+	// Also verify the formatted form matches the pure format directly
+	formatted, err := fcutil.FormattedWWPNFromFCUID(esxiUID)
+	if err != nil {
+		t.Fatalf("FormattedWWPNFromFCUID(%q): %v", esxiUID, err)
+	}
+	if !fcutil.EqualWWNs(formatted, pureHostWWN) {
+		t.Errorf("formatted WWPN %q does not match Pure host WWN %q", formatted, pureHostWWN)
+	}
+}
+
+// TestParseFCUIDReturnsBothComponents verifies that ParseFCUID returns
+// both WWNN and WWPN correctly and that WWPNFromFCUID returns only the WWPN.
+func TestParseFCUIDReturnsBothComponents(t *testing.T) {
+	t.Parallel()
+
+	uid := "fc.20000090fa6e67a8:21000090fa6e67a8"
+	wantWWNN := "20000090FA6E67A8"
+	wantWWPN := "21000090FA6E67A8"
+
+	wwnn, wwpn, err := fcutil.ParseFCUID(uid)
+	if err != nil {
+		t.Fatalf("ParseFCUID(%q): %v", uid, err)
+	}
+	if wwnn != wantWWNN {
+		t.Errorf("WWNN = %q, want %q", wwnn, wantWWNN)
+	}
+	if wwpn != wantWWPN {
+		t.Errorf("WWPN = %q, want %q", wwpn, wantWWPN)
+	}
+
+	// WWPNFromFCUID must return the same WWPN
+	onlyWWPN, err := fcutil.WWPNFromFCUID(uid)
+	if err != nil {
+		t.Fatalf("WWPNFromFCUID(%q): %v", uid, err)
+	}
+	if onlyWWPN != wantWWPN {
+		t.Errorf("WWPNFromFCUID = %q, want %q", onlyWWPN, wantWWPN)
+	}
+}
+
+// TestColonSeparatedRoundTrip verifies that StripWWNFormatting(ColonSeparated(x)) == ToUpper(x)
+// for any even-length hex string — i.e. the two operations are inverse to each other.
+func TestColonSeparatedRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		"2100000000000001",
+		"21000090fa6e67a8",
+		"0000000000000000",
+		"ffffffffffffffff",
+		"aabbccddeeff0011",
+	}
+
+	for _, in := range inputs {
+		in := in
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			colonFmt := fcutil.ColonSeparated(in)
+			stripped := fcutil.StripWWNFormatting(colonFmt)
+			wantUpper := strings.ToUpper(in)
+			if stripped != wantUpper {
+				t.Errorf("round-trip of %q: ColonSeparated=%q, StripWWNFormatting=%q, want %q",
+					in, colonFmt, stripped, wantUpper)
+			}
+		})
+	}
+}

--- a/pkg/vpwned/sdk/storage/netapp/netapp.go
+++ b/pkg/vpwned/sdk/storage/netapp/netapp.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/platform9/vjailbreak/pkg/vpwned/sdk/storage"
+	"github.com/platform9/vjailbreak/pkg/vpwned/sdk/storage/fcutil"
 	"k8s.io/klog/v2"
 )
 
@@ -60,9 +61,13 @@ type OntapLUNResponse struct {
 }
 
 type OntapIgroup struct {
-	UUID       string `json:"uuid"`
-	Name       string `json:"name"`
-	Protocol   string `json:"protocol"`
+	UUID     string `json:"uuid"`
+	Name     string `json:"name"`
+	Protocol string `json:"protocol"`
+	SVM      struct {
+		Name string `json:"name"`
+		UUID string `json:"uuid"`
+	} `json:"svm"`
 	Initiators []struct {
 		Name string `json:"name"`
 	} `json:"initiators"`
@@ -253,39 +258,183 @@ func (n *NetAppStorageProvider) GetAllVolumeNAAs() ([]string, error) {
 	return n.BaseStorageProvider.GetAllVolumeNAAs(n.ListAllVolumes)
 }
 
-// CreateOrUpdateInitiatorGroup creates or updates an igroup with the ESX adapters
+// detectSANProtocol inspects hbaIdentifiers and returns the ONTAP igroup protocol
+// string: "fcp" when all adapters are Fibre Channel, "iscsi" when all are iSCSI,
+// or "mixed" when both types are present.
+func detectSANProtocol(hbaIdentifiers []string) string {
+	hasFC, hasIQN := false, false
+	for _, id := range hbaIdentifiers {
+		lower := strings.ToLower(id)
+		switch {
+		case strings.HasPrefix(lower, "fc."):
+			hasFC = true
+		case strings.HasPrefix(lower, "iqn."), strings.HasPrefix(lower, "eui."), strings.HasPrefix(lower, "nqn."):
+			hasIQN = true
+		}
+	}
+	switch {
+	case hasFC && !hasIQN:
+		return "fcp"
+	case hasIQN && !hasFC:
+		return "iscsi"
+	default:
+		return "mixed"
+	}
+}
+
+// normaliseToONTAPInitiators converts HBA identifiers to the format ONTAP expects.
+// FC adapter UIDs (fc.WWNN:WWPN) are converted to colon-separated WWPN strings;
+// IQN / EUI / NQN values are kept as-is.
+func normaliseToONTAPInitiators(hbaIdentifiers []string) ([]string, error) {
+	out := make([]string, 0, len(hbaIdentifiers))
+	for _, id := range hbaIdentifiers {
+		if strings.HasPrefix(strings.ToLower(id), "fc.") {
+			wwpn, err := fcutil.FormattedWWPNFromFCUID(id)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse FC adapter UID %q: %w", id, err)
+			}
+			out = append(out, wwpn)
+		} else {
+			out = append(out, id)
+		}
+	}
+	return out, nil
+}
+
+// ensureIgroupExists returns the UUID of the named igroup on svmName, creating it
+// (with the given protocol and os_type "vmware") if it does not already exist.
+func (n *NetAppStorageProvider) ensureIgroupExists(ctx context.Context, name, protocol, svmName string) (string, error) {
+	igroups, err := n.listIgroups(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to list igroups: %w", err)
+	}
+	for _, ig := range igroups {
+		if ig.Name == name {
+			klog.Infof("Igroup %q already exists (UUID: %s)", name, ig.UUID)
+			return ig.UUID, nil
+		}
+	}
+
+	klog.Infof("Creating igroup %q (protocol: %s, SVM: %s)", name, protocol, svmName)
+	reqBody := map[string]interface{}{
+		"name":     name,
+		"protocol": protocol,
+		"os_type":  "vmware",
+		"svm": map[string]interface{}{
+			"name": svmName,
+		},
+	}
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal igroup create request: %w", err)
+	}
+
+	var response OntapIgroupResponse
+	err = n.DoRequestJSON(ctx, "POST", "/protocols/san/igroups?return_records=true", bytes.NewReader(jsonBody), &response)
+	if err != nil {
+		return "", fmt.Errorf("failed to create igroup %q: %w", name, err)
+	}
+	if len(response.Records) == 0 {
+		return "", fmt.Errorf("igroup creation returned no records for %q", name)
+	}
+	klog.Infof("Created igroup %q with UUID %s", name, response.Records[0].UUID)
+	return response.Records[0].UUID, nil
+}
+
+// addInitiatorToIgroup adds a single initiator (IQN or colon-separated WWPN) to
+// the igroup identified by igroupUUID. Duplicate-initiator errors are silently
+// ignored since the desired state is already satisfied.
+func (n *NetAppStorageProvider) addInitiatorToIgroup(ctx context.Context, igroupUUID, initiatorName string) error {
+	reqBody := map[string]interface{}{"name": initiatorName}
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+	endpoint := fmt.Sprintf("/protocols/san/igroups/%s/initiators", igroupUUID)
+	err = n.DoRequestJSON(ctx, "POST", endpoint, bytes.NewReader(jsonBody), nil)
+	if err != nil {
+		if strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate") {
+			klog.Infof("Initiator %q already in igroup %s — skipping", initiatorName, igroupUUID)
+			return nil
+		}
+		return fmt.Errorf("failed to add initiator %q to igroup %s: %w", initiatorName, igroupUUID, err)
+	}
+	klog.Infof("Added initiator %q to igroup %s", initiatorName, igroupUUID)
+	return nil
+}
+
+// CreateOrUpdateInitiatorGroup creates or updates an igroup with the ESX adapters.
+// It supports both iSCSI (IQN) and Fibre Channel (fc.WWNN:WWPN) adapter identifiers.
+//
+// The function first searches all existing igroups for one that already contains a
+// matching initiator. If none is found it creates a protocol-specific vjailbreak
+// igroup (name: "<initiatorGroupName>-fcp" or "<initiatorGroupName>-iscsi") and
+// populates it with the normalised initiator list.
 func (n *NetAppStorageProvider) CreateOrUpdateInitiatorGroup(initiatorGroupName string, hbaIdentifiers []string) (storage.MappingContext, error) {
 	ctx := context.Background()
 
-	// List existing igroups and find matches
+	// Normalise FC UIDs → colon-separated WWPN; IQNs are kept unchanged.
+	ontapInitiators, err := normaliseToONTAPInitiators(hbaIdentifiers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to normalise HBA identifiers: %w", err)
+	}
+
+	protocol := detectSANProtocol(hbaIdentifiers)
+	klog.Infof("Detected SAN protocol: %s, normalised initiators: %v", protocol, ontapInitiators)
+
+	// Search existing igroups for a matching initiator.
 	igroups, err := n.listIgroups(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list igroups: %w", err)
 	}
 
 	matchedIgroups := []string{}
-
 	for _, ig := range igroups {
 		initiatorNames := make([]string, len(ig.Initiators))
 		for i, init := range ig.Initiators {
 			initiatorNames[i] = init.Name
 		}
-		klog.Infof("Checking igroup %s, initiators: %v", ig.Name, initiatorNames)
+		klog.Infof("Checking igroup %s (protocol: %s), initiators: %v", ig.Name, ig.Protocol, initiatorNames)
 
 		for _, init := range ig.Initiators {
-			if storage.ContainsIgnoreCase(hbaIdentifiers, init.Name) {
-				klog.Infof("Adding igroup %s (matched initiator: %s)", ig.Name, init.Name)
+			if storage.ContainsIgnoreCase(ontapInitiators, init.Name) {
+				klog.Infof("Matched igroup %s via initiator %s", ig.Name, init.Name)
 				matchedIgroups = append(matchedIgroups, ig.Name)
 				break
 			}
 		}
 	}
 
-	if len(matchedIgroups) == 0 {
-		return nil, fmt.Errorf("no igroups found matching any of the provided IQNs/WWNs: %v", hbaIdentifiers)
+	if len(matchedIgroups) > 0 {
+		return storage.MappingContext{"igroups": matchedIgroups}, nil
 	}
 
-	return storage.MappingContext{"igroups": matchedIgroups}, nil
+	// No existing igroup matched — create a vjailbreak-managed one.
+	if protocol == "mixed" {
+		return nil, fmt.Errorf(
+			"host has both FC and iSCSI adapters; cannot create a single ONTAP igroup — "+
+				"ensure the ESXi host uses a single transport type: %v", hbaIdentifiers)
+	}
+
+	_, svmName, err := n.getDefaultVolumePathAndSVM(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover SVM for igroup creation: %w", err)
+	}
+
+	igroupName := fmt.Sprintf("%s-%s", initiatorGroupName, protocol)
+	igroupUUID, err := n.ensureIgroupExists(ctx, igroupName, protocol, svmName)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, initiator := range ontapInitiators {
+		klog.Infof("Adding initiator %q to igroup %s", initiator, igroupName)
+		if err := n.addInitiatorToIgroup(ctx, igroupUUID, initiator); err != nil {
+			return nil, err
+		}
+	}
+
+	return storage.MappingContext{"igroups": []string{igroupName}}, nil
 }
 
 // MapVolumeToGroup maps a LUN to igroups
@@ -534,7 +683,7 @@ func (n *NetAppStorageProvider) listLUNs(ctx context.Context, filter string) ([]
 
 func (n *NetAppStorageProvider) listIgroups(ctx context.Context) ([]OntapIgroup, error) {
 	var response OntapIgroupResponse
-	err := n.DoRequestJSON(ctx, "GET", "/protocols/san/igroups?fields=uuid,name,initiators", nil, &response)
+	err := n.DoRequestJSON(ctx, "GET", "/protocols/san/igroups?fields=uuid,name,protocol,svm,initiators", nil, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vpwned/sdk/storage/pure/pure.go
+++ b/pkg/vpwned/sdk/storage/pure/pure.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/devans10/pugo/flasharray"
 	"github.com/platform9/vjailbreak/pkg/vpwned/sdk/storage"
+	"github.com/platform9/vjailbreak/pkg/vpwned/sdk/storage/fcutil"
 	"k8s.io/klog/v2"
 )
 
@@ -155,8 +156,9 @@ func (p *PureStorageProvider) GetAllVolumeNAAs() ([]string, error) {
 	return p.BaseStorageProvider.GetAllVolumeNAAs(p.ListAllVolumes)
 }
 
-// CreateOrUpdateInitiatorGroup creates or updates an initiator group with the ESX adapters
-// mapping esxi's hba adapters initiator group to the volume host in pure.
+// CreateOrUpdateInitiatorGroup creates or updates an initiator group with the ESX adapters,
+// mapping the ESXi host's HBA adapters to the corresponding Pure FlashArray host object.
+// Supports both iSCSI (IQN) and Fibre Channel (fc.WWNN:WWPN) adapter identifiers.
 func (p *PureStorageProvider) CreateOrUpdateInitiatorGroup(initiatorGroupName string, hbaIdentifiers []string) (storage.MappingContext, error) {
 	hosts, err := p.client.Hosts.ListHosts(nil)
 	if err != nil {
@@ -167,12 +169,43 @@ func (p *PureStorageProvider) CreateOrUpdateInitiatorGroup(initiatorGroupName st
 
 	for _, h := range hosts {
 		klog.Infof("Checking host %s, iqns: %v, wwns: %v", h.Name, h.Iqn, h.Wwn)
+		matched := false
 
-		// Check IQNs (case-insensitive since IQNs can be presented with different casing)
+		// Check IQNs (iSCSI) — case-insensitive
 		for _, iqn := range h.Iqn {
 			if storage.ContainsIgnoreCase(hbaIdentifiers, iqn) {
 				klog.Infof("Adding host %s to group (matched IQN: %s)", h.Name, iqn)
 				matchedHosts = append(matchedHosts, h.Name)
+				matched = true
+				break
+			}
+		}
+		if matched {
+			continue
+		}
+
+		// Check WWNs (Fibre Channel) — extract WWPN from the ESXi fc.WWNN:WWPN identifier
+		// and compare against the Pure host's registered WWN list. fcutil.EqualWWNs
+		// normalises both sides (strips colons/dashes, uppercases) before comparing.
+		for _, hostWWN := range h.Wwn {
+			for _, hbaID := range hbaIdentifiers {
+				if !strings.HasPrefix(hbaID, "fc.") {
+					continue
+				}
+				wwpn, err := fcutil.WWPNFromFCUID(hbaID)
+				if err != nil {
+					klog.Warningf("Failed to parse FC adapter UID %s: %v", hbaID, err)
+					continue
+				}
+				klog.Infof("Comparing ESXi WWPN %s with Pure host WWN %s", wwpn, hostWWN)
+				if fcutil.EqualWWNs(wwpn, hostWWN) {
+					klog.Infof("Adding host %s to group (matched FC WWN: %s)", h.Name, hostWWN)
+					matchedHosts = append(matchedHosts, h.Name)
+					matched = true
+					break
+				}
+			}
+			if matched {
 				break
 			}
 		}

--- a/v2v-helper/esxi-ssh/disk_ops.go
+++ b/v2v-helper/esxi-ssh/disk_ops.go
@@ -697,3 +697,155 @@ func (c *Client) GetHostIQN() (string, error) {
 
 	return "", fmt.Errorf("no iSCSI IQN found on ESXi host")
 }
+
+// GetHostFCAdapters returns the Fibre Channel adapter UIDs of the ESXi host.
+// FC UIDs are returned in ESXi format: "fc.WWNN:WWPN" (lowercase hex, no separators).
+func (c *Client) GetHostFCAdapters() ([]string, error) {
+	if c.sshClient == nil {
+		return nil, fmt.Errorf("not connected to ESXi host")
+	}
+
+	results, err := c.RunEsxcliCommand("storage", []string{"core", "adapter", "list"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get storage adapter list: %w", err)
+	}
+
+	var fcAdapters []string
+	for _, adapter := range results {
+		uid, hasUID := adapter["UID"]
+		linkState, hasLink := adapter["LinkState"]
+		driver := adapter["Driver"]
+
+		if !hasUID || !hasLink {
+			continue
+		}
+
+		uid = strings.ToLower(strings.TrimSpace(uid))
+		isActive := linkState == "link-up" || linkState == "online"
+		if isActive && strings.HasPrefix(uid, "fc.") {
+			klog.Infof("Found ESXi FC adapter: Driver=%s, UID=%s", driver, uid)
+			fcAdapters = append(fcAdapters, uid)
+		}
+	}
+
+	if len(fcAdapters) == 0 {
+		return nil, fmt.Errorf("no FC adapters found on ESXi host")
+	}
+	return fcAdapters, nil
+}
+
+// GetTransportType returns the dominant storage transport type on the ESXi host.
+// Returns "fc" if FC adapters are present, "iscsi" for iSCSI only, "mixed" for both,
+// or "unknown" if neither is detected.
+func (c *Client) GetTransportType() (string, error) {
+	if c.sshClient == nil {
+		return "", fmt.Errorf("not connected to ESXi host")
+	}
+
+	results, err := c.RunEsxcliCommand("storage", []string{"core", "adapter", "list"})
+	if err != nil {
+		return "", fmt.Errorf("failed to get storage adapter list: %w", err)
+	}
+
+	hasISCSI := false
+	hasFC := false
+
+	for _, adapter := range results {
+		uid, hasUID := adapter["UID"]
+		linkState, hasLink := adapter["LinkState"]
+		if !hasUID || !hasLink {
+			continue
+		}
+		uid = strings.ToLower(strings.TrimSpace(uid))
+		isActive := linkState == "link-up" || linkState == "online"
+		if isActive && strings.HasPrefix(uid, "iqn.") {
+			hasISCSI = true
+		} else if isActive && strings.HasPrefix(uid, "fc.") {
+			hasFC = true
+		}
+	}
+
+	switch {
+	case hasFC && hasISCSI:
+		return "mixed", nil
+	case hasFC:
+		return "fc", nil
+	case hasISCSI:
+		return "iscsi", nil
+	default:
+		return "unknown", nil
+	}
+}
+
+// GetAllHostAdapters returns all active storage HBA identifiers on the ESXi host.
+// Includes iSCSI IQNs (format: "iqn.xxx") and FC UIDs (format: "fc.WWNN:WWPN").
+// Use this instead of GetHostIQN when the host may use FC or mixed transport.
+func (c *Client) GetAllHostAdapters() ([]string, error) {
+	if c.sshClient == nil {
+		return nil, fmt.Errorf("not connected to ESXi host")
+	}
+
+	results, err := c.RunEsxcliCommand("storage", []string{"core", "adapter", "list"})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get storage adapter list: %w", err)
+	}
+
+	var adapters []string
+	for _, adapter := range results {
+		uid, hasUID := adapter["UID"]
+		linkState, hasLink := adapter["LinkState"]
+		driver := adapter["Driver"]
+		if !hasUID || !hasLink {
+			continue
+		}
+		uid = strings.ToLower(strings.TrimSpace(uid))
+		isActive := linkState == "link-up" || linkState == "online"
+		if isActive && (strings.HasPrefix(uid, "iqn.") || strings.HasPrefix(uid, "fc.")) {
+			klog.Infof("Found ESXi adapter: Driver=%s, UID=%s", driver, uid)
+			adapters = append(adapters, uid)
+		}
+	}
+
+	if len(adapters) == 0 {
+		return nil, fmt.Errorf("no iSCSI or FC adapters found on ESXi host")
+	}
+	return adapters, nil
+}
+
+// GetDatastoreBackingNAA returns the NAA identifier of the physical device backing
+// a VMFS datastore. Used to identify the source volume on the storage array for
+// FC server-side copy operations.
+func (c *Client) GetDatastoreBackingNAA(datastoreName string) (string, error) {
+	if c.sshClient == nil {
+		return "", fmt.Errorf("not connected to ESXi host")
+	}
+
+	output, err := c.ExecuteCommand("esxcli storage vmfs extent list")
+	if err != nil {
+		return "", fmt.Errorf("failed to list VMFS extents: %w", err)
+	}
+
+	// Output format:
+	// Volume Name   VMFS UUID                              Extent Number  Device Name           Partition
+	// -----------   -------------------------------------  -------------  --------------------  ---------
+	// datastore1    5f16f71f-xxxx-xxxx-xxxx-xxxxxxxxxxxx  0              naa.624a9370...       1
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		// Skip header and separator lines
+		if trimmed == "" || strings.HasPrefix(trimmed, "Volume") || strings.HasPrefix(trimmed, "-") {
+			continue
+		}
+		fields := strings.Fields(line)
+		// Expect: [volume_name, uuid, extent_number, device_name, partition]
+		if len(fields) >= 4 && fields[0] == datastoreName {
+			deviceName := fields[3]
+			if strings.HasPrefix(deviceName, "naa.") {
+				klog.Infof("Found backing device %s for datastore %s", deviceName, datastoreName)
+				return deviceName, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no VMFS backing device found for datastore %s", datastoreName)
+}

--- a/v2v-helper/esxi-ssh/disk_ops.go
+++ b/v2v-helper/esxi-ssh/disk_ops.go
@@ -734,49 +734,6 @@ func (c *Client) GetHostFCAdapters() ([]string, error) {
 	return fcAdapters, nil
 }
 
-// GetTransportType returns the dominant storage transport type on the ESXi host.
-// Returns "fc" if FC adapters are present, "iscsi" for iSCSI only, "mixed" for both,
-// or "unknown" if neither is detected.
-func (c *Client) GetTransportType() (string, error) {
-	if c.sshClient == nil {
-		return "", fmt.Errorf("not connected to ESXi host")
-	}
-
-	results, err := c.RunEsxcliCommand("storage", []string{"core", "adapter", "list"})
-	if err != nil {
-		return "", fmt.Errorf("failed to get storage adapter list: %w", err)
-	}
-
-	hasISCSI := false
-	hasFC := false
-
-	for _, adapter := range results {
-		uid, hasUID := adapter["UID"]
-		linkState, hasLink := adapter["LinkState"]
-		if !hasUID || !hasLink {
-			continue
-		}
-		uid = strings.ToLower(strings.TrimSpace(uid))
-		isActive := linkState == "link-up" || linkState == "online"
-		if isActive && strings.HasPrefix(uid, "iqn.") {
-			hasISCSI = true
-		} else if isActive && strings.HasPrefix(uid, "fc.") {
-			hasFC = true
-		}
-	}
-
-	switch {
-	case hasFC && hasISCSI:
-		return "mixed", nil
-	case hasFC:
-		return "fc", nil
-	case hasISCSI:
-		return "iscsi", nil
-	default:
-		return "unknown", nil
-	}
-}
-
 // GetAllHostAdapters returns all active storage HBA identifiers on the ESXi host.
 // Includes iSCSI IQNs (format: "iqn.xxx") and FC UIDs (format: "fc.WWNN:WWPN").
 // Use this instead of GetHostIQN when the host may use FC or mixed transport.
@@ -810,42 +767,4 @@ func (c *Client) GetAllHostAdapters() ([]string, error) {
 		return nil, fmt.Errorf("no iSCSI or FC adapters found on ESXi host")
 	}
 	return adapters, nil
-}
-
-// GetDatastoreBackingNAA returns the NAA identifier of the physical device backing
-// a VMFS datastore. Used to identify the source volume on the storage array for
-// FC server-side copy operations.
-func (c *Client) GetDatastoreBackingNAA(datastoreName string) (string, error) {
-	if c.sshClient == nil {
-		return "", fmt.Errorf("not connected to ESXi host")
-	}
-
-	output, err := c.ExecuteCommand("esxcli storage vmfs extent list")
-	if err != nil {
-		return "", fmt.Errorf("failed to list VMFS extents: %w", err)
-	}
-
-	// Output format:
-	// Volume Name   VMFS UUID                              Extent Number  Device Name           Partition
-	// -----------   -------------------------------------  -------------  --------------------  ---------
-	// datastore1    5f16f71f-xxxx-xxxx-xxxx-xxxxxxxxxxxx  0              naa.624a9370...       1
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		// Skip header and separator lines
-		if trimmed == "" || strings.HasPrefix(trimmed, "Volume") || strings.HasPrefix(trimmed, "-") {
-			continue
-		}
-		fields := strings.Fields(line)
-		// Expect: [volume_name, uuid, extent_number, device_name, partition]
-		if len(fields) >= 4 && fields[0] == datastoreName {
-			deviceName := fields[3]
-			if strings.HasPrefix(deviceName, "naa.") {
-				klog.Infof("Found backing device %s for datastore %s", deviceName, datastoreName)
-				return deviceName, nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("no VMFS backing device found for datastore %s", datastoreName)
 }

--- a/v2v-helper/migrate/vaai_copy.go
+++ b/v2v-helper/migrate/vaai_copy.go
@@ -123,36 +123,16 @@ func (migobj *Migrate) StorageAcceleratedCopyCopyDisks(ctx context.Context, vmin
 	}
 	migobj.logMessage(fmt.Sprintf("Detected storage transport type: %s", transportType))
 
-	// Check whether the storage provider supports server-side FC copy
-	_, isFCCapable := migobj.StorageProvider.(storage.FCCopyCapable)
-	useFCPath := (transportType == "fc" || transportType == "mixed") && isFCCapable
-
 	volumes := []storage.Volume{}
 
 	// Process each disk
 	for idx, vmdisk := range vminfo.VMDisks {
 		migobj.logMessage(fmt.Sprintf("Processing disk %d/%d: %s", idx+1, len(vminfo.VMDisks), vmdisk.Name))
 
-		var clonedVolume storage.Volume
-
-		if useFCPath {
-			// Attempt the FC server-side copy path (Pure FlashArray CopyVolume API).
-			// Falls back to the vmkfstools path if the source volume cannot be identified.
-			migobj.logMessage(fmt.Sprintf("Attempting FC server-side copy for disk %s", vmdisk.Name))
-			clonedVolume, err = migobj.copyDiskViaFCStorageAcceleratedCopy(ctx, esxiClient, idx, &vminfo, hostIP)
-			if err != nil {
-				migobj.logMessage(fmt.Sprintf("FC server-side copy failed (%v); falling back to vmkfstools path", err))
-				clonedVolume, err = migobj.copyDiskViaStorageAcceleratedCopy(ctx, esxiClient, idx, &vminfo, hostIP)
-				if err != nil {
-					return []storage.Volume{}, errors.Wrapf(err, "failed to copy disk %s via StorageAcceleratedCopy (fallback)", vmdisk.Name)
-				}
-			}
-		} else {
-			// iSCSI path (or FC without FCCopyCapable): use vmkfstools RDM clone
-			clonedVolume, err = migobj.copyDiskViaStorageAcceleratedCopy(ctx, esxiClient, idx, &vminfo, hostIP)
-			if err != nil {
-				return []storage.Volume{}, errors.Wrapf(err, "failed to copy disk %s via StorageAcceleratedCopy", vmdisk.Name)
-			}
+		// use vmkfstools RDM clone
+		clonedVolume, err := migobj.copyDiskViaStorageAcceleratedCopy(ctx, esxiClient, idx, &vminfo, hostIP)
+		if err != nil {
+			return []storage.Volume{}, errors.Wrapf(err, "failed to copy disk %s via StorageAcceleratedCopy", vmdisk.Name)
 		}
 
 		// Update the disk with the OpenStack volume info from the cloned volume
@@ -332,121 +312,6 @@ func extractSerialFromPureNAA(naa string) (string, error) {
 		return "", fmt.Errorf("could not extract serial number from NAA %q", naa)
 	}
 	return strings.ToUpper(serial), nil
-}
-
-// copyDiskViaFCStorageAcceleratedCopy copies a single VM disk using the Pure FlashArray
-// server-side CopyVolume API over Fibre Channel transport. This avoids routing data
-// through the ESXi host: the storage array copies the source LUN directly into the
-// newly provisioned target LUN.
-//
-// Prerequisites:
-//   - The VM disk must reside on a VMFS datastore that is backed by a single Pure LUN
-//     (i.e. dedicated datastore, not shared among multiple VMs). If the datastore is
-//     shared the copy would overwrite the whole datastore into the smaller target volume
-//     and will be rejected via a size mismatch check.
-//   - The storage provider must implement storage.FCCopyCapable.
-func (migobj *Migrate) copyDiskViaFCStorageAcceleratedCopy(ctx context.Context, esxiClient *esxissh.Client,
-	idx int, vminfo *vm.VMInfo, hostIP string,
-) (storage.Volume, error) {
-	startTime := time.Now()
-	vmDisk := vminfo.VMDisks[idx]
-
-	defer func() {
-		migobj.logMessage(fmt.Sprintf("FC StorageAcceleratedCopy completed in %s for disk %s",
-			time.Since(startTime).Round(time.Second), vmDisk.Name))
-		migobj.StorageProvider.Disconnect()
-	}()
-
-	// Re-initialize the storage provider for this disk (matches iSCSI path behaviour)
-	migobj.InitializeStorageProvider(ctx)
-
-	fcCapable, ok := migobj.StorageProvider.(storage.FCCopyCapable)
-	if !ok {
-		return storage.Volume{}, fmt.Errorf("storage provider %s does not implement FCCopyCapable", migobj.StorageProvider.WhoAmI())
-	}
-
-	// Step 1: Find the Pure volume that backs the source VMFS datastore
-	migobj.logMessage(fmt.Sprintf("Locating source volume on storage array for datastore %q", vmDisk.Datastore))
-	sourceNAA, err := esxiClient.GetDatastoreBackingNAA(vmDisk.Datastore)
-	if err != nil {
-		return storage.Volume{}, errors.Wrapf(err, "failed to locate datastore backing device for %q", vmDisk.Datastore)
-	}
-	migobj.logMessage(fmt.Sprintf("Source datastore %q is backed by device: %s", vmDisk.Datastore, sourceNAA))
-
-	serial, err := extractSerialFromPureNAA(sourceNAA)
-	if err != nil {
-		return storage.Volume{}, errors.Wrapf(err, "failed to extract serial from source NAA %s", sourceNAA)
-	}
-
-	sourceVolume, err := fcCapable.FindVolumeBySerial(serial)
-	if err != nil {
-		return storage.Volume{}, errors.Wrapf(err, "failed to find source volume by serial %s", serial)
-	}
-	migobj.logMessage(fmt.Sprintf("Found source Pure volume: %s (size: %d bytes)", sourceVolume.Name, sourceVolume.Size))
-
-	// Step 2: Validate that the source LUN is not significantly larger than the VM disk.
-	// A large discrepancy suggests a shared datastore (multiple VMs) which cannot be
-	// handled with a block-level copy.
-	diskSizeBytes := vmDisk.Size
-	if diskSizeBytes%512 != 0 {
-		diskSizeBytes = ((diskSizeBytes / 512) + 1) * 512
-	}
-	if sourceVolume.Size > diskSizeBytes*2 {
-		return storage.Volume{}, fmt.Errorf(
-			"source volume %s (%d bytes) is more than twice the VM disk size (%d bytes); "+
-				"datastore is likely shared among multiple VMs — cannot use FC server-side copy",
-			sourceVolume.Name, sourceVolume.Size, diskSizeBytes)
-	}
-
-	// Step 3: Create a target volume on the storage array
-	sanitizedName := sanitizeVolumeName(vminfo.Name + "-" + vmDisk.Name)
-	migobj.logMessage(fmt.Sprintf("Creating target volume %q with size %d bytes", sanitizedName, sourceVolume.Size))
-	// Use source volume size to ensure the copy succeeds
-	targetVolume, err := migobj.StorageProvider.CreateVolume(sanitizedName, sourceVolume.Size)
-	if err != nil {
-		return storage.Volume{}, errors.Wrapf(err, "failed to create target volume %q", sanitizedName)
-	}
-
-	// Step 4: Import the target volume into Cinder (renames it on Pure to volume-<id>-cinder)
-	migobj.logMessage(fmt.Sprintf("Importing target volume %q into Cinder", targetVolume.Name))
-	cinderVolumeID, err := migobj.manageVolumeToCinder(ctx, targetVolume.Name, vmDisk)
-	if err != nil {
-		return storage.Volume{}, errors.Wrapf(err, "failed to import volume %q into Cinder", targetVolume.Name)
-	}
-	vminfo.VMDisks[idx].OpenstackVol = &cindervolumes.Volume{
-		ID:   cinderVolumeID,
-		Name: targetVolume.Name,
-		Size: int(sourceVolume.Size / (1024 * 1024 * 1024)),
-	}
-
-	// Resolve the Cinder-renamed volume name on the array (e.g. volume-<uuid>-cinder)
-	resolvedTarget, err := migobj.StorageProvider.ResolveCinderVolumeToLUN(cinderVolumeID)
-	if err != nil {
-		return storage.Volume{}, errors.Wrapf(err, "failed to resolve Cinder volume %s on storage array", cinderVolumeID)
-	}
-	cinderVolumeName := resolvedTarget.Name
-	migobj.logMessage(fmt.Sprintf("Cinder renamed target volume to: %s", cinderVolumeName))
-
-	// Step 5: Execute the server-side copy on the Pure FlashArray
-	// This copies the source datastore LUN content into the target LUN without any
-	// ESXi data path involvement.
-	migobj.logMessage(fmt.Sprintf("Starting Pure FlashArray server-side copy: %s -> %s",
-		sourceVolume.Name, cinderVolumeName))
-	copyStart := time.Now()
-
-	if err := fcCapable.CopyVolumeOnArray(sourceVolume.Name, cinderVolumeName); err != nil {
-		return storage.Volume{}, errors.Wrapf(err, "Pure FlashArray server-side copy failed: %s -> %s",
-			sourceVolume.Name, cinderVolumeName)
-	}
-
-	migobj.logMessage(fmt.Sprintf("Pure FlashArray server-side copy completed in %s",
-		time.Since(copyStart).Round(time.Second)))
-
-	targetVolume.OpenstackVol = storage.OpenstackVolume{ID: cinderVolumeID}
-	targetVolume.Name = cinderVolumeName
-	targetVolume.NAA = resolvedTarget.NAA
-
-	return targetVolume, nil
 }
 
 // ValidateStorageAcceleratedCopyPrerequisites validates that all prerequisites for StorageAcceleratedCopy copy are met

--- a/v2v-helper/migrate/vaai_copy.go
+++ b/v2v-helper/migrate/vaai_copy.go
@@ -21,6 +21,10 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 )
 
+// pureFCNAAPrefix is the Pure FlashArray NAA vendor prefix used to identify
+// Pure volumes from their NAA identifiers.
+const pureFCNAAPrefix = "naa.624a9370"
+
 // sanitizeVolumeName converts a volume name to meet storage array naming requirements:
 // - 1-63 characters long
 // - Alphanumeric, '_', and '-' only
@@ -111,16 +115,44 @@ func (migobj *Migrate) StorageAcceleratedCopyCopyDisks(ctx context.Context, vmin
 	migobj.logMessage("Waiting 5 seconds for ESXi to release disk file locks...")
 	time.Sleep(5 * time.Second)
 
+	// Detect storage transport type to decide which copy path to use
+	transportType, err := esxiClient.GetTransportType()
+	if err != nil {
+		migobj.logMessage(fmt.Sprintf("Warning: could not detect transport type (%v); defaulting to iSCSI path", err))
+		transportType = "iscsi"
+	}
+	migobj.logMessage(fmt.Sprintf("Detected storage transport type: %s", transportType))
+
+	// Check whether the storage provider supports server-side FC copy
+	_, isFCCapable := migobj.StorageProvider.(storage.FCCopyCapable)
+	useFCPath := (transportType == "fc" || transportType == "mixed") && isFCCapable
+
 	volumes := []storage.Volume{}
 
 	// Process each disk
 	for idx, vmdisk := range vminfo.VMDisks {
 		migobj.logMessage(fmt.Sprintf("Processing disk %d/%d: %s", idx+1, len(vminfo.VMDisks), vmdisk.Name))
 
-		// Perform StorageAcceleratedCopy copy for this disk
-		clonedVolume, err := migobj.copyDiskViaStorageAcceleratedCopy(ctx, esxiClient, idx, &vminfo, hostIP)
-		if err != nil {
-			return []storage.Volume{}, errors.Wrapf(err, "failed to copy disk %s via StorageAcceleratedCopy", vmdisk.Name)
+		var clonedVolume storage.Volume
+
+		if useFCPath {
+			// Attempt the FC server-side copy path (Pure FlashArray CopyVolume API).
+			// Falls back to the vmkfstools path if the source volume cannot be identified.
+			migobj.logMessage(fmt.Sprintf("Attempting FC server-side copy for disk %s", vmdisk.Name))
+			clonedVolume, err = migobj.copyDiskViaFCStorageAcceleratedCopy(ctx, esxiClient, idx, &vminfo, hostIP)
+			if err != nil {
+				migobj.logMessage(fmt.Sprintf("FC server-side copy failed (%v); falling back to vmkfstools path", err))
+				clonedVolume, err = migobj.copyDiskViaStorageAcceleratedCopy(ctx, esxiClient, idx, &vminfo, hostIP)
+				if err != nil {
+					return []storage.Volume{}, errors.Wrapf(err, "failed to copy disk %s via StorageAcceleratedCopy (fallback)", vmdisk.Name)
+				}
+			}
+		} else {
+			// iSCSI path (or FC without FCCopyCapable): use vmkfstools RDM clone
+			clonedVolume, err = migobj.copyDiskViaStorageAcceleratedCopy(ctx, esxiClient, idx, &vminfo, hostIP)
+			if err != nil {
+				return []storage.Volume{}, errors.Wrapf(err, "failed to copy disk %s via StorageAcceleratedCopy", vmdisk.Name)
+			}
 		}
 
 		// Update the disk with the OpenStack volume info from the cloned volume
@@ -139,10 +171,10 @@ func (migobj *Migrate) StorageAcceleratedCopyCopyDisks(ctx context.Context, vmin
 		vminfo.VMDisks[idx].Path = devicePath
 		volumes = append(volumes, clonedVolume)
 
-		migobj.logMessage(fmt.Sprintf("Successfully copied disk %s via StorageAcceleratedCopy XCOPY", vmdisk.Name))
+		migobj.logMessage(fmt.Sprintf("Successfully copied disk %s via StorageAcceleratedCopy", vmdisk.Name))
 	}
 
-	migobj.logMessage("StorageAcceleratedCopy XCOPY-based disk copy completed successfully")
+	migobj.logMessage("StorageAcceleratedCopy disk copy completed successfully")
 	return volumes, nil
 }
 
@@ -162,17 +194,17 @@ func (migobj *Migrate) copyDiskViaStorageAcceleratedCopy(ctx context.Context, es
 	// Step 1: Initialize storage provider
 	migobj.InitializeStorageProvider(ctx)
 
-	// Step 2: Get ESXi host IQN for volume mapping
-	hostIQN, err := esxiClient.GetHostIQN()
+	// Step 2: Get all ESXi host HBA adapters (IQN for iSCSI, fc.WWNN:WWPN for FC)
+	hostAdapters, err := esxiClient.GetAllHostAdapters()
 	if err != nil {
-		return storage.Volume{}, errors.Wrap(err, "failed to get ESXi host IQN")
+		return storage.Volume{}, errors.Wrap(err, "failed to get ESXi host adapters")
 	}
-	migobj.logMessage(fmt.Sprintf("ESXi host IQN: %s", hostIQN))
+	migobj.logMessage(fmt.Sprintf("ESXi host adapters: %v", hostAdapters))
 
-	// Step 3: Map host IQN to initiator group
+	// Step 3: Map host adapters to initiator group on the storage array
 	initiatorGroup := fmt.Sprintf("vjailbreak-xcopy")
 	migobj.logMessage(fmt.Sprintf("Creating/updating initiator group: %s", initiatorGroup))
-	mappingContext, err := migobj.StorageProvider.CreateOrUpdateInitiatorGroup(initiatorGroup, []string{hostIQN})
+	mappingContext, err := migobj.StorageProvider.CreateOrUpdateInitiatorGroup(initiatorGroup, hostAdapters)
 	if err != nil {
 		return storage.Volume{}, errors.Wrapf(err, "failed to create initiator group %s", initiatorGroup)
 	}
@@ -284,6 +316,135 @@ func (migobj *Migrate) copyDiskViaStorageAcceleratedCopy(ctx context.Context, es
 	targetVolume.OpenstackVol = storage.OpenstackVolume{
 		ID: cinderVolumeId,
 	}
+
+	return targetVolume, nil
+}
+
+// extractSerialFromPureNAA extracts the volume serial number from a Pure FlashArray NAA identifier.
+// Pure NAA format: naa.624a9370<serial_lowercase>
+func extractSerialFromPureNAA(naa string) (string, error) {
+	naa = strings.ToLower(naa)
+	if !strings.HasPrefix(naa, pureFCNAAPrefix) {
+		return "", fmt.Errorf("NAA %q is not a Pure FlashArray device (expected prefix %s)", naa, pureFCNAAPrefix)
+	}
+	serial := strings.TrimPrefix(naa, pureFCNAAPrefix)
+	if serial == "" {
+		return "", fmt.Errorf("could not extract serial number from NAA %q", naa)
+	}
+	return strings.ToUpper(serial), nil
+}
+
+// copyDiskViaFCStorageAcceleratedCopy copies a single VM disk using the Pure FlashArray
+// server-side CopyVolume API over Fibre Channel transport. This avoids routing data
+// through the ESXi host: the storage array copies the source LUN directly into the
+// newly provisioned target LUN.
+//
+// Prerequisites:
+//   - The VM disk must reside on a VMFS datastore that is backed by a single Pure LUN
+//     (i.e. dedicated datastore, not shared among multiple VMs). If the datastore is
+//     shared the copy would overwrite the whole datastore into the smaller target volume
+//     and will be rejected via a size mismatch check.
+//   - The storage provider must implement storage.FCCopyCapable.
+func (migobj *Migrate) copyDiskViaFCStorageAcceleratedCopy(ctx context.Context, esxiClient *esxissh.Client,
+	idx int, vminfo *vm.VMInfo, hostIP string,
+) (storage.Volume, error) {
+	startTime := time.Now()
+	vmDisk := vminfo.VMDisks[idx]
+
+	defer func() {
+		migobj.logMessage(fmt.Sprintf("FC StorageAcceleratedCopy completed in %s for disk %s",
+			time.Since(startTime).Round(time.Second), vmDisk.Name))
+		migobj.StorageProvider.Disconnect()
+	}()
+
+	// Re-initialize the storage provider for this disk (matches iSCSI path behaviour)
+	migobj.InitializeStorageProvider(ctx)
+
+	fcCapable, ok := migobj.StorageProvider.(storage.FCCopyCapable)
+	if !ok {
+		return storage.Volume{}, fmt.Errorf("storage provider %s does not implement FCCopyCapable", migobj.StorageProvider.WhoAmI())
+	}
+
+	// Step 1: Find the Pure volume that backs the source VMFS datastore
+	migobj.logMessage(fmt.Sprintf("Locating source volume on storage array for datastore %q", vmDisk.Datastore))
+	sourceNAA, err := esxiClient.GetDatastoreBackingNAA(vmDisk.Datastore)
+	if err != nil {
+		return storage.Volume{}, errors.Wrapf(err, "failed to locate datastore backing device for %q", vmDisk.Datastore)
+	}
+	migobj.logMessage(fmt.Sprintf("Source datastore %q is backed by device: %s", vmDisk.Datastore, sourceNAA))
+
+	serial, err := extractSerialFromPureNAA(sourceNAA)
+	if err != nil {
+		return storage.Volume{}, errors.Wrapf(err, "failed to extract serial from source NAA %s", sourceNAA)
+	}
+
+	sourceVolume, err := fcCapable.FindVolumeBySerial(serial)
+	if err != nil {
+		return storage.Volume{}, errors.Wrapf(err, "failed to find source volume by serial %s", serial)
+	}
+	migobj.logMessage(fmt.Sprintf("Found source Pure volume: %s (size: %d bytes)", sourceVolume.Name, sourceVolume.Size))
+
+	// Step 2: Validate that the source LUN is not significantly larger than the VM disk.
+	// A large discrepancy suggests a shared datastore (multiple VMs) which cannot be
+	// handled with a block-level copy.
+	diskSizeBytes := vmDisk.Size
+	if diskSizeBytes%512 != 0 {
+		diskSizeBytes = ((diskSizeBytes / 512) + 1) * 512
+	}
+	if sourceVolume.Size > diskSizeBytes*2 {
+		return storage.Volume{}, fmt.Errorf(
+			"source volume %s (%d bytes) is more than twice the VM disk size (%d bytes); "+
+				"datastore is likely shared among multiple VMs — cannot use FC server-side copy",
+			sourceVolume.Name, sourceVolume.Size, diskSizeBytes)
+	}
+
+	// Step 3: Create a target volume on the storage array
+	sanitizedName := sanitizeVolumeName(vminfo.Name + "-" + vmDisk.Name)
+	migobj.logMessage(fmt.Sprintf("Creating target volume %q with size %d bytes", sanitizedName, sourceVolume.Size))
+	// Use source volume size to ensure the copy succeeds
+	targetVolume, err := migobj.StorageProvider.CreateVolume(sanitizedName, sourceVolume.Size)
+	if err != nil {
+		return storage.Volume{}, errors.Wrapf(err, "failed to create target volume %q", sanitizedName)
+	}
+
+	// Step 4: Import the target volume into Cinder (renames it on Pure to volume-<id>-cinder)
+	migobj.logMessage(fmt.Sprintf("Importing target volume %q into Cinder", targetVolume.Name))
+	cinderVolumeID, err := migobj.manageVolumeToCinder(ctx, targetVolume.Name, vmDisk)
+	if err != nil {
+		return storage.Volume{}, errors.Wrapf(err, "failed to import volume %q into Cinder", targetVolume.Name)
+	}
+	vminfo.VMDisks[idx].OpenstackVol = &cindervolumes.Volume{
+		ID:   cinderVolumeID,
+		Name: targetVolume.Name,
+		Size: int(sourceVolume.Size / (1024 * 1024 * 1024)),
+	}
+
+	// Resolve the Cinder-renamed volume name on the array (e.g. volume-<uuid>-cinder)
+	resolvedTarget, err := migobj.StorageProvider.ResolveCinderVolumeToLUN(cinderVolumeID)
+	if err != nil {
+		return storage.Volume{}, errors.Wrapf(err, "failed to resolve Cinder volume %s on storage array", cinderVolumeID)
+	}
+	cinderVolumeName := resolvedTarget.Name
+	migobj.logMessage(fmt.Sprintf("Cinder renamed target volume to: %s", cinderVolumeName))
+
+	// Step 5: Execute the server-side copy on the Pure FlashArray
+	// This copies the source datastore LUN content into the target LUN without any
+	// ESXi data path involvement.
+	migobj.logMessage(fmt.Sprintf("Starting Pure FlashArray server-side copy: %s -> %s",
+		sourceVolume.Name, cinderVolumeName))
+	copyStart := time.Now()
+
+	if err := fcCapable.CopyVolumeOnArray(sourceVolume.Name, cinderVolumeName); err != nil {
+		return storage.Volume{}, errors.Wrapf(err, "Pure FlashArray server-side copy failed: %s -> %s",
+			sourceVolume.Name, cinderVolumeName)
+	}
+
+	migobj.logMessage(fmt.Sprintf("Pure FlashArray server-side copy completed in %s",
+		time.Since(copyStart).Round(time.Second)))
+
+	targetVolume.OpenstackVol = storage.OpenstackVolume{ID: cinderVolumeID}
+	targetVolume.Name = cinderVolumeName
+	targetVolume.NAA = resolvedTarget.NAA
 
 	return targetVolume, nil
 }

--- a/v2v-helper/migrate/vaai_copy.go
+++ b/v2v-helper/migrate/vaai_copy.go
@@ -21,10 +21,6 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 )
 
-// pureFCNAAPrefix is the Pure FlashArray NAA vendor prefix used to identify
-// Pure volumes from their NAA identifiers.
-const pureFCNAAPrefix = "naa.624a9370"
-
 // sanitizeVolumeName converts a volume name to meet storage array naming requirements:
 // - 1-63 characters long
 // - Alphanumeric, '_', and '-' only
@@ -114,14 +110,6 @@ func (migobj *Migrate) StorageAcceleratedCopyCopyDisks(ctx context.Context, vmin
 	// This is necessary to avoid "Failed to lock the file" errors during vmkfstools clone
 	migobj.logMessage("Waiting 5 seconds for ESXi to release disk file locks...")
 	time.Sleep(5 * time.Second)
-
-	// Detect storage transport type to decide which copy path to use
-	transportType, err := esxiClient.GetTransportType()
-	if err != nil {
-		migobj.logMessage(fmt.Sprintf("Warning: could not detect transport type (%v); defaulting to iSCSI path", err))
-		transportType = "iscsi"
-	}
-	migobj.logMessage(fmt.Sprintf("Detected storage transport type: %s", transportType))
 
 	volumes := []storage.Volume{}
 
@@ -298,20 +286,6 @@ func (migobj *Migrate) copyDiskViaStorageAcceleratedCopy(ctx context.Context, es
 	}
 
 	return targetVolume, nil
-}
-
-// extractSerialFromPureNAA extracts the volume serial number from a Pure FlashArray NAA identifier.
-// Pure NAA format: naa.624a9370<serial_lowercase>
-func extractSerialFromPureNAA(naa string) (string, error) {
-	naa = strings.ToLower(naa)
-	if !strings.HasPrefix(naa, pureFCNAAPrefix) {
-		return "", fmt.Errorf("NAA %q is not a Pure FlashArray device (expected prefix %s)", naa, pureFCNAAPrefix)
-	}
-	serial := strings.TrimPrefix(naa, pureFCNAAPrefix)
-	if serial == "" {
-		return "", fmt.Errorf("could not extract serial number from NAA %q", naa)
-	}
-	return strings.ToUpper(serial), nil
 }
 
 // ValidateStorageAcceleratedCopyPrerequisites validates that all prerequisites for StorageAcceleratedCopy copy are met


### PR DESCRIPTION
## What this PR does / why we need it
This PR adds logic to detect FC HBA, FC target/initiator.
Detailed changes for future reference also:
pkg/vpwned/sdk/storage/fcutil/fcutil.go — New helper package for FC WWN normalization:
  - ParseFCUID / WWPNFromFCUID — parse ESXi's fc.WWNN:WWPN UID format                                                                                                                                       
  - EqualWWNs — compare WWNs regardless of separator format (21:00:... vs 2100...)                                                                                                                          
  - FormattedWWPNFromFCUID — convert ESXi FC UID → colon-separated WWPN (ONTAP format)                                                                                                                      
  - Full unit test suite (fcutil_test.go)                                                                                                                                                                   
                                                                                                                                                                                                            
  v2v-helper/esxi-ssh/disk_ops.go — New ESXi SSH functions:                                                                                                                                                 
  - GetHostFCAdapters() — returns active FC adapter UIDs in fc.WWNN:WWPN format                                                                                                                             
  - GetAllHostAdapters() — returns all adapters (IQNs + FC UIDs combined); replaces GetHostIQN() in the copy flow                                                                                           
                                                                                                                                                                                                            
  pure/pure.go — FC host matching in CreateOrUpdateInitiatorGroup:                                                                                                                                          
  - Now checks both h.Iqn (iSCSI) and h.Wwn (FC) against the ESXi adapters                                                                                                                                  
  - Uses fcutil.WWPNFromFCUID + fcutil.EqualWWNs to normalise and compare                                                                                                                                   
                                                                                                                                                                                                            
  netapp/netapp.go — Full FC igroup support in CreateOrUpdateInitiatorGroup:                                                                                                                                
  - detectSANProtocol() — returns "fcp", "iscsi", or "mixed" from adapter UIDs                                                                                                                              
  - normaliseToONTAPInitiators() — converts fc.WWNN:WWPN → 21:00:00:90:fa:6e:67:a8 (ONTAP format); IQNs pass through unchanged                                                                              
  - ensureIgroupExists() — GET to find existing igroup, POST to create if missing (protocol-specific: vjailbreak-xcopy-fcp or -iscsi)                                                                       
  - addInitiatorToIgroup() — idempotent initiator addition via POST /protocols/san/igroups/{uuid}/initiators                                                                                                
  - OntapIgroup struct updated with SVM field; listIgroups now fetches protocol and svm                                                                                                                     
                                                                                                                                                                                                            
  The copy flow itself (copyDiskViaStorageAcceleratedCopy) needed no changes — vmkfstools RDM clone works identically over FC and iSCSI since both are VMFS block devices from ESXi's perspective.      

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1764 , #1785. 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_