### PR TITLE
1825 : Enhance Amplitude Events with OS Region Name from Credentials

### DIFF
--- a/ui/src/features/credentials/components/OpenstackCredentialsDrawer.tsx
+++ b/ui/src/features/credentials/components/OpenstackCredentialsDrawer.tsx
@@ -84,6 +84,7 @@ export default function OpenstackCredentialsDrawer({
   const [submitting, setSubmitting] = useState(false)
   const [createdCredentialName, setCreatedCredentialName] = useState<string | null>(null)
   const [createdCredentialIsPcd, setCreatedCredentialIsPcd] = useState(false)
+  const [createdRegionName, setCreatedRegionName] = useState<string | null>(null)
   const [promptAddVmwareOpen, setPromptAddVmwareOpen] = useState(false)
 
   const watchedValues = watch()
@@ -110,6 +111,7 @@ export default function OpenstackCredentialsDrawer({
     setRcFileValues(null)
     setCreatedCredentialName(null)
     setCreatedCredentialIsPcd(false)
+    setCreatedRegionName(null)
     setValidatingOpenstackCreds(false)
     setOpenstackCredsValidated(null)
     setOperationError(null)
@@ -189,6 +191,9 @@ export default function OpenstackCredentialsDrawer({
       setValidatingOpenstackCreds(true)
       setOperationError(null)
 
+      const regionName = (rcFileValues.OS_REGION_NAME || '').trim()
+      setCreatedRegionName(regionName || null)
+
       try {
         const projectName = rcFileValues.OS_PROJECT_NAME || rcFileValues.OS_TENANT_NAME
 
@@ -215,6 +220,7 @@ export default function OpenstackCredentialsDrawer({
         track(AMPLITUDE_EVENTS.PCD_CREDENTIALS_ADDED, {
           credentialName: values.credentialName,
           isPcd: values.isPcd,
+          regionName,
           namespace: response.metadata.namespace,
           stage: 'creation_success'
         })
@@ -224,6 +230,7 @@ export default function OpenstackCredentialsDrawer({
         track(AMPLITUDE_EVENTS.PCD_CREDENTIALS_FAILED, {
           credentialName: values.credentialName,
           isPcd: values.isPcd,
+          regionName,
           errorMessage: error instanceof Error ? error.message : String(error),
           stage: 'creation'
         })
@@ -290,6 +297,7 @@ export default function OpenstackCredentialsDrawer({
       track(AMPLITUDE_EVENTS.PCD_CREDENTIALS_FAILED, {
         credentialName: createdCredentialName,
         isPcd: createdCredentialIsPcd,
+        regionName: createdRegionName || undefined,
         errorMessage: message || 'Validation failed',
         stage: 'validation'
       })

--- a/ui/src/features/migration/MigrationForm.tsx
+++ b/ui/src/features/migration/MigrationForm.tsx
@@ -6,7 +6,8 @@ import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { postMigrationPlan } from 'src/features/migration/api/migration-plans/migrationPlans'
 import { MigrationPlan } from 'src/features/migration/api/migration-plans/model'
-import SecurityGroupAndServerGroupStep from './SecurityGroupAndServerGroup'
+import { createMigrationTemplateJson } from 'src/features/migration/api/migration-templates/helpers'
+import { createMigrationPlanJson } from 'src/features/migration/api/migration-plans/helpers'
 import {
   getMigrationTemplate,
   patchMigrationTemplate,
@@ -16,17 +17,17 @@ import {
 import { MigrationTemplate, VmData } from 'src/features/migration/api/migration-templates/model'
 import { createNetworkMappingJson } from 'src/api/network-mapping/helpers'
 import { postNetworkMapping } from 'src/api/network-mapping/networkMappings'
-import { OpenstackCreds } from 'src/api/openstack-creds/model'
-import {
-  getOpenstackCredentials,
-  deleteOpenstackCredentials
-} from 'src/api/openstack-creds/openstackCreds'
 import { createStorageMappingJson } from 'src/api/storage-mappings/helpers'
 import { postStorageMapping } from 'src/api/storage-mappings/storageMappings'
 import { createArrayCredsMappingJson } from 'src/api/arraycreds-mapping/helpers'
 import { postArrayCredsMapping } from 'src/api/arraycreds-mapping/arrayCredsMapping'
 import { VMwareCreds } from 'src/api/vmware-creds/model'
 import { getVmwareCredentials, deleteVmwareCredentials } from 'src/api/vmware-creds/vmwareCreds'
+import { OpenstackCreds } from 'src/api/openstack-creds/model'
+import {
+  getOpenstackCredentials,
+  deleteOpenstackCredentials
+} from 'src/api/openstack-creds/openstackCreds'
 import { THREE_SECONDS } from 'src/constants'
 import { MIGRATIONS_QUERY_KEY } from 'src/hooks/api/useMigrationsQuery'
 import { VMWARE_MACHINES_BASE_KEY } from 'src/hooks/api/useVMwareMachinesQuery'
@@ -35,6 +36,7 @@ import useParams from 'src/hooks/useParams'
 import { isNilOrEmpty } from 'src/utils'
 import MigrationOptions from './MigrationOptionsAlt'
 import NetworkAndStorageMappingStep from './NetworkAndStorageMappingStep'
+import SecurityGroupAndServerGroupStep from './SecurityGroupAndServerGroup'
 import SourceDestinationClusterSelection from './SourceDestinationClusterSelection'
 import VmsSelectionStep from './VmsSelectionStep'
 import { CUTOVER_TYPES } from './constants'
@@ -46,8 +48,7 @@ import { useRdmConfigValidation } from 'src/hooks/useRdmConfigValidation'
 import { useRdmDisksQuery } from 'src/hooks/api/useRdmDisksQuery'
 import { useAmplitude } from 'src/hooks/useAmplitude'
 import { AMPLITUDE_EVENTS } from 'src/types/amplitude'
-import { createMigrationTemplateJson } from 'src/features/migration/api/migration-templates/helpers'
-import { createMigrationPlanJson } from 'src/features/migration/api/migration-plans/helpers'
+import { getRegionNameForOpenstackRef } from 'src/utils/regionNameResolver'
 import {
   ActionButton,
   DrawerFooter,
@@ -702,7 +703,12 @@ export default function MigrationFormDrawer({
 
     const networkOverridesPerVM: Record<
       string,
-      Array<{ interfaceIndex: number; preserveIP: boolean; preserveMAC: boolean; UserAssignedIP?: string }>
+      Array<{
+        interfaceIndex: number
+        preserveIP: boolean
+        preserveMAC: boolean
+        UserAssignedIP?: string
+      }>
     > = {}
     if (params.vms) {
       params.vms.forEach((vm) => {
@@ -800,6 +806,11 @@ export default function MigrationFormDrawer({
 
     const body = createMigrationPlanJson(migrationFields)
 
+    const regionName = await getRegionNameForOpenstackRef(
+      openstackCredentials?.metadata?.name,
+      openstackCredentials?.metadata?.namespace
+    )
+
     try {
       const data = await postMigrationPlan(body)
       const virtualMachines = (data as any)?.spec?.virtualMachines
@@ -833,6 +844,7 @@ export default function MigrationFormDrawer({
           migrationTemplateName: updatedMigrationTemplate?.metadata?.name,
           virtualMachineCount: vmNames.length,
           vmName,
+          regionName,
           migrationType: migrationFields.type,
           hasDataCopyStartTime: !!migrationFields.dataCopyStart,
           hasAdminInitiatedCutover: !!migrationFields.adminInitiatedCutOver,
@@ -851,6 +863,7 @@ export default function MigrationFormDrawer({
         migrationTemplateName: updatedMigrationTemplate?.metadata?.name,
         virtualMachineCount: vmsToMigrate?.length || 0,
         migrationType: migrationFields.type,
+        regionName,
         errorMessage: error instanceof Error ? error.message : String(error),
         stage: 'creation'
       })

--- a/ui/src/features/migration/RollingMigrationForm.tsx
+++ b/ui/src/features/migration/RollingMigrationForm.tsx
@@ -1268,7 +1268,12 @@ export default function RollingMigrationFormDrawer({
 
       const networkOverridesPerVM: Record<
         string,
-        Array<{ interfaceIndex: number; preserveIP: boolean; preserveMAC: boolean; UserAssignedIP?: string }>
+        Array<{
+          interfaceIndex: number
+          preserveIP: boolean
+          preserveMAC: boolean
+          UserAssignedIP?: string
+        }>
       > = {}
       vmsWithAssignments
         .filter((vm) => selectedVMs.includes(vm.id))
@@ -1458,7 +1463,7 @@ export default function RollingMigrationFormDrawer({
 
       await postRollingMigrationPlan(migrationPlanJson, VJAILBREAK_DEFAULT_NAMESPACE)
 
-      console.log('Submitted rolling migration plan', migrationPlanJson)
+      const regionName = openstackCredData?.metadata?.labels?.['vjailbreak.k8s.pf9.io/region-name']
 
       // Track successful cluster conversion creation
       track(AMPLITUDE_EVENTS.ROLLING_MIGRATION_CREATED, {
@@ -1483,6 +1488,7 @@ export default function RollingMigrationFormDrawer({
           selectedMigrationOptions.cutoverOption &&
           params.cutoverOption === CUTOVER_TYPES.TIME_WINDOW,
         migrationTemplate: migrationTemplateResponse.metadata.name,
+        regionName,
         namespace: VJAILBREAK_DEFAULT_NAMESPACE
       })
 
@@ -1499,6 +1505,8 @@ export default function RollingMigrationFormDrawer({
       const selectedPCD = pcdData.find((p) => p.id === destinationPCD)
       const selectedVMsData = vmsWithAssignments.filter((vm) => selectedVMs.includes(vm.id))
 
+      const regionName = openstackCredData?.metadata?.labels?.['vjailbreak.k8s.pf9.io/region-name']
+
       track(AMPLITUDE_EVENTS.ROLLING_MIGRATION_SUBMISSION_FAILED, {
         clusterMigrationName: clusterObj?.name,
         sourceCluster: clusterObj?.name,
@@ -1507,6 +1515,7 @@ export default function RollingMigrationFormDrawer({
         pcdCredential: selectedPcdCredName,
         virtualMachineCount: selectedVMsData?.length || 0,
         esxHostCount: orderedESXHosts?.length || 0,
+        regionName,
         errorMessage: error instanceof Error ? error.message : String(error),
         stage: 'creation'
       })

--- a/ui/src/features/migration/pages/MigrationsPage.tsx
+++ b/ui/src/features/migration/pages/MigrationsPage.tsx
@@ -13,6 +13,7 @@ import WarningIcon from '@mui/icons-material/Warning'
 import { useMigrationStatusMonitor } from '../hooks/useMigrationStatusMonitor'
 import { useAmplitude } from 'src/hooks/useAmplitude'
 import { AMPLITUDE_EVENTS } from 'src/types/amplitude'
+import { getRegionNameForMigrationPlan } from 'src/utils/regionNameResolver'
 
 export default function MigrationsPage() {
   const queryClient = useQueryClient()
@@ -105,12 +106,20 @@ export default function MigrationsPage() {
       )
 
       migrationsSnapshot.forEach((migration) => {
-        track(AMPLITUDE_EVENTS.MIGRATION_DELETED, {
-          migrationName: migration.metadata?.name,
-          migrationPlan: migration.spec?.migrationPlan,
-          vmName: migration.spec?.vmName,
-          namespace: migration.metadata?.namespace
-        })
+        void (async () => {
+          const regionName = await getRegionNameForMigrationPlan(
+            migration.spec?.migrationPlan,
+            migration.metadata?.namespace
+          )
+
+          track(AMPLITUDE_EVENTS.MIGRATION_DELETED, {
+            migrationName: migration.metadata?.name,
+            migrationPlan: migration.spec?.migrationPlan,
+            vmName: migration.spec?.vmName,
+            regionName,
+            namespace: migration.metadata?.namespace
+          })
+        })()
       })
 
       queryClient.invalidateQueries({ queryKey: MIGRATIONS_QUERY_KEY })
@@ -119,13 +128,21 @@ export default function MigrationsPage() {
       const errorMessage = error instanceof Error ? error.message : String(error)
 
       migrationsSnapshot.forEach((migration) => {
-        track(AMPLITUDE_EVENTS.MIGRATION_DELETE_FAILED, {
-          migrationName: migration.metadata?.name,
-          migrationPlan: migration.spec?.migrationPlan,
-          vmName: migration.spec?.vmName,
-          namespace: migration.metadata?.namespace,
-          errorMessage
-        })
+        void (async () => {
+          const regionName = await getRegionNameForMigrationPlan(
+            migration.spec?.migrationPlan,
+            migration.metadata?.namespace
+          )
+
+          track(AMPLITUDE_EVENTS.MIGRATION_DELETE_FAILED, {
+            migrationName: migration.metadata?.name,
+            migrationPlan: migration.spec?.migrationPlan,
+            vmName: migration.spec?.vmName,
+            regionName,
+            namespace: migration.metadata?.namespace,
+            errorMessage
+          })
+        })()
       })
 
       setDeleteError(errorMessage)

--- a/ui/src/hooks/useMigrationStatusMonitor.ts
+++ b/ui/src/hooks/useMigrationStatusMonitor.ts
@@ -4,6 +4,7 @@ import { useAmplitude } from './useAmplitude'
 import { useErrorHandler } from './useErrorHandler'
 import { useStatusTracker } from './useStatusMonitor'
 import { AMPLITUDE_EVENTS } from 'src/types/amplitude'
+import { getRegionNameForMigrationPlan } from 'src/utils/regionNameResolver'
 
 export const useMigrationStatusMonitor = (migrations: Migration[] = []) => {
   const { track } = useAmplitude({ component: 'MigrationStatusMonitor' })
@@ -67,19 +68,27 @@ export const useMigrationStatusMonitor = (migrations: Migration[] = []) => {
       if (currentPhase === Phase.Failed && tracker.lastReportedPhase !== Phase.Failed) {
         const errorDetails = getErrorDetails()
 
-        // Track with Amplitude
-        track(AMPLITUDE_EVENTS.MIGRATION_EXECUTION_FAILED, {
-          migrationName,
-          migrationPlan: migration.spec?.migrationPlan,
-          vmName: migration.spec?.vmName,
-          podRef: migration.spec?.podRef,
-          previousPhase: tracker.previousPhase,
-          currentPhase,
-          errorMessage: errorDetails.message,
-          errorReason: errorDetails.reason,
-          failureTime: errorDetails.lastTransitionTime,
-          namespace: migration.metadata?.namespace
-        })
+        void (async () => {
+          const regionName = await getRegionNameForMigrationPlan(
+            migration.spec?.migrationPlan,
+            migration.metadata?.namespace
+          )
+
+          // Track with Amplitude
+          track(AMPLITUDE_EVENTS.MIGRATION_EXECUTION_FAILED, {
+            migrationName,
+            migrationPlan: migration.spec?.migrationPlan,
+            vmName: migration.spec?.vmName,
+            podRef: migration.spec?.podRef,
+            previousPhase: tracker.previousPhase,
+            currentPhase,
+            regionName,
+            errorMessage: errorDetails.message,
+            errorReason: errorDetails.reason,
+            failureTime: errorDetails.lastTransitionTime,
+            namespace: migration.metadata?.namespace
+          })
+        })()
 
         // Report to Bugsnag
         const bugsnagError = new Error(`Migration execution failed: ${errorDetails.message}`)
@@ -113,14 +122,22 @@ export const useMigrationStatusMonitor = (migrations: Migration[] = []) => {
 
       // Handle migration success (optional - for analytics)
       if (currentPhase === Phase.Succeeded && tracker.lastReportedPhase !== Phase.Succeeded) {
-        track(AMPLITUDE_EVENTS.MIGRATION_SUCCEEDED, {
-          migrationName,
-          migrationPlan: migration.spec?.migrationPlan,
-          vmName: migration.spec?.vmName,
-          previousPhase: tracker.previousPhase,
-          currentPhase,
-          namespace: migration.metadata?.namespace
-        })
+        void (async () => {
+          const regionName = await getRegionNameForMigrationPlan(
+            migration.spec?.migrationPlan,
+            migration.metadata?.namespace
+          )
+
+          track(AMPLITUDE_EVENTS.MIGRATION_SUCCEEDED, {
+            migrationName,
+            migrationPlan: migration.spec?.migrationPlan,
+            vmName: migration.spec?.vmName,
+            previousPhase: tracker.previousPhase,
+            currentPhase,
+            regionName,
+            namespace: migration.metadata?.namespace
+          })
+        })()
 
         // Mark as reported BEFORE updating previousPhase to prevent race conditions
         statusTrackerRef.current[migrationName].lastReportedPhase = Phase.Succeeded

--- a/ui/src/hooks/useRollingMigrationsStatusMonitor.ts
+++ b/ui/src/hooks/useRollingMigrationsStatusMonitor.ts
@@ -4,6 +4,7 @@ import { useAmplitude } from './useAmplitude'
 import { useErrorHandler } from './useErrorHandler'
 import { useStatusTracker } from './useStatusMonitor'
 import { AMPLITUDE_EVENTS } from 'src/types/amplitude'
+import { getRegionNameForMigrationTemplate } from 'src/utils/regionNameResolver'
 
 export const useRollingMigrationsStatusMonitor = (
   rollingMigrationPlans: RollingMigrationPlan[] = []
@@ -60,20 +61,28 @@ export const useRollingMigrationsStatusMonitor = (
       if (isFailed && tracker.lastReportedPhase !== currentPhase) {
         const errorDetails = getErrorDetails()
 
-        // Track with Amplitude
-        track(AMPLITUDE_EVENTS.CLUSTER_CONVERSION_EXECUTION_FAILED, {
-          rollingMigrationPlanName: planName,
-          clusterName: rollingMigrationPlan.spec?.clusterSequence?.[0]?.clusterName,
-          previousPhase: tracker.previousPhase,
-          currentPhase,
-          errorMessage: errorDetails.message,
-          bmConfigRef: rollingMigrationPlan.spec?.bmConfigRef?.name,
-          clusterSequenceLength: rollingMigrationPlan.spec?.clusterSequence?.length || 0,
-          vmSequenceLength:
-            rollingMigrationPlan.spec?.clusterSequence?.[0]?.vmSequence?.length || 0,
-          namespace: rollingMigrationPlan.metadata?.namespace,
-          migrationStrategy: rollingMigrationPlan.spec?.migrationStrategy?.type
-        })
+        void (async () => {
+          const regionName = await getRegionNameForMigrationTemplate(
+            rollingMigrationPlan.spec?.migrationTemplate,
+            rollingMigrationPlan.metadata?.namespace
+          )
+
+          // Track with Amplitude
+          track(AMPLITUDE_EVENTS.CLUSTER_CONVERSION_EXECUTION_FAILED, {
+            rollingMigrationPlanName: planName,
+            clusterName: rollingMigrationPlan.spec?.clusterSequence?.[0]?.clusterName,
+            previousPhase: tracker.previousPhase,
+            currentPhase,
+            regionName,
+            errorMessage: errorDetails.message,
+            bmConfigRef: rollingMigrationPlan.spec?.bmConfigRef?.name,
+            clusterSequenceLength: rollingMigrationPlan.spec?.clusterSequence?.length || 0,
+            vmSequenceLength:
+              rollingMigrationPlan.spec?.clusterSequence?.[0]?.vmSequence?.length || 0,
+            namespace: rollingMigrationPlan.metadata?.namespace,
+            migrationStrategy: rollingMigrationPlan.spec?.migrationStrategy?.type
+          })
+        })()
 
         // Report to Bugsnag
         const bugsnagError = new Error(
@@ -111,18 +120,26 @@ export const useRollingMigrationsStatusMonitor = (
       // Handle rolling migration plan success (optional - for analytics)
       const isSucceeded = currentPhase === 'Succeeded'
       if (isSucceeded && tracker.lastReportedPhase !== currentPhase) {
-        track(AMPLITUDE_EVENTS.CLUSTER_CONVERSION_SUCCEEDED, {
-          rollingMigrationPlanName: planName,
-          clusterName: rollingMigrationPlan.spec?.clusterSequence?.[0]?.clusterName,
-          previousPhase: tracker.previousPhase,
-          currentPhase,
-          bmConfigRef: rollingMigrationPlan.spec?.bmConfigRef?.name,
-          clusterSequenceLength: rollingMigrationPlan.spec?.clusterSequence?.length || 0,
-          vmSequenceLength:
-            rollingMigrationPlan.spec?.clusterSequence?.[0]?.vmSequence?.length || 0,
-          namespace: rollingMigrationPlan.metadata?.namespace,
-          migrationStrategy: rollingMigrationPlan.spec?.migrationStrategy?.type
-        })
+        void (async () => {
+          const regionName = await getRegionNameForMigrationTemplate(
+            rollingMigrationPlan.spec?.migrationTemplate,
+            rollingMigrationPlan.metadata?.namespace
+          )
+
+          track(AMPLITUDE_EVENTS.CLUSTER_CONVERSION_SUCCEEDED, {
+            rollingMigrationPlanName: planName,
+            clusterName: rollingMigrationPlan.spec?.clusterSequence?.[0]?.clusterName,
+            previousPhase: tracker.previousPhase,
+            currentPhase,
+            regionName,
+            bmConfigRef: rollingMigrationPlan.spec?.bmConfigRef?.name,
+            clusterSequenceLength: rollingMigrationPlan.spec?.clusterSequence?.length || 0,
+            vmSequenceLength:
+              rollingMigrationPlan.spec?.clusterSequence?.[0]?.vmSequence?.length || 0,
+            namespace: rollingMigrationPlan.metadata?.namespace,
+            migrationStrategy: rollingMigrationPlan.spec?.migrationStrategy?.type
+          })
+        })()
 
         // Mark as reported BEFORE updating previousPhase to prevent race conditions
         statusTrackerRef.current[planName].lastReportedPhase = currentPhase

--- a/ui/src/utils/regionNameResolver.ts
+++ b/ui/src/utils/regionNameResolver.ts
@@ -1,0 +1,80 @@
+import { getMigrationPlan } from 'src/api/migration-plans/migrationPlans'
+import { getMigrationTemplate } from 'src/api/migration-templates/migrationTemplates'
+import { getOpenstackCredentials } from 'src/api/openstack-creds/openstackCreds'
+import { getSecret } from 'src/api/secrets/secrets'
+
+const REGION_LABEL_KEY = 'vjailbreak.k8s.pf9.io/region-name'
+
+const regionByPlanCache = new Map<string, Promise<string | undefined>>()
+const regionByTemplateCache = new Map<string, Promise<string | undefined>>()
+const regionByOpenstackRefCache = new Map<string, Promise<string | undefined>>()
+
+const normalizeRegion = (region: unknown) =>
+  typeof region === 'string' && region.trim().length > 0 ? region.trim() : undefined
+
+export const getRegionNameForOpenstackRef = (openstackRef?: string, namespace?: string) => {
+  if (!openstackRef) return Promise.resolve(undefined)
+  const key = `${namespace || ''}:${openstackRef}`
+
+  const cached = regionByOpenstackRefCache.get(key)
+  if (cached) return cached
+
+  const regionPromise = (async () => {
+    try {
+      const openstackCred = await getOpenstackCredentials(openstackRef, namespace)
+      const labeledRegion = normalizeRegion(openstackCred?.metadata?.labels?.[REGION_LABEL_KEY])
+      if (labeledRegion) return labeledRegion
+
+      const secretName = `${openstackRef}-openstack-secret`
+      const secret = await getSecret(secretName, namespace)
+      return normalizeRegion(secret?.data?.OS_REGION_NAME)
+    } catch {
+      return undefined
+    }
+  })()
+
+  regionByOpenstackRefCache.set(key, regionPromise)
+  return regionPromise
+}
+
+export const getRegionNameForMigrationTemplate = (templateName?: string, namespace?: string) => {
+  if (!templateName) return Promise.resolve(undefined)
+  const key = `${namespace || ''}:${templateName}`
+
+  const cached = regionByTemplateCache.get(key)
+  if (cached) return cached
+
+  const regionPromise = (async () => {
+    try {
+      const template = await getMigrationTemplate(templateName, namespace)
+      const openstackRef = template?.spec?.destination?.openstackRef
+      return getRegionNameForOpenstackRef(openstackRef, namespace)
+    } catch {
+      return undefined
+    }
+  })()
+
+  regionByTemplateCache.set(key, regionPromise)
+  return regionPromise
+}
+
+export const getRegionNameForMigrationPlan = (planName?: string, namespace?: string) => {
+  if (!planName) return Promise.resolve(undefined)
+  const key = `${namespace || ''}:${planName}`
+
+  const cached = regionByPlanCache.get(key)
+  if (cached) return cached
+
+  const regionPromise = (async () => {
+    try {
+      const plan = await getMigrationPlan(planName, namespace)
+      const templateName = plan?.spec?.migrationTemplate
+      return getRegionNameForMigrationTemplate(templateName, namespace)
+    } catch {
+      return undefined
+    }
+  })()
+
+  regionByPlanCache.set(key, regionPromise)
+  return regionPromise
+}


### PR DESCRIPTION
## What this PR does / why we need it
- Added regionName parameter to Amplitude event tracking for credentials, migrations, and cluster conversions. 
- Implemented region name resolution utilities that fetch region information from OpenStack credentials, secrets, migration plans, and templates with caching. 
- Updated all relevant Amplitude event calls to include regionName for better analytics tracking.

## Which issue(s) this PR fixes
fixes #1825 

## Testing done
<img width="1533" height="748" alt="Screenshot from 2026-04-20 11-19-31" src="https://github.com/user-attachments/assets/ee67effd-e80b-4cad-b9cf-765dbacc7019" />
