### PR TITLE
Update portgroupkey if stale with correct live mor of the dvpg. 

### DIFF
--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -576,7 +576,7 @@ func GetVMwNetworks(ctx context.Context, k3sclient client.Client, vmwcreds *vjai
 
 	// Get the network name of the VM
 	var o mo.VirtualMachine
-	err = vm.Properties(ctx, vm.Reference(), []string{"config", "network"}, &o)
+	err = vm.Properties(ctx, vm.Reference(), []string{"config", "network", "guest"}, &o)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get VM properties: %w", err)
 	}
@@ -588,9 +588,19 @@ func GetVMwNetworks(ctx context.Context, k3sclient client.Client, vmwcreds *vjai
 		return nil, fmt.Errorf("failed to get virtual NICs for vm %s: %w", vmname, err)
 	}
 
+	var guestNets []types.GuestNicInfo
+	if o.Guest != nil {
+		guestNets = o.Guest.Net
+	}
 	for _, nic := range nicList {
 		name, err := resolveNetworkName(ctx, c, nic)
 		if err != nil {
+			// Last-resort: ask VMware Tools for the portgroup name of this
+			// MAC. Covers DVPGs genuinely deleted from vCenter.
+			if toolsName := guestNetworkNameForMAC(guestNets, nic.MAC); toolsName != "" {
+				networks = append(networks, toolsName)
+				continue
+			}
 			return nil, err
 		}
 		networks = append(networks, name)
@@ -859,12 +869,21 @@ func resolveNetworkName(ctx context.Context, c *vim25.Client, nic vjailbreakv1al
 		return netObj.Name, nil
 
 	case constants.VMwareNetworkTypeDistributedVirtualPortgroup:
+		// Try direct MOR lookup first — the fast path.
 		var netObj mo.DistributedVirtualPortgroup
 		netRef := types.ManagedObjectReference{Type: constants.VMwareNetworkTypeDistributedVirtualPortgroup, Value: nic.Network}
-		if err := property.DefaultCollector(c).RetrieveOne(ctx, netRef, []string{"name"}, &netObj); err != nil {
-			return "", fmt.Errorf("failed to retrieve distributed virtual portgroup name for %s: %w", nic.Network, err)
+		if err := property.DefaultCollector(c).RetrieveOne(ctx, netRef, []string{"name"}, &netObj); err == nil {
+			return netObj.Name, nil
 		}
-		return netObj.Name, nil
+		// Fallback: NIC backing stores the DVPG `key`, not the current MOR.
+		// After a cross-vCenter DVS import, each DVPG keeps its original MOR
+		// as `key` while being assigned a new MOR on the target vCenter, so
+		// the VMX-stored identifier is the key. Scan for a DVPG with a
+		// matching key.
+		if name, err := findDVPGByKey(ctx, c, nic.Network); err == nil {
+			return name, nil
+		}
+		return "", fmt.Errorf("failed to retrieve distributed virtual portgroup %s (no matching MOR or key)", nic.Network)
 
 	case constants.VMwareNetworkTypeOpaqueNetwork:
 		m := view.NewManager(c)
@@ -889,6 +908,49 @@ func resolveNetworkName(ctx context.Context, c *vim25.Client, nic vjailbreakv1al
 	default:
 		return "", fmt.Errorf("unknown network type %q for NIC %s", nic.NetworkType, nic.MAC)
 	}
+}
+
+// findDVPGByKey scans every DistributedVirtualPortgroup on the vCenter for
+// one whose `key` property matches the given id, returning its display name.
+// Used as a fallback when a NIC backing stores a preserved key (e.g. after a
+// cross-vCenter DVS import) rather than the live MOR.
+func findDVPGByKey(ctx context.Context, c *vim25.Client, key string) (string, error) {
+	m := view.NewManager(c)
+	v, err := m.CreateContainerView(ctx, c.ServiceContent.RootFolder,
+		[]string{constants.VMwareNetworkTypeDistributedVirtualPortgroup}, true)
+	if err != nil {
+		return "", fmt.Errorf("create DVPG container view: %w", err)
+	}
+	defer v.Destroy(ctx) //nolint:errcheck
+
+	var dvpgs []mo.DistributedVirtualPortgroup
+	if err := v.Retrieve(ctx,
+		[]string{constants.VMwareNetworkTypeDistributedVirtualPortgroup},
+		[]string{"name", "key"}, &dvpgs); err != nil {
+		return "", fmt.Errorf("retrieve DVPGs: %w", err)
+	}
+	for _, pg := range dvpgs {
+		if pg.Key == key {
+			return pg.Name, nil
+		}
+	}
+	return "", fmt.Errorf("no DVPG with key %s", key)
+}
+
+// guestNetworkNameForMAC returns the portgroup name VMware Tools reports for
+// the given MAC, or "" if there is no match. Used as a last-resort fallback
+// when vCenter lookups fail because the DVPG has been deleted — Tools still
+// remembers the last-known portgroup name per NIC.
+func guestNetworkNameForMAC(guestNets []types.GuestNicInfo, mac string) string {
+	if mac == "" {
+		return ""
+	}
+	for _, g := range guestNets {
+		if g.Network != "" && strings.EqualFold(g.MacAddress, mac) {
+			return g.Network
+		}
+	}
+	return ""
 }
 
 // ExtractGuestNetworkInfo retrieves the runtime guest network configuration (guest.net)
@@ -1777,9 +1839,19 @@ func processSingleVM(ctx context.Context, scope *scope.VMwareCredsScope, vm *obj
 		appendToVMErrorsThreadSafe(errMu, vmErrors, vm.Name(), fmt.Errorf("failed to get virtual NICs for vm %s: %w", vm.Name(), err))
 	}
 	// Build networks list from NetworkInterfaces to match NIC count
+	var guestNets []types.GuestNicInfo
+	if vmProps.Guest != nil {
+		guestNets = vmProps.Guest.Net
+	}
 	for _, nic := range nicList {
 		name, err := resolveNetworkName(ctx, c, nic)
 		if err != nil {
+			// Last-resort: ask VMware Tools for the portgroup name of this
+			// MAC. Covers DVPGs genuinely deleted from vCenter.
+			if toolsName := guestNetworkNameForMAC(guestNets, nic.MAC); toolsName != "" {
+				networks = append(networks, toolsName)
+				continue
+			}
 			// Network is orphaned/deleted or has no backing — log but continue VM discovery
 			appendToVMErrorsThreadSafe(errMu, vmErrors, vm.Name(), err)
 			networks = append(networks, "Orphaned Network")


### PR DESCRIPTION
## What this PR does / why we need it

```
DEBUG  vmNetworkIndex  indexed DVPG
  mor="dvportgroup-2276"  key="dvportgroup-90743"  name="vlan83"

DEBUG  vmNetworkIndex  indexed DVPG
  mor="dvportgroup-2322"  key="dvportgroup-90752"  name="vlan89"

DEBUG  vmNetworkIndex  built VM network index
  entries=4

DEBUG  nicResolver    resolving NIC networks
  nicCount=2  liveNetworkCount=2  indexEntries=4  guestNicCount=2

DEBUG  nicResolver    rewriting NIC.Network from stale key to live MOR
  nicIndex=0  mac="00:50:56:aa:bb:01"  type="DistributedVirtualPortgroup"
  nicNetworkID="dvportgroup-90752"
  oldNetwork="dvportgroup-90752"  newMOR="dvportgroup-2322"
  resolvedName="vlan89"

DEBUG  nicResolver    rewriting NIC.Network from stale key to live MOR
  nicIndex=1  mac="00:50:56:aa:bb:02"  type="DistributedVirtualPortgroup"
  nicNetworkID="dvportgroup-90743"
  oldNetwork="dvportgroup-90743"  newMOR="dvportgroup-2276"
  resolvedName="vlan83"

```

NIC index | MAC | Backing PortgroupKey (from VMX) | Live MOR on target vCenter | DVPG name
0 | 00:50:56:aa:bb:01 | dvportgroup-90752 | dvportgroup-2322 | vlan89
1 | 00:50:56:aa:bb:02 | dvportgroup-90743 | dvportgroup-2276 | vlan83

```
vmProps.Network returns 2 live DVPG refs (dvportgroup-2276, dvportgroup-2322). buildVMNetworkIndex retrieves name + key for each, producing 4 index entries (MOR and key each point to the same {MOR, Name} value) — note entries=4 for 2 DVPGs.

Each NIC's backing stores the preserved key (dvportgroup-9xxxx), not a MOR on the target vCenter.

A single idx[nic.Network] lookup hits via the key alias, yields the live MOR and display name, and rewrites NIC.Network in place to the live MOR.
```

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1818 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_