### PR TITLE
Handling interfaces with no ip for rhel based os

### DIFF
--- a/scripts/generate-udev-mapping.sh
+++ b/scripts/generate-udev-mapping.sh
@@ -135,7 +135,31 @@ process_rhel(){
     fi
     
     if [[ -z "$FOUND_IP" ]]; then
-      display_msg "Skipping entry with empty IP for MAC $FOUND_MAC: $line_entry"
+      display_msg "No IP found for MAC $FOUND_MAC, generating no-IP interface: $line_entry"
+      if [[ -n "$TARGET_DIR" && -d "$TARGET_DIR" ]]; then
+        {
+          echo "TYPE=Ethernet"
+          echo "BOOTPROTO=none"
+          echo "NAME=vjb$VJB_INDEX"
+          echo "DEVICE=vjb$VJB_INDEX"
+          echo "ONBOOT=yes"
+          echo "HWADDR=$FOUND_MAC"
+        } > "$TARGET_DIR/ifcfg-vjb$VJB_INDEX"
+        VJB_INDEX=$((VJB_INDEX+1))
+      elif [[ -d "$NM_CONN_PATH" ]]; then
+        {
+          echo "[connection]"
+          echo "id=vjb$VJB_INDEX"
+          echo "type=ethernet"
+          echo "interface-name=vjb$VJB_INDEX"
+          echo "mac-address=$FOUND_MAC"
+          echo "[ipv4]"
+          echo "method=disabled"
+        } > "$NM_CONN_PATH/vjb$VJB_INDEX.nmconnection"
+        VJB_INDEX=$((VJB_INDEX+1))
+      else
+        display_msg "Notice: No valid interface configuration path found. Skipping no-IP interface generation."
+      fi
       continue
     fi
 

--- a/scripts/generate-udev-mapping.sh
+++ b/scripts/generate-udev-mapping.sh
@@ -155,6 +155,8 @@ process_rhel(){
           echo "mac-address=$FOUND_MAC"
           echo "[ipv4]"
           echo "method=disabled"
+          echo "[ipv6]"
+          echo "method=disabled"
         } > "$NM_CONN_PATH/vjb$VJB_INDEX.nmconnection"
         VJB_INDEX=$((VJB_INDEX+1))
       else


### PR DESCRIPTION
## What this PR does / why we need it

Explicitly injecting a no ip configuration for interfaces having no ip at the source to maintain consistency

fixes #1832 

## Special notes for your reviewer


## Testing done
### No ip configuration being injected during migration 
<img width="708" height="217" alt="image" src="https://github.com/user-attachments/assets/055bf2c7-45bc-48a5-b7d5-d08ceea7c5d6" />

### Configuration at destination with no ip 
<img width="1105" height="621" alt="image" src="https://github.com/user-attachments/assets/35e8eebd-3c71-48b6-99c3-de1c3fcaba94" />
