### PR TITLE
Remove default profile auto-selection and fix boot volume metadata merge

### DIFF
--- a/deploy/volumeimageprofile-defaults.yaml
+++ b/deploy/volumeimageprofile-defaults.yaml
@@ -7,11 +7,11 @@ spec:
   osFamily: windowsGuest
   description: Default profile for Windows VMs
   properties:
-    hw_disk_bus: virtio
-    hw_vif_model: virtio
-    os_type: windows
     hw_qemu_guest_agent: "yes"
-    hw_video_model: qxl
+    hw_video_model: virtio
+    hw_pointer_model: usbtablet
+    hw_disk_bus: virtio
+    os_type: windows
 ---
 apiVersion: vjailbreak.k8s.pf9.io/v1alpha1
 kind: VolumeImageProfile
@@ -23,5 +23,5 @@ spec:
   description: Default profile for Linux VMs
   properties:
     hw_qemu_guest_agent: "yes"
-    hw_disk_bus: virtio
-    hw_scsi_model: virtio-scsi
+    hw_video_model: virtio
+    hw_pointer_model: usbtablet

--- a/ui/src/features/migration/SecurityGroupAndServerGroup.tsx
+++ b/ui/src/features/migration/SecurityGroupAndServerGroup.tsx
@@ -1,5 +1,5 @@
 import { Box, Alert, Autocomplete, Chip, TextField } from '@mui/material'
-import { useMemo, useEffect, useRef, useState } from 'react'
+import { useMemo, useEffect, useState } from 'react'
 import { Step, RHFAutocomplete } from 'src/shared/components/forms'
 import { FormGrid } from 'src/components'
 import { FieldLabel } from 'src/components/design-system/ui/FieldLabel'
@@ -73,45 +73,6 @@ export default function SecurityGroupAndServerGroup({
     () => (Array.isArray(params?.imageProfiles) ? params.imageProfiles : []),
     [params?.imageProfiles]
   )
-
-  // Auto-select OS-matching default profiles whenever the VM selection changes.
-  const lastVmsKeyRef = useRef<string>('')
-  const vmsKey = (params?.vms ?? []).map((vm) => vm.name ?? vm.id ?? '').sort().join(',')
-  useEffect(() => {
-    if (loadingProfiles) return
-    if (vmsKey === lastVmsKeyRef.current) return
-
-    lastVmsKeyRef.current = vmsKey
-
-    if (!params?.vms || params.vms.length === 0) return
-
-    const current = new Set(selectedImageProfiles)
-    const toAdd = applicableProfiles
-      .filter((p) => {
-        const name = p.metadata?.name || ''
-        if (current.has(name)) return false
-        const fam = p.spec?.osFamily || ''
-        if (fam === 'windowsGuest' && hasWindowsVMSelected && name === 'default-windows')
-          return true
-        if (fam === 'linuxGuest' && hasLinuxVMSelected && name === 'default-linux')
-          return true
-        return false
-      })
-      .map((p) => p.metadata.name)
-
-    if (toAdd.length > 0) {
-      onChange('imageProfiles')([...selectedImageProfiles, ...toAdd])
-    }
-  }, [
-    vmsKey,
-    loadingProfiles,
-    applicableProfiles,
-    hasLinuxVMSelected,
-    hasWindowsVMSelected,
-    onChange,
-    selectedImageProfiles,
-    params?.vms
-  ])
 
   const [profileConflictError, setProfileConflictError] = useState('')
 
@@ -222,7 +183,7 @@ export default function SecurityGroupAndServerGroup({
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
           <FieldLabel
             label="Profiles"
-            tooltip="Apply OpenStack image metadata to the boot volume. Profiles matching the selected VMs' OS family are pre-selected. Properties from later profiles override earlier ones on duplicate keys."
+            tooltip="Apply OpenStack volume image properties."
             align="flex-start"
           />
           <Autocomplete

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -381,49 +381,16 @@ func (osclient *OpenStackClients) SetVolumeImageMetadata(ctx context.Context, vo
 	return nil
 }
 
+// ApplyBootVolumeImageMetadata merges profile-supplied properties onto the boot volume's existing
+// image metadata. Any key present in both the hardcoded set and the profile resolves to the profile value.
 func (osclient *OpenStackClients) ApplyBootVolumeImageMetadata(ctx context.Context, volume *volumes.Volume, metadata map[string]string) error {
 	if len(metadata) == 0 {
 		return nil
 	}
-
-	// Fetch current state so we know which existing keys to drop.
-	current, err := volumes.Get(ctx, osclient.BlockStorageClient, volume.ID).Extract()
-	if err != nil {
-		return fmt.Errorf("failed to read current volume state before applying image metadata: %s", err)
-	}
-
-	desired := make(map[string]bool, len(metadata))
-	for k := range metadata {
-		desired[k] = true
-	}
-
-	actionURL := osclient.BlockStorageClient.ServiceURL("volumes", volume.ID, "action")
-	for existingKey := range current.VolumeImageMetadata {
-		if desired[existingKey] {
-			continue
-		}
-		body := map[string]interface{}{
-			"os-unset_image_metadata": map[string]interface{}{"key": existingKey},
-		}
-		resp, unsetErr := osclient.BlockStorageClient.Post(ctx, actionURL, body, nil, &gophercloud.RequestOpts{
-			OkCodes: []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent},
-		})
-		if resp != nil && resp.Body != nil {
-			_ = resp.Body.Close()
-		}
-		if unsetErr != nil {
-			// Non-fatal: log and continue
-			PrintLog(fmt.Sprintf("WARN: failed to unset image metadata key %q on boot volume %s: %s",
-				existingKey, volume.ID, unsetErr))
-			continue
-		}
-		PrintLog(fmt.Sprintf("OPENSTACK API: Removed stale image metadata key %q from boot volume %s", existingKey, volume.ID))
-	}
-
-	PrintLog(fmt.Sprintf("OPENSTACK API: Applying %d image metadata key(s) to boot volume %s", len(metadata), volume.ID))
+	PrintLog(fmt.Sprintf("OPENSTACK API: Merging %d profile image metadata key(s) onto boot volume %s", len(metadata), volume.ID))
 	options := volumes.ImageMetadataOpts{Metadata: metadata}
 	if err := volumes.SetImageMetadata(ctx, osclient.BlockStorageClient, volume.ID, options).ExtractErr(); err != nil {
-		return fmt.Errorf("failed to apply boot volume image metadata: %s", err)
+		return fmt.Errorf("failed to apply profile image metadata to boot volume: %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## What this PR does / why we need it

- Remove auto-selection of default-windows/default-linux profiles in migration form; profiles are now opt-in only
- Merge profile properties on top of existing metadata, conflicting keys resolve to the user's profile value
- Align default profile YAMLs to exactly match hardcoded properties (hw_qemu_guest_agent, hw_video_model, hw_pointer_model for both OS families; hw_disk_bus, os_type additionally for Windows)

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1844 
fixes #931 

## Testing done

- no auto selection
<img width="1362" height="508" alt="image" src="https://github.com/user-attachments/assets/2262754c-9a6c-4029-8294-b4d201aeab38" />

- confict on same properties with different key value
<img width="1264" height="348" alt="image" src="https://github.com/user-attachments/assets/4601fbac-a5e1-4aee-99e9-c2174b5fbc16" />

### Test Case 1
- selected two profiles with diff values:
<img width="861" height="812" alt="image" src="https://github.com/user-attachments/assets/ae6a74cb-2c68-415e-b2ec-bb12e723fb46" />

- it got migrated with union of all propperties
<img width="466" height="769" alt="image" src="https://github.com/user-attachments/assets/da40d4b7-57da-4669-b5cd-a21e3cce9fd1" />

### Test Case 2

- selected 3 different profiles with different values and kept one value different for default property to override
<img width="864" height="811" alt="image" src="https://github.com/user-attachments/assets/16c02f02-e331-41a2-93d3-c4c9caaf86c7" />

- it got migrated with union of all and override the value of default `hw_qemu_guest_agent` and detected source VM is UEFI so auto applied `hw_firmware_type=uefi`
<img width="504" height="773" alt="image" src="https://github.com/user-attachments/assets/10bef720-03bf-45fb-b64b-a324880d6cbb" />


### Test Case 3

- selected no profile 
<img width="859" height="810" alt="image" src="https://github.com/user-attachments/assets/debe8ab6-7c28-4081-b372-607d13505309" />

- it got migrated with default image properties and detected source VM is UEFI so auto applied `hw_firmware_type=uefi`

<img width="513" height="796" alt="image" src="https://github.com/user-attachments/assets/311a4d2e-5f5c-486e-a065-044926f117d4" />

### Test Case 4

- selected profile with an addition property `os_type`
<img width="858" height="810" alt="image" src="https://github.com/user-attachments/assets/16b69d8c-c98a-46dc-aa2f-739704890a4f" />

- it got migrated with proper union of all properties

<img width="458" height="764" alt="image" src="https://github.com/user-attachments/assets/a35ceed9-0e26-411e-80ba-4a03803a7445" />


## didn't touched image properties for data devices of any VM
<img width="456" height="748" alt="image" src="https://github.com/user-attachments/assets/0e2ca47d-31ce-4441-9ce5-85d291d3301a" />
