### PR TITLE
fix - Suse-11-4 - VM ends up in maintenance mode post migration

### DIFF
--- a/scripts/generate-mount-persistence.sh
+++ b/scripts/generate-mount-persistence.sh
@@ -248,7 +248,11 @@ while IFS="$(printf '\t')" read -r SRC TGT FST; do
       if [ "$TGT_FSTAB" = "/" ]; then
         DUMP_PASS="1 1"
       else
-        DUMP_PASS="0 2"
+        # Skip boot-time fsck on secondary ext filesystems. On sysvinit (e.g.
+        # SLES 11 / openSUSE 11) the fsck step cannot resolve a UUID for a
+        # not-yet-attached Cinder disk and drops the system to a maintenance
+        # shell. Runtime fsck on mount still works when needed.
+        DUMP_PASS="0 0"
       fi
       ;;
     *)
@@ -283,11 +287,28 @@ if $APPLY; then
 
   cp "$FSTAB_PATH" "$FSTAB_PATH.bak.$(date +%s)"
 
+  # Marker comment so post-migration inspection can tell at a glance whether
+  # this script actually ran against the guest's fstab. Grep for:
+  #   grep 'vJailbreak mount-persistence' /etc/fstab
+  if $FORCE_UUID; then
+    MARKER_MODE="force-uuid"
+  elif $REPLACE_FSTAB; then
+    MARKER_MODE="replace-fstab"
+  else
+    MARKER_MODE="apply"
+  fi
+  MARKER_TS=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)
+  MARKER_LINE="# vJailbreak mount-persistence: ran at ${MARKER_TS} mode=${MARKER_MODE}"
+
   if $REPLACE_FSTAB; then
     echo "Replacing existing fstab entries for detected mounts and swap..."
     tmp_fstab=$(mktemp)
 
     while IFS= read -r line; do
+      # Strip any prior vJailbreak marker so reruns don't accumulate headers.
+      case "$line" in
+        "# vJailbreak mount-persistence:"*) continue ;;
+      esac
       skip=false
       while IFS= read -r entry; do
         mp=$(echo "$entry" | awk '{print $2}')
@@ -298,11 +319,13 @@ if $APPLY; then
       $skip || echo "$line" >> "$tmp_fstab"
     done < "$FSTAB_PATH"
 
-    # Append new entries (already in UUID format from get_fstab_id)
+    # Append marker and new entries (already in UUID format from get_fstab_id)
+    echo "$MARKER_LINE" >> "$tmp_fstab"
     cat "$FSTAB_LINES_FILE" >> "$tmp_fstab"
 
     mv "$tmp_fstab" "$FSTAB_PATH"
   else
+    echo "$MARKER_LINE" >> "$FSTAB_PATH"
     cat "$FSTAB_LINES_FILE" >> "$FSTAB_PATH"
   fi
 

--- a/scripts/generate-mount-persistence.sh
+++ b/scripts/generate-mount-persistence.sh
@@ -248,11 +248,7 @@ while IFS="$(printf '\t')" read -r SRC TGT FST; do
       if [ "$TGT_FSTAB" = "/" ]; then
         DUMP_PASS="1 1"
       else
-        # Skip boot-time fsck on secondary ext filesystems. On sysvinit (e.g.
-        # SLES 11 / openSUSE 11) the fsck step cannot resolve a UUID for a
-        # not-yet-attached Cinder disk and drops the system to a maintenance
-        # shell. Runtime fsck on mount still works when needed.
-        DUMP_PASS="0 0"
+        DUMP_PASS="0 2"
       fi
       ;;
     *)
@@ -287,28 +283,11 @@ if $APPLY; then
 
   cp "$FSTAB_PATH" "$FSTAB_PATH.bak.$(date +%s)"
 
-  # Marker comment so post-migration inspection can tell at a glance whether
-  # this script actually ran against the guest's fstab. Grep for:
-  #   grep 'vJailbreak mount-persistence' /etc/fstab
-  if $FORCE_UUID; then
-    MARKER_MODE="force-uuid"
-  elif $REPLACE_FSTAB; then
-    MARKER_MODE="replace-fstab"
-  else
-    MARKER_MODE="apply"
-  fi
-  MARKER_TS=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date)
-  MARKER_LINE="# vJailbreak mount-persistence: ran at ${MARKER_TS} mode=${MARKER_MODE}"
-
   if $REPLACE_FSTAB; then
     echo "Replacing existing fstab entries for detected mounts and swap..."
     tmp_fstab=$(mktemp)
 
     while IFS= read -r line; do
-      # Strip any prior vJailbreak marker so reruns don't accumulate headers.
-      case "$line" in
-        "# vJailbreak mount-persistence:"*) continue ;;
-      esac
       skip=false
       while IFS= read -r entry; do
         mp=$(echo "$entry" | awk '{print $2}')
@@ -319,13 +298,11 @@ if $APPLY; then
       $skip || echo "$line" >> "$tmp_fstab"
     done < "$FSTAB_PATH"
 
-    # Append marker and new entries (already in UUID format from get_fstab_id)
-    echo "$MARKER_LINE" >> "$tmp_fstab"
+    # Append new entries (already in UUID format from get_fstab_id)
     cat "$FSTAB_LINES_FILE" >> "$tmp_fstab"
 
     mv "$tmp_fstab" "$FSTAB_PATH"
   else
-    echo "$MARKER_LINE" >> "$FSTAB_PATH"
     cat "$FSTAB_LINES_FILE" >> "$FSTAB_PATH"
   fi
 

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -847,6 +847,24 @@ func (osclient *OpenStackClients) CreateVM(ctx context.Context, flavor *flavors.
 	}
 
 	serverCreateOpts.BlockDevice = blockDevices
+	for idx, disk := range vminfo.VMDisks {
+		// Skip boot disk
+		if idx == bootableDiskIndex {
+			continue
+		}
+		// Skip ESP disk if it was attached at create time (UEFI multi-disk layout)
+		if vminfo.UEFI && espDiskIndex >= 0 && idx == espDiskIndex && espDiskIndex != bootableDiskIndex {
+			continue
+		}
+
+		serverCreateOpts.BlockDevice = append(serverCreateOpts.BlockDevice, servers.BlockDevice{
+			DeleteOnTermination: false,
+			DestinationType:     servers.DestinationVolume,
+			SourceType:          servers.SourceVolume,
+			UUID:                disk.OpenstackVol.ID,
+			BootIndex:           -1,
+		})
+	}
 
 	// Prepare scheduler hints for server group if specified
 	var schedulerHints servers.SchedulerHintOptsBuilder
@@ -902,27 +920,9 @@ func (osclient *OpenStackClients) CreateVM(ctx context.Context, flavor *flavors.
 		time.Sleep(time.Duration(vjailbreakSettings.VMActiveWaitIntervalSeconds) * time.Second)
 	}
 
-	PrintLog(fmt.Sprintf("Server created with ID: %s, Attaching Additional Disks", server.ID))
+	// PrintLog(fmt.Sprintf("Server created with ID: %s, Attaching Additional Disks", server.ID))
 
 	// Build list of disks to hot-attach (exclude boot disk and ESP disk if already attached)
-	for idx, disk := range vminfo.VMDisks {
-		// Skip boot disk
-		if idx == bootableDiskIndex {
-			continue
-		}
-		// Skip ESP disk if it was attached at create time (UEFI multi-disk layout)
-		if vminfo.UEFI && espDiskIndex >= 0 && idx == espDiskIndex && espDiskIndex != bootableDiskIndex {
-			continue
-		}
-
-		_, err := volumeattach.Create(ctx, osclient.ComputeClient, server.ID, volumeattach.CreateOpts{
-			VolumeID:            disk.OpenstackVol.ID,
-			DeleteOnTermination: false,
-		}).Extract()
-		if err != nil {
-			return nil, fmt.Errorf("failed to attach volume to VM: %s", err)
-		}
-	}
 
 	return server, nil
 }


### PR DESCRIPTION
## What this PR does / why we need it

Implemented robust boot-time disk detection mechanism for Linux, ensuring backward compatibility with older kernels that lack hot-plug disk support.

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1792

## Special notes for your reviewer


## Testing done

### Disks post migration 
<img width="854" height="647" alt="image" src="https://github.com/user-attachments/assets/1a422b6e-e51c-48fb-a9aa-ebc601eab4c1" />
