### PR TITLE
fix - dirty disk post migration windows 

### DIFF
--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -920,10 +920,6 @@ func (osclient *OpenStackClients) CreateVM(ctx context.Context, flavor *flavors.
 		time.Sleep(time.Duration(vjailbreakSettings.VMActiveWaitIntervalSeconds) * time.Second)
 	}
 
-	// PrintLog(fmt.Sprintf("Server created with ID: %s, Attaching Additional Disks", server.ID))
-
-	// Build list of disks to hot-attach (exclude boot disk and ESP disk if already attached)
-
 	return server, nil
 }
 

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -294,12 +294,14 @@ func NTFSFix(path string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get partitions: %w", err)
 	}
+	// add arguments to ensure no dirty disk post migration
+	args := []string{"--clear-dirty"}
 	log.Printf("Partitions: %v", partitions)
 	for _, partition := range partitions {
 		if partition == path {
 			continue
 		}
-		cmd := exec.Command("ntfsfix", partition)
+		cmd := exec.Command("ntfsfix", append(args, partition)...)
 		log.Printf("Executing %s", cmd.String())
 
 		// Use the debug logging with proper file cleanup


### PR DESCRIPTION
## What this PR does / why we need it

Earlier windows vm post migration the C drive in windows VMs was marked as dirty, In this PR the disk has been fixed so ensuring no such dirty disks post migration

fixes #1855 

## Testing done

<img width="1066" height="617" alt="image" src="https://github.com/user-attachments/assets/7cf37fa2-ece9-45b2-9e12-4f5372ea7ee0" />