### PR TITLE
Remove L2 instance ID from UI and backend

### DIFF
--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -1754,10 +1754,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              vjbinstanceid:
-                description: VJBInstanceID is the ID of current vjailbreak instance
-                  (needed if metadata service is not available)
-                type: string
             type: object
           status:
             description: OpenstackCredsStatus defines the observed state of OpenstackCreds

--- a/deploy/05controller-deployment.yaml
+++ b/deploy/05controller-deployment.yaml
@@ -75,6 +75,9 @@ spec:
         - mountPath: /etc/hosts
           name: hosts-file
           readOnly: true
+        - mountPath: /host/dmi/product_uuid
+          name: dmi-product-uuid
+          readOnly: true
       dnsConfig:
         options:
         - name: ndots
@@ -99,4 +102,8 @@ spec:
           path: /etc/hosts
           type: File
         name: hosts-file
+      - hostPath:
+          path: /sys/class/dmi/id/product_uuid
+          type: File
+        name: dmi-product-uuid
 ---

--- a/deploy/installer.yaml
+++ b/deploy/installer.yaml
@@ -1754,10 +1754,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              vjbinstanceid:
-                description: VJBInstanceID is the ID of current vjailbreak instance
-                  (needed if metadata service is not available)
-                type: string
             type: object
           status:
             description: OpenstackCredsStatus defines the observed state of OpenstackCreds
@@ -4630,6 +4626,9 @@ spec:
         - mountPath: /etc/hosts
           name: hosts-file
           readOnly: true
+        - mountPath: /host/dmi/product_uuid
+          name: dmi-product-uuid
+          readOnly: true
       dnsConfig:
         options:
         - name: ndots
@@ -4654,6 +4653,10 @@ spec:
           path: /etc/hosts
           type: File
         name: hosts-file
+      - hostPath:
+          path: /sys/class/dmi/id/product_uuid
+          type: File
+        name: dmi-product-uuid
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/k8s/migration/api/v1alpha1/openstackcreds_types.go
+++ b/k8s/migration/api/v1alpha1/openstackcreds_types.go
@@ -53,8 +53,6 @@ type OpenStackCredsInfo struct {
 	Insecure bool
 	// DomainName is the OpenStack domain
 	DomainName string
-	// VJBInstanceID is the VJB instance ID (optional, used for VJB instances)
-	VJBInstanceID string
 }
 
 // SecurityGroupInfo holds the security group name and ID
@@ -122,9 +120,6 @@ type OpenstackCredsSpec struct {
 
 	// ProjectName is the name of the project in openstack
 	ProjectName string `json:"projectName,omitempty"`
-
-	// VJBInstanceID is the ID of current vjailbreak instance (needed if metadata service is not available)
-	VJBInstanceID string `json:"vjbinstanceid,omitempty"`
 }
 
 // OpenstackCredsStatus defines the observed state of OpenstackCreds

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_openstackcreds.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_openstackcreds.yaml
@@ -210,10 +210,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              vjbinstanceid:
-                description: VJBInstanceID is the ID of current vjailbreak instance
-                  (needed if metadata service is not available)
-                type: string
             type: object
           status:
             description: OpenstackCredsStatus defines the observed state of OpenstackCreds

--- a/k8s/migration/config/manager/manager.yaml
+++ b/k8s/migration/config/manager/manager.yaml
@@ -100,10 +100,16 @@ spec:
         volumeMounts:
         - mountPath: /etc/pf9/k3s
           name: master-token
-        - mountPath: /home/ubuntu                                 
+        - mountPath: /home/ubuntu
           name: vddk
         - mountPath: /etc/hosts
           name: hosts-file
+          readOnly: true
+        # Master-only: expose the host's DMI product_uuid so the master can
+        # discover its OpenStack instance UUID without depending on the
+        # (sometimes flaky) metadata service. Used by CheckAndCreateMasterNodeEntry.
+        - mountPath: /host/dmi/product_uuid
+          name: dmi-product-uuid
           readOnly: true
       serviceAccountName: controller-manager
       volumes:
@@ -112,11 +118,15 @@ spec:
           path: /var/lib/rancher/k3s/server
           type: Directory
       - name: vddk
-        hostPath:                                                                 
-          path: /home/ubuntu                                                      
+        hostPath:
+          path: /home/ubuntu
           type: Directory
       - name: hosts-file
         hostPath:
           path: /etc/hosts
-          type: File                                                      
+          type: File
+      - name: dmi-product-uuid
+        hostPath:
+          path: /sys/class/dmi/id/product_uuid
+          type: File
       terminationGracePeriodSeconds: 30

--- a/k8s/migration/internal/controller/openstackcreds_controller.go
+++ b/k8s/migration/internal/controller/openstackcreds_controller.go
@@ -515,12 +515,6 @@ func handleValidatedCreds(ctx context.Context, r *OpenstackCredsReconciler, scop
 
 func setupMasterNode(ctx context.Context, r *OpenstackCredsReconciler, scope *scope.OpenstackCredsScope) error {
 	ctxlog := scope.Logger
-	if scope.OpenstackCreds.Spec.VJBInstanceID != "" {
-		err := utils.CheckAndCreateMasterNodeEntry(ctx, r.Client, false, scope.OpenstackCreds.Spec.VJBInstanceID)
-		if err != nil {
-			return errors.Wrap(err, "failed to check and create master node entry")
-		}
-	}
 	err := utils.UpdateMasterNodeImageID(ctx, r.Client, r.Local)
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {

--- a/k8s/migration/internal/controller/openstackcreds_controller.go
+++ b/k8s/migration/internal/controller/openstackcreds_controller.go
@@ -481,10 +481,6 @@ func (r *OpenstackCredsReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func handleValidatedCreds(ctx context.Context, r *OpenstackCredsReconciler, scope *scope.OpenstackCredsScope) error {
-	if err := setupMasterNode(ctx, r, scope); err != nil {
-		return err
-	}
-
 	if err := createDummyPCDCluster(ctx, r, scope); err != nil {
 		return err
 	}
@@ -510,20 +506,6 @@ func handleValidatedCreds(ctx context.Context, r *OpenstackCredsReconciler, scop
 		return err
 	}
 
-	return nil
-}
-
-func setupMasterNode(ctx context.Context, r *OpenstackCredsReconciler, scope *scope.OpenstackCredsScope) error {
-	ctxlog := scope.Logger
-	err := utils.UpdateMasterNodeImageID(ctx, r.Client, r.Local)
-	if err != nil {
-		if strings.Contains(err.Error(), "404") {
-			ctxlog.Error(err, "Failed to update master node image ID and flavor list, skipping reconciliation")
-		} else {
-			return errors.Wrap(err, "failed to update master node image id")
-		}
-		ctxlog.Error(err, "Failed to update master node image ID and flavor list")
-	}
 	return nil
 }
 

--- a/k8s/migration/internal/controller/openstackcreds_controller.go
+++ b/k8s/migration/internal/controller/openstackcreds_controller.go
@@ -481,6 +481,10 @@ func (r *OpenstackCredsReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func handleValidatedCreds(ctx context.Context, r *OpenstackCredsReconciler, scope *scope.OpenstackCredsScope) error {
+	if err := setupMasterNode(ctx, r, scope); err != nil {
+		return err
+	}
+
 	if err := createDummyPCDCluster(ctx, r, scope); err != nil {
 		return err
 	}
@@ -506,6 +510,20 @@ func handleValidatedCreds(ctx context.Context, r *OpenstackCredsReconciler, scop
 		return err
 	}
 
+	return nil
+}
+
+func setupMasterNode(ctx context.Context, r *OpenstackCredsReconciler, scope *scope.OpenstackCredsScope) error {
+	ctxlog := scope.Logger
+	err := utils.UpdateMasterNodeImageID(ctx, r.Client, r.Local)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			ctxlog.Error(err, "Failed to update master node image ID and flavor list, skipping reconciliation")
+		} else {
+			return errors.Wrap(err, "failed to update master node image id")
+		}
+		ctxlog.Error(err, "Failed to update master node image ID and flavor list")
+	}
 	return nil
 }
 

--- a/k8s/migration/internal/controller/vjailbreaknode_controller.go
+++ b/k8s/migration/internal/controller/vjailbreaknode_controller.go
@@ -102,11 +102,17 @@ func (r *VjailbreakNodeReconciler) reconcileNormal(ctx context.Context,
 	controllerutil.AddFinalizer(vjNode, constants.VjailbreakNodeFinalizer)
 
 	if vjNode.Spec.NodeRole == constants.NodeRoleMaster {
+		if vjNode.Status.OpenstackUUID == "" {
+			if err := utils.CheckAndCreateMasterNodeEntry(ctx, r.Client, r.Local, ""); err != nil {
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, errors.Wrap(err, "failed to resolve master node uuid")
+			}
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
 		err := utils.UpdateMasterNodeImageID(ctx, r.Client, r.Local)
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, errors.Wrap(err, "failed to update master node image id")
 		}
-		log.Info("Skipping master node, updating flavor", "name", vjNode.Name)
+		log.Info("Updated master node image and flavor", "name", vjNode.Name)
 		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 	}
 

--- a/k8s/migration/internal/controller/vjailbreaknode_controller.go
+++ b/k8s/migration/internal/controller/vjailbreaknode_controller.go
@@ -83,7 +83,8 @@ func (r *VjailbreakNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Quick path for just updating ActiveMigrations if node is ready
 	if vjailbreakNode.Status.Phase == constants.VjailbreakNodePhaseNodeReady {
-		return ctrl.Result{}, errors.Wrap(err, "Already in ready state so we are quiting.")
+		log.Info("************ Node is ready, exit*************")
+		return r.updateActiveMigrations(ctx, vjailbreakNodeScope)
 	}
 
 	// Handle regular VjailbreakNode reconcile

--- a/k8s/migration/internal/controller/vjailbreaknode_controller.go
+++ b/k8s/migration/internal/controller/vjailbreaknode_controller.go
@@ -83,7 +83,6 @@ func (r *VjailbreakNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Quick path for just updating ActiveMigrations if node is ready
 	if vjailbreakNode.Status.Phase == constants.VjailbreakNodePhaseNodeReady {
-		log.Info("************ Node is ready, exit*************")
 		return r.updateActiveMigrations(ctx, vjailbreakNodeScope)
 	}
 
@@ -107,7 +106,6 @@ func (r *VjailbreakNodeReconciler) reconcileNormal(ctx context.Context,
 			if err := utils.CheckAndCreateMasterNodeEntry(ctx, r.Client, r.Local, ""); err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, errors.Wrap(err, "failed to resolve master node uuid")
 			}
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 		err := utils.UpdateMasterNodeImageID(ctx, r.Client, r.Local)
 		if err != nil {

--- a/k8s/migration/internal/controller/vjailbreaknode_controller.go
+++ b/k8s/migration/internal/controller/vjailbreaknode_controller.go
@@ -83,7 +83,7 @@ func (r *VjailbreakNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Quick path for just updating ActiveMigrations if node is ready
 	if vjailbreakNode.Status.Phase == constants.VjailbreakNodePhaseNodeReady {
-		return r.updateActiveMigrations(ctx, vjailbreakNodeScope)
+		return ctrl.Result{}, errors.Wrap(err, "Already in ready state so we are quiting.")
 	}
 
 	// Handle regular VjailbreakNode reconcile

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -406,7 +406,6 @@ func ValidateAndGetProviderClient(ctx context.Context, k3sclient client.Client,
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get openstack credentials from secret")
 	}
-	openstackCredential.VJBInstanceID = openstackcreds.Spec.VJBInstanceID
 
 	providerClient, err := openstack.NewClient(openstackCredential.AuthURL)
 	if err != nil {
@@ -455,10 +454,6 @@ func ValidateAndGetProviderClient(ctx context.Context, k3sclient client.Client,
 		default:
 			return nil, fmt.Errorf("authentication failed: %w. Please verify your OpenStack credentials", err)
 		}
-	}
-
-	if openstackCredential.VJBInstanceID != "" {
-		return providerClient, nil
 	}
 
 	_, err = VerifyCredentialsMatchCurrentEnvironment(providerClient, openstackCredential.RegionName)

--- a/k8s/migration/pkg/utils/metadata_utils.go
+++ b/k8s/migration/pkg/utils/metadata_utils.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +17,29 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	"github.com/pkg/errors"
 )
+
+// dmiProductUUIDPath is the in-pod mount path for the host's
+// /sys/class/dmi/id/product_uuid (exposed via hostPath in the controller
+// deployment). Used only by the master node — see GetMasterInstanceUUIDFromDMI.
+const dmiProductUUIDPath = "/host/dmi/product_uuid"
+
+// GetMasterInstanceUUIDFromDMI reads the SMBIOS/DMI product UUID exposed by
+// the hypervisor via /sys/class/dmi/id/product_uuid and returns it as a
+// lower-cased UUID string.
+// This is intended ONLY for the master VjailbreakNode. On a Nova/KVM-backed
+// Callers should treat any error here as "not available" and fall back to the
+// existing metadata-service path.
+func GetMasterInstanceUUIDFromDMI() (string, error) {
+	data, err := os.ReadFile(dmiProductUUIDPath)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read DMI product_uuid")
+	}
+	uuid := strings.ToLower(strings.TrimSpace(string(data)))
+	if uuid == "" {
+		return "", errors.New("DMI product_uuid file is empty")
+	}
+	return uuid, nil
+}
 
 // InstanceMetadata contains metadata about the current instance.
 type InstanceMetadata struct {

--- a/k8s/migration/pkg/utils/metadata_utils.go
+++ b/k8s/migration/pkg/utils/metadata_utils.go
@@ -23,6 +23,10 @@ import (
 // deployment). Used only by the master node — see GetMasterInstanceUUIDFromDMI.
 const dmiProductUUIDPath = "/host/dmi/product_uuid"
 
+// metadataServiceURL is the OpenStack metadata service endpoint used as the
+// fallback path when DMI is unavailable.
+const metadataServiceURL = "http://169.254.169.254/openstack/latest/meta_data.json"
+
 // GetMasterInstanceUUIDFromDMI reads the SMBIOS/DMI product UUID exposed by
 // the hypervisor via /sys/class/dmi/id/product_uuid and returns it as a
 // lower-cased UUID string.
@@ -32,11 +36,23 @@ const dmiProductUUIDPath = "/host/dmi/product_uuid"
 func GetMasterInstanceUUIDFromDMI() (string, error) {
 	data, err := os.ReadFile(dmiProductUUIDPath)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to read DMI product_uuid")
+		if os.IsNotExist(err) {
+			return "", errors.Wrapf(err, "DMI product_uuid not found at %s "+
+				"(controller pod likely missing the hostPath mount — check the "+
+				"'dmi-product-uuid' volume in deploy/05controller-deployment.yaml)",
+				dmiProductUUIDPath)
+		}
+		if os.IsPermission(err) {
+			return "", errors.Wrapf(err, "DMI product_uuid at %s is not readable "+
+				"(check pod securityContext / host file permissions)",
+				dmiProductUUIDPath)
+		}
+		return "", errors.Wrapf(err, "failed to read DMI product_uuid at %s", dmiProductUUIDPath)
 	}
 	uuid := strings.ToLower(strings.TrimSpace(string(data)))
 	if uuid == "" {
-		return "", errors.New("DMI product_uuid file is empty")
+		return "", errors.Errorf("DMI product_uuid file %s is empty "+
+			"(host hypervisor did not expose a SMBIOS UUID)", dmiProductUUIDPath)
 	}
 	return uuid, nil
 }
@@ -51,15 +67,21 @@ func GetMasterInstanceUUIDFromDMI() (string, error) {
 // instance UUID. Worker nodes (v2v-helper pods) do not have the DMI
 // hostPath mount and must continue using their own GetCurrentInstanceUUID.
 func GetMasterInstanceUUID() (string, error) {
-	if uuid, err := GetMasterInstanceUUIDFromDMI(); err == nil && uuid != "" {
+	uuid, dmiErr := GetMasterInstanceUUIDFromDMI()
+	if dmiErr == nil && uuid != "" {
+		log.Printf("[INFO] master instance UUID resolved via DMI (%s): %s", dmiProductUUIDPath, uuid)
 		return uuid, nil
-	} else if err != nil {
-		log.Printf("[INFO] DMI-based master UUID lookup unavailable, falling back to metadata service: %v", err)
 	}
+	log.Printf("[WARN] DMI-based master UUID lookup failed, falling back to OpenStack metadata service at %s: %v",
+		metadataServiceURL, dmiErr)
+
 	metadata, err := GetCurrentInstanceMetadata()
 	if err != nil {
-		return "", err
+		return "", errors.Wrapf(err,
+			"could not resolve master instance UUID via DMI or metadata service "+
+				"(DMI error: %v)", dmiErr)
 	}
+	log.Printf("[INFO] master instance UUID resolved via metadata service: %s", metadata.UUID)
 	return metadata.UUID, nil
 }
 
@@ -105,15 +127,18 @@ func GetCurrentInstanceMetadata() (*InstanceMetadata, error) {
 
 	// Step 4: Fetch metadata from the OpenStack metadata service
 
+	log.Printf("[INFO] fetching instance metadata from %s", metadataServiceURL)
 	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest("GET", "http://169.254.169.254/openstack/latest/meta_data.json", nil)
+	req, err := http.NewRequest("GET", metadataServiceURL, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create metadata request")
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch instance metadata")
+		return nil, errors.Wrapf(err, "failed to fetch instance metadata from %s "+
+			"(metadata service unreachable — common on L2-only networks or when "+
+			"169.254.169.254 routing is not configured)", metadataServiceURL)
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {

--- a/k8s/migration/pkg/utils/metadata_utils.go
+++ b/k8s/migration/pkg/utils/metadata_utils.go
@@ -41,6 +41,28 @@ func GetMasterInstanceUUIDFromDMI() (string, error) {
 	return uuid, nil
 }
 
+// GetMasterInstanceUUID returns the OpenStack instance UUID for the master
+// node (the node running the controller). It prefers the SMBIOS/DMI
+// product UUID exposed via the controller pod's hostPath mount (no network
+// dependency, works even when the OpenStack metadata service is disabled)
+// and falls back to the metadata service only if DMI is unavailable.
+//
+// Use this on the master node anywhere we need the controller's own
+// instance UUID. Worker nodes (v2v-helper pods) do not have the DMI
+// hostPath mount and must continue using their own GetCurrentInstanceUUID.
+func GetMasterInstanceUUID() (string, error) {
+	if uuid, err := GetMasterInstanceUUIDFromDMI(); err == nil && uuid != "" {
+		return uuid, nil
+	} else if err != nil {
+		log.Printf("[INFO] DMI-based master UUID lookup unavailable, falling back to metadata service: %v", err)
+	}
+	metadata, err := GetCurrentInstanceMetadata()
+	if err != nil {
+		return "", err
+	}
+	return metadata.UUID, nil
+}
+
 // InstanceMetadata contains metadata about the current instance.
 type InstanceMetadata struct {
 	UUID string `json:"uuid"`
@@ -124,11 +146,10 @@ func GetCurrentInstanceMetadata() (*InstanceMetadata, error) {
 
 // VerifyCredentialsMatchCurrentEnvironment checks if the provided credentials can access the current instance
 func VerifyCredentialsMatchCurrentEnvironment(providerClient *gophercloud.ProviderClient, regionName string) (bool, error) {
-	// Get current instance metadata
-	metadata, err := GetCurrentInstanceMetadata()
+	uuid, err := GetMasterInstanceUUID()
 	if err != nil {
-		return false, fmt.Errorf("unable to get current instance metadata: %w. "+
-			"Please ensure this is running on an OpenStack instance with metadata service enabled", err)
+		return false, fmt.Errorf("unable to resolve master instance UUID via DMI or metadata service: %w. "+
+			"Ensure the controller pod has /host/dmi/product_uuid mounted, or that the OpenStack metadata service is reachable", err)
 	}
 
 	computeClient, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{
@@ -138,7 +159,7 @@ func VerifyCredentialsMatchCurrentEnvironment(providerClient *gophercloud.Provid
 	if err != nil {
 		return false, fmt.Errorf("failed to create OpenStack compute client: %w", err)
 	}
-	_, err = servers.Get(context.TODO(), computeClient, metadata.UUID).Extract()
+	_, err = servers.Get(context.TODO(), computeClient, uuid).Extract()
 	if err != nil {
 		if strings.Contains(err.Error(), "Resource not found") ||
 			strings.Contains(err.Error(), "No server with a name or ID") {

--- a/k8s/migration/pkg/utils/vjailbreaknodeutils.go
+++ b/k8s/migration/pkg/utils/vjailbreaknodeutils.go
@@ -71,19 +71,23 @@ func CheckAndCreateMasterNodeEntry(ctx context.Context, k3sclient client.Client,
 			Spec: vjailbreakv1alpha1.VjailbreakNodeSpec{
 				NodeRole: constants.NodeRoleMaster,
 			},
+			Status: vjailbreakv1alpha1.VjailbreakNodeStatus{
+				OpenstackUUID: openstackuuid,
+			},
 		}
 
 		err = k3sclient.Create(ctx, &vjNode)
-		if err != nil && !apierrors.IsAlreadyExists(err) {
-			return errors.Wrap(err, "failed to create vjailbreak node")
-		}
-
-		err = k3sclient.Get(ctx, types.NamespacedName{
-			Namespace: constants.NamespaceMigrationSystem,
-			Name:      constants.VjailbreakMasterNodeName,
-		}, &vjNode)
 		if err != nil {
-			return errors.Wrap(err, "failed to get vjailbreak node")
+			if !apierrors.IsAlreadyExists(err) {
+				return errors.Wrap(err, "failed to create vjailbreak node")
+			}
+			// Another process already created it; fetch the existing object to get its ResourceVersion.
+			if err = k3sclient.Get(ctx, types.NamespacedName{
+				Namespace: constants.NamespaceMigrationSystem,
+				Name:      constants.VjailbreakMasterNodeName,
+			}, &vjNode); err != nil {
+				return errors.Wrap(err, "failed to get vjailbreak node")
+			}
 		}
 	}
 	vmIP := GetNodeInternalIP(masterNode)

--- a/k8s/migration/pkg/utils/vjailbreaknodeutils.go
+++ b/k8s/migration/pkg/utils/vjailbreaknodeutils.go
@@ -55,10 +55,19 @@ func CheckAndCreateMasterNodeEntry(ctx context.Context, k3sclient client.Client,
 			// Local mode
 			openstackuuid = "fake-openstackuuid"
 		} else {
-			// Controller manager is always on the master node due to pod affinity
-			openstackuuid, err = utils.GetCurrentInstanceUUID()
-			if err != nil {
-				return errors.Wrap(err, "failed to get current instance uuid")
+			// Controller manager is always on the master node due to pod affinity.
+			// Try DMI (no network, no creds) first; if unavailable, fall back to
+			// the existing pod-name / metadata-service helper.
+			if dmiUUID, dmiErr := GetMasterInstanceUUIDFromDMI(); dmiErr == nil && dmiUUID != "" {
+				openstackuuid = dmiUUID
+			} else {
+				if dmiErr != nil {
+					fmt.Printf("[INFO] DMI-based master UUID lookup unavailable, falling back to metadata service: %v\n", dmiErr)
+				}
+				openstackuuid, err = utils.GetCurrentInstanceUUID()
+				if err != nil {
+					return errors.Wrap(err, "failed to get current instance uuid")
+				}
 			}
 		}
 	}
@@ -241,8 +250,11 @@ func CreateOpenstackVMForWorkerNode(ctx context.Context, k3sclient client.Client
 
 	var networkIDs []servers.Network
 	var masterSecurityGroups []string
-	if creds.Spec.VJBInstanceID != "" {
-		networkIDs, masterSecurityGroups, err = GetInstanceNetworkInfoByID(ctx, openstackClients, creds.Spec.VJBInstanceID)
+	// Prefer the master VjailbreakNode's UUID (resolved via DMI / metadata at
+	// startup) so we can query Neutron directly. Fall back to the metadata
+	// service only if the master UUID hasn't been populated yet.
+	if masterVjNode.Status.OpenstackUUID != "" {
+		networkIDs, masterSecurityGroups, err = GetInstanceNetworkInfoByID(ctx, openstackClients, masterVjNode.Status.OpenstackUUID)
 		if err != nil {
 			return "", errors.Wrap(err, "failed to get network info")
 		}
@@ -677,19 +689,12 @@ func GetOpenstackVMStatus(ctx context.Context, k3sclient client.Client, vjNode *
 
 // GetFlavorIDFromVM retrieves the flavor ID from a virtual machine using its UUID
 func GetFlavorIDFromVM(ctx context.Context, k3sclient client.Client, uuid string, openstackcreds *vjailbreakv1alpha1.OpenstackCreds) (string, error) {
+	if uuid == "" {
+		return "", fmt.Errorf("instance UUID is required to look up flavor")
+	}
 	openstackClients, err := GetOpenStackClients(ctx, k3sclient, openstackcreds)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get openstack clients")
-	}
-
-	openstackCredential, err := GetOpenstackCredentialsFromSecret(ctx, k3sclient, openstackcreds.Spec.SecretRef.Name)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to get openstack credentials from secret")
-	}
-
-	if uuid == "" {
-		// if uuid is not provided, assume this is L2 network and use the VJB instance ID from the secret
-		uuid = openstackCredential.VJBInstanceID
 	}
 
 	// Fetch the VM details
@@ -706,19 +711,12 @@ func GetFlavorIDFromVM(ctx context.Context, k3sclient client.Client, uuid string
 
 // GetImageIDFromVM retrieves the image ID from a virtual machine using its UUID
 func GetImageIDFromVM(ctx context.Context, k3sclient client.Client, uuid string, openstackcreds *vjailbreakv1alpha1.OpenstackCreds) (string, error) {
+	if uuid == "" {
+		return "", fmt.Errorf("instance UUID is required to look up image")
+	}
 	openstackClients, err := GetOpenStackClients(ctx, k3sclient, openstackcreds)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get openstack clients")
-	}
-
-	openstackCredential, err := GetOpenstackCredentialsFromSecret(ctx, k3sclient, openstackcreds.Spec.SecretRef.Name)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to get openstack credentials from secret")
-	}
-
-	if uuid == "" {
-		// if uuid is not provided, assume this is L2 network and use the VJB instance ID from the secret
-		uuid = openstackCredential.VJBInstanceID
 	}
 
 	// Fetch the VM details

--- a/k8s/migration/pkg/utils/vjailbreaknodeutils.go
+++ b/k8s/migration/pkg/utils/vjailbreaknodeutils.go
@@ -24,7 +24,6 @@ import (
 	k8scommon "github.com/platform9/vjailbreak/pkg/common/k8s"
 	openstackpkg "github.com/platform9/vjailbreak/pkg/common/openstack"
 	commonutils "github.com/platform9/vjailbreak/pkg/common/utils"
-	"github.com/platform9/vjailbreak/v2v-helper/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,18 +55,11 @@ func CheckAndCreateMasterNodeEntry(ctx context.Context, k3sclient client.Client,
 			openstackuuid = "fake-openstackuuid"
 		} else {
 			// Controller manager is always on the master node due to pod affinity.
-			// Try DMI (no network, no creds) first; if unavailable, fall back to
-			// the existing pod-name / metadata-service helper.
-			if dmiUUID, dmiErr := GetMasterInstanceUUIDFromDMI(); dmiErr == nil && dmiUUID != "" {
-				openstackuuid = dmiUUID
-			} else {
-				if dmiErr != nil {
-					fmt.Printf("[INFO] DMI-based master UUID lookup unavailable, falling back to metadata service: %v\n", dmiErr)
-				}
-				openstackuuid, err = utils.GetCurrentInstanceUUID()
-				if err != nil {
-					return errors.Wrap(err, "failed to get current instance uuid")
-				}
+			// GetMasterInstanceUUID tries DMI first (no network) then falls back
+			// to the metadata service.
+			openstackuuid, err = GetMasterInstanceUUID()
+			if err != nil {
+				return errors.Wrap(err, "failed to get current instance uuid")
 			}
 		}
 	}

--- a/k8s/migration/pkg/utils/vjailbreaknodeutils.go
+++ b/k8s/migration/pkg/utils/vjailbreaknodeutils.go
@@ -28,7 +28,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -55,9 +54,7 @@ func CheckAndCreateMasterNodeEntry(ctx context.Context, k3sclient client.Client,
 			// Local mode
 			openstackuuid = "fake-openstackuuid"
 		} else {
-			// Controller manager is always on the master node due to pod affinity.
-			// GetMasterInstanceUUID tries DMI first (no network) then falls back
-			// to the metadata service.
+			// Controller manager is always on the master node due to pod affinity
 			openstackuuid, err = GetMasterInstanceUUID()
 			if err != nil {
 				return errors.Wrap(err, "failed to get current instance uuid")
@@ -80,33 +77,28 @@ func CheckAndCreateMasterNodeEntry(ctx context.Context, k3sclient client.Client,
 		if err != nil && !apierrors.IsAlreadyExists(err) {
 			return errors.Wrap(err, "failed to create vjailbreak node")
 		}
-	}
 
-	vmIP := GetNodeInternalIP(masterNode)
-
-	// DMI returns the UUID synchronously in microseconds, so the window between
-	// Create and Status().Update is much tighter than with the metadata-service
-	// path — tight enough to race the VjailbreakNode reconciler that wakes up
-	// on the Create event and bumps resourceVersion. Retry on conflict, re-Get
-	// the latest object each attempt.
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := k3sclient.Get(ctx, types.NamespacedName{
+		err = k3sclient.Get(ctx, types.NamespacedName{
 			Namespace: constants.NamespaceMigrationSystem,
 			Name:      constants.VjailbreakMasterNodeName,
-		}, &vjNode); err != nil {
+		}, &vjNode)
+		if err != nil {
 			return errors.Wrap(err, "failed to get vjailbreak node")
 		}
-		if vmIP != "" {
-			vjNode.Status.VMIP = vmIP
-		}
-		vjNode.Status.Phase = constants.VjailbreakNodePhaseNodeReady
-		vjNode.Status.OpenstackUUID = openstackuuid
+	}
+	vmIP := GetNodeInternalIP(masterNode)
+	if vmIP != "" {
+		vjNode.Status.VMIP = vmIP
+	}
+	vjNode.Status.Phase = constants.VjailbreakNodePhaseNodeReady
+	vjNode.Status.OpenstackUUID = openstackuuid
 
-		if err := k3sclient.Status().Update(ctx, &vjNode); err != nil {
-			return errors.Wrap(err, "failed to update vjailbreak node status")
-		}
-		return nil
-	})
+	err = k3sclient.Status().Update(ctx, &vjNode)
+	if err != nil {
+		return errors.Wrap(err, "failed to update vjailbreak node status")
+	}
+
+	return nil
 }
 
 // UpdateMasterNodeImageID updates the image ID and flavor ID of the master node

--- a/k8s/migration/pkg/utils/vjailbreaknodeutils.go
+++ b/k8s/migration/pkg/utils/vjailbreaknodeutils.go
@@ -28,6 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -39,14 +40,10 @@ func CheckAndCreateMasterNodeEntry(ctx context.Context, k3sclient client.Client,
 	}
 
 	vjNode := vjailbreakv1alpha1.VjailbreakNode{}
-	nodeExists := false
 	err = k3sclient.Get(ctx, client.ObjectKey{Name: constants.VjailbreakMasterNodeName}, &vjNode)
-	if err == nil {
-		nodeExists = true
+	if err == nil && vjNode.Status.OpenstackUUID != "" {
 		// VjailbreakNode already exists with OpenstackUUID set
-		if vjNode.Status.OpenstackUUID != "" {
-			return nil
-		}
+		return nil
 	}
 
 	if openstackuuid == "" {
@@ -64,8 +61,8 @@ func CheckAndCreateMasterNodeEntry(ctx context.Context, k3sclient client.Client,
 		}
 	}
 
-	if !nodeExists {
-		vjNode = vjailbreakv1alpha1.VjailbreakNode{
+	if apierrors.IsNotFound(err) {
+		newNode := vjailbreakv1alpha1.VjailbreakNode{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      constants.VjailbreakMasterNodeName,
 				Namespace: constants.NamespaceMigrationSystem,
@@ -74,33 +71,35 @@ func CheckAndCreateMasterNodeEntry(ctx context.Context, k3sclient client.Client,
 				NodeRole: constants.NodeRoleMaster,
 			},
 		}
-
-		err = k3sclient.Create(ctx, &vjNode)
-		if err != nil && !apierrors.IsAlreadyExists(err) {
+		if err = k3sclient.Create(ctx, &newNode); err != nil && !apierrors.IsAlreadyExists(err) {
 			return errors.Wrap(err, "failed to create vjailbreak node")
 		}
+	}
 
-		err = k3sclient.Get(ctx, types.NamespacedName{
+	vmIP := GetNodeInternalIP(masterNode)
+
+	// Re-Get and Status().Update under retry — the VjailbreakNode reconciler
+	// may race us on resourceVersion right after Create.
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := vjailbreakv1alpha1.VjailbreakNode{}
+		if err := k3sclient.Get(ctx, types.NamespacedName{
 			Namespace: constants.NamespaceMigrationSystem,
 			Name:      constants.VjailbreakMasterNodeName,
-		}, &vjNode)
-		if err != nil {
+		}, &latest); err != nil {
 			return errors.Wrap(err, "failed to get vjailbreak node")
 		}
-	}
-	vmIP := GetNodeInternalIP(masterNode)
-	if vmIP != "" {
-		vjNode.Status.VMIP = vmIP
-	}
-	vjNode.Status.Phase = constants.VjailbreakNodePhaseNodeReady
-	vjNode.Status.OpenstackUUID = openstackuuid
-
-	err = k3sclient.Status().Update(ctx, &vjNode)
-	if err != nil {
-		return errors.Wrap(err, "failed to update vjailbreak node status")
-	}
-
-	return nil
+		if latest.Status.OpenstackUUID == openstackuuid &&
+			latest.Status.Phase == constants.VjailbreakNodePhaseNodeReady &&
+			(vmIP == "" || latest.Status.VMIP == vmIP) {
+			return nil
+		}
+		if vmIP != "" {
+			latest.Status.VMIP = vmIP
+		}
+		latest.Status.Phase = constants.VjailbreakNodePhaseNodeReady
+		latest.Status.OpenstackUUID = openstackuuid
+		return k3sclient.Status().Update(ctx, &latest)
+	})
 }
 
 // UpdateMasterNodeImageID updates the image ID and flavor ID of the master node

--- a/k8s/migration/pkg/utils/vjailbreaknodeutils.go
+++ b/k8s/migration/pkg/utils/vjailbreaknodeutils.go
@@ -40,10 +40,14 @@ func CheckAndCreateMasterNodeEntry(ctx context.Context, k3sclient client.Client,
 	}
 
 	vjNode := vjailbreakv1alpha1.VjailbreakNode{}
+	nodeExists := false
 	err = k3sclient.Get(ctx, client.ObjectKey{Name: constants.VjailbreakMasterNodeName}, &vjNode)
-	if err == nil && vjNode.Status.OpenstackUUID != "" {
+	if err == nil {
+		nodeExists = true
 		// VjailbreakNode already exists with OpenstackUUID set
-		return nil
+		if vjNode.Status.OpenstackUUID != "" {
+			return nil
+		}
 	}
 
 	if openstackuuid == "" {
@@ -61,8 +65,8 @@ func CheckAndCreateMasterNodeEntry(ctx context.Context, k3sclient client.Client,
 		}
 	}
 
-	if apierrors.IsNotFound(err) {
-		newNode := vjailbreakv1alpha1.VjailbreakNode{
+	if !nodeExists {
+		vjNode = vjailbreakv1alpha1.VjailbreakNode{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      constants.VjailbreakMasterNodeName,
 				Namespace: constants.NamespaceMigrationSystem,
@@ -71,34 +75,37 @@ func CheckAndCreateMasterNodeEntry(ctx context.Context, k3sclient client.Client,
 				NodeRole: constants.NodeRoleMaster,
 			},
 		}
-		if err = k3sclient.Create(ctx, &newNode); err != nil && !apierrors.IsAlreadyExists(err) {
+
+		err = k3sclient.Create(ctx, &vjNode)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
 			return errors.Wrap(err, "failed to create vjailbreak node")
 		}
 	}
 
 	vmIP := GetNodeInternalIP(masterNode)
 
-	// Re-Get and Status().Update under retry — the VjailbreakNode reconciler
-	// may race us on resourceVersion right after Create.
+	// DMI returns the UUID synchronously in microseconds, so the window between
+	// Create and Status().Update is much tighter than with the metadata-service
+	// path — tight enough to race the VjailbreakNode reconciler that wakes up
+	// on the Create event and bumps resourceVersion. Retry on conflict, re-Get
+	// the latest object each attempt.
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := vjailbreakv1alpha1.VjailbreakNode{}
 		if err := k3sclient.Get(ctx, types.NamespacedName{
 			Namespace: constants.NamespaceMigrationSystem,
 			Name:      constants.VjailbreakMasterNodeName,
-		}, &latest); err != nil {
+		}, &vjNode); err != nil {
 			return errors.Wrap(err, "failed to get vjailbreak node")
 		}
-		if latest.Status.OpenstackUUID == openstackuuid &&
-			latest.Status.Phase == constants.VjailbreakNodePhaseNodeReady &&
-			(vmIP == "" || latest.Status.VMIP == vmIP) {
-			return nil
-		}
 		if vmIP != "" {
-			latest.Status.VMIP = vmIP
+			vjNode.Status.VMIP = vmIP
 		}
-		latest.Status.Phase = constants.VjailbreakNodePhaseNodeReady
-		latest.Status.OpenstackUUID = openstackuuid
-		return k3sclient.Status().Update(ctx, &latest)
+		vjNode.Status.Phase = constants.VjailbreakNodePhaseNodeReady
+		vjNode.Status.OpenstackUUID = openstackuuid
+
+		if err := k3sclient.Status().Update(ctx, &vjNode); err != nil {
+			return errors.Wrap(err, "failed to update vjailbreak node status")
+		}
+		return nil
 	})
 }
 

--- a/pkg/common/validation/openstack/validate.go
+++ b/pkg/common/validation/openstack/validate.go
@@ -252,11 +252,11 @@ func verifyCredentialsMatchCurrentEnvironment(providerClient *gophercloud.Provid
 		return false, fmt.Errorf("region name is empty")
 	}
 
-	// Get current instance metadata
-	metadata, err := utils.GetCurrentInstanceMetadata()
+	// Resolve master instance UUID — DMI first (no network), metadata service as fallback.
+	uuid, err := utils.GetMasterInstanceUUID()
 	if err != nil {
-		return false, fmt.Errorf("unable to get current instance metadata: %w. "+
-			"Please ensure this is running on an OpenStack instance with metadata service enabled", err)
+		return false, fmt.Errorf("unable to resolve master instance UUID via DMI or metadata service: %w. "+
+			"Ensure the controller pod has /host/dmi/product_uuid mounted, or that the OpenStack metadata service is reachable", err)
 	}
 
 	computeClient, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{
@@ -266,7 +266,7 @@ func verifyCredentialsMatchCurrentEnvironment(providerClient *gophercloud.Provid
 	if err != nil {
 		return false, fmt.Errorf("failed to create OpenStack compute client: %w", err)
 	}
-	_, err = servers.Get(context.TODO(), computeClient, metadata.UUID).Extract()
+	_, err = servers.Get(context.TODO(), computeClient, uuid).Extract()
 	if err != nil {
 		if strings.Contains(err.Error(), "Resource not found") ||
 			strings.Contains(err.Error(), "No server with a name or ID") {

--- a/pkg/common/validation/openstack/validate.go
+++ b/pkg/common/validation/openstack/validate.go
@@ -74,8 +74,6 @@ func Validate(ctx context.Context, k8sClient client.Client, openstackcreds *vjai
 			Error:   err,
 		}
 	}
-	openstackCredential.VJBInstanceID = openstackcreds.Spec.VJBInstanceID
-
 	// Create provider client
 	providerClient, err := openstack.NewClient(openstackCredential.AuthURL)
 	if err != nil {
@@ -146,19 +144,6 @@ func Validate(ctx context.Context, k8sClient client.Client, openstackcreds *vjai
 			Message: "Authentication failed: client endpoint catalog was not initialized. Please verify your OpenStack credentials and try again",
 			Error:   fmt.Errorf("authentication returned no error but ProviderClient.EndpointLocator is nil"),
 		}
-	}
-
-	if openstackCredential.VJBInstanceID != "" {
-		// Verify the provided instance ID exists in the OpenStack environment
-		_, err = verifyInstanceExists(providerClient, openstackCredential.RegionName, openstackCredential.VJBInstanceID)
-		if err != nil {
-			return ValidationResult{
-				Valid:   false,
-				Message: fmt.Sprintf("Failed to verify instance ID '%s': %s", openstackCredential.VJBInstanceID, err.Error()),
-				Error:   err,
-			}
-		}
-		return successfulValidationObject
 	}
 
 	// Verify credentials match current environment
@@ -289,47 +274,6 @@ func verifyCredentialsMatchCurrentEnvironment(providerClient *gophercloud.Provid
 		}
 		return false, fmt.Errorf("failed to verify instance access: %w. "+
 			"Please check if the provided credentials have compute:get_server permission", err)
-	}
-	return true, nil
-}
-
-// verifyInstanceExists checks if the provided instance ID exists in the OpenStack environment
-func verifyInstanceExists(providerClient *gophercloud.ProviderClient, regionName string, instanceID string) (ok bool, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			ok = false
-			err = fmt.Errorf("panic while verifying instance existence: %v", r)
-		}
-	}()
-
-	if providerClient == nil {
-		return false, fmt.Errorf("provider client is nil")
-	}
-	if providerClient.EndpointLocator == nil {
-		return false, fmt.Errorf("OpenStack client is not authenticated (endpoint locator is not initialized)")
-	}
-	if strings.TrimSpace(regionName) == "" {
-		return false, fmt.Errorf("region name is empty")
-	}
-	if strings.TrimSpace(instanceID) == "" {
-		return false, fmt.Errorf("instance ID is empty")
-	}
-
-	computeClient, err := openstack.NewComputeV2(providerClient, gophercloud.EndpointOpts{
-		Region: regionName,
-	})
-	if err != nil {
-		return false, fmt.Errorf("failed to create OpenStack compute client: %w", err)
-	}
-
-	_, err = servers.Get(context.TODO(), computeClient, instanceID).Extract()
-	if err != nil {
-		if strings.Contains(err.Error(), "Resource not found") ||
-			strings.Contains(err.Error(), "No server with a name or ID") ||
-			strings.Contains(err.Error(), "404") {
-			return false, fmt.Errorf("instance ID '%s' not found in the OpenStack environment. Please verify the instance ID and ensure the credentials are for the correct OpenStack environment", instanceID)
-		}
-		return false, fmt.Errorf("failed to verify instance access: %w. Please check if the provided credentials have compute:get_server permission", err)
 	}
 	return true, nil
 }

--- a/pkg/common/validation/openstack/validate.go
+++ b/pkg/common/validation/openstack/validate.go
@@ -293,14 +293,8 @@ func FetchResourcesPostValidation(ctx context.Context, k8sClient client.Client, 
 
 	ctx = ensureLogger(ctx)
 
-	log.Printf("Updating Master Node Image ID")
-	err := utils.UpdateMasterNodeImageID(ctx, k8sClient, false)
-	if err != nil {
-		log.Printf("Warning: Failed to update master node image ID: %v", err)
-	}
-
 	log.Printf("Creating Dummy PCD Cluster if needed")
-	err = utils.CreateDummyPCDClusterForStandAlonePCDHosts(ctx, k8sClient, openstackcreds)
+	err := utils.CreateDummyPCDClusterForStandAlonePCDHosts(ctx, k8sClient, openstackcreds)
 	if err != nil {
 		if !strings.Contains(err.Error(), "already exists") {
 			return nil, errors.Wrap(err, "failed to create dummy PCD cluster")

--- a/ui/src/api/helpers.ts
+++ b/ui/src/api/helpers.ts
@@ -110,7 +110,6 @@ export const createOpenstackCredsWithSecretFlow = async (
   },
   isPcd: boolean = false,
   projectName: string,
-  vjbInstanceId?: string,
   namespace = VJAILBREAK_DEFAULT_NAMESPACE
 ) => {
   const secretName = `${credName}-openstack-secret`
@@ -135,11 +134,6 @@ export const createOpenstackCredsWithSecretFlow = async (
       },
       projectName: projectName
     }
-  }
-
-  // Add vjbInstanceId to spec if provided
-  if (vjbInstanceId && vjbInstanceId.trim() !== '') {
-    credBody.spec.vjbinstanceid = vjbInstanceId.trim()
   }
 
   return postOpenstackCredentials(credBody, namespace)

--- a/ui/src/features/credentials/components/OpenstackCredentialsDrawer.tsx
+++ b/ui/src/features/credentials/components/OpenstackCredentialsDrawer.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@mui/material'
 import axios from 'axios'
-import { useEffect, useState, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import {
   DrawerShell,
@@ -47,8 +47,6 @@ interface OpenstackCredentialsFormValues {
   rcFile?: File
   isPcd: boolean
   insecure: boolean
-  passVjbInstanceId: boolean
-  vjbInstanceId: string
 }
 
 export default function OpenstackCredentialsDrawer({
@@ -64,9 +62,7 @@ export default function OpenstackCredentialsDrawer({
       credentialName: '',
       rcFile: undefined,
       isPcd: true,
-      insecure: false,
-      passVjbInstanceId: false,
-      vjbInstanceId: ''
+      insecure: false
     }
   })
 
@@ -90,8 +86,6 @@ export default function OpenstackCredentialsDrawer({
   const watchedValues = watch()
   const credentialName = watchedValues.credentialName
   const rcFile = watchedValues.rcFile
-  const passVjbInstanceId = watchedValues.passVjbInstanceId
-  const vjbInstanceId = watchedValues.vjbInstanceId
 
   const { refetch: refetchOpenstackCreds } = useOpenstackCredentialsQuery()
   const { refetch: refetchVmwareCreds } = useVmwareCredentialsQuery(undefined, {
@@ -104,9 +98,7 @@ export default function OpenstackCredentialsDrawer({
       credentialName: '',
       rcFile: undefined,
       isPcd: false,
-      insecure: false,
-      passVjbInstanceId: false,
-      vjbInstanceId: ''
+      insecure: false
     })
     setRcFileValues(null)
     setCreatedCredentialName(null)
@@ -142,12 +134,6 @@ export default function OpenstackCredentialsDrawer({
   }, [createdCredentialName, resetDrawerState])
 
   const [rcFileValues, setRcFileValues] = useState<Record<string, string> | null>(null)
-
-  useEffect(() => {
-    if (!passVjbInstanceId && vjbInstanceId) {
-      setValue('vjbInstanceId', '')
-    }
-  }, [passVjbInstanceId, setValue, vjbInstanceId])
 
   const handleRCFileParsed = useCallback(
     (values: Record<string, string>) => {
@@ -210,8 +196,7 @@ export default function OpenstackCredentialsDrawer({
             OS_INSECURE: values.insecure
           },
           values.isPcd,
-          projectName,
-          values.passVjbInstanceId ? values.vjbInstanceId : undefined
+          projectName
         )
 
         setCreatedCredentialName(response.metadata.name)
@@ -261,8 +246,7 @@ export default function OpenstackCredentialsDrawer({
     !!errors.rcFile ||
     !credentialName ||
     !rcFile ||
-    !rcFileValues ||
-    (passVjbInstanceId && !vjbInstanceId?.trim())
+    !rcFileValues
 
   const handleValidationStatus = (status: string, message?: string) => {
     if (status === 'Succeeded') {
@@ -439,35 +423,6 @@ export default function OpenstackCredentialsDrawer({
                 size="small"
                 required
               />
-
-              <Row gap={3} flexWrap="wrap">
-                <Box sx={{ flex: 1, minWidth: 260 }}>
-                  <RHFToggleField
-                    name="passVjbInstanceId"
-                    label="vJailbreak VM is on Layer 2 Network (PCD)"
-                    description="Enable this if the vJailbreak VM is deployed on a PCD Layer 2 network. When enabled, you'll need to provide the vJailbreak instance ID to establish connectivity."
-                  />
-                </Box>
-              </Row>
-
-              {passVjbInstanceId && (
-                <FormGrid minWidth={360} gap={2}>
-                  <RHFTextField
-                    name="vjbInstanceId"
-                    label="vJailbreak Instance ID"
-                    placeholder="e.g. 12345678-1234-1234-1234-123456789abc"
-                    helperText="Specify the PCD instance ID where vJailbreak is running."
-                    rules={{
-                      validate: (value: string) =>
-                        !passVjbInstanceId ||
-                        Boolean(value?.trim()) ||
-                        'Instance ID is required when vJailbreak is on an L2 network'
-                    }}
-                    fullWidth
-                    required
-                  />
-                </FormGrid>
-              )}
 
               <Row gap={3} flexWrap="wrap">
                 <Box sx={{ flex: 1, minWidth: 260 }}>


### PR DESCRIPTION
## What this PR does / why we need it
This PR removes the need of adding instance ID when vjailbreak is hosted on L2 only network. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1852 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_