### PR TITLE
Pass vmkey instead of vmname to delete object

### DIFF
--- a/ui/src/features/migration/pages/MigrationsPage.tsx
+++ b/ui/src/features/migration/pages/MigrationsPage.tsx
@@ -77,7 +77,8 @@ export default function MigrationsPage() {
               migrationsToDelete: new Set<string>()
             }
           }
-          acc[planId].vmsToRemove.add(migration.spec.vmName)
+          const vmKey = migration.metadata?.labels?.['vjailbreak.k8s.pf9.io/vm-key'] || migration.spec.vmName
+          acc[planId].vmsToRemove.add(vmKey)
           acc[planId].migrationsToDelete.add(migration.metadata.name)
           return acc
         },


### PR DESCRIPTION
## What this PR does / why we need it
Pass vmkey instead of vmname to delete object


## Which issue(s) this PR fixes
fixes #1857
fixes #1828 

## Testing done

<img width="1440" height="530" alt="image" src="https://github.com/user-attachments/assets/5e4a0742-4826-4c48-b1bd-efb5dd77cfa1" />
<img width="1433" height="92" alt="image" src="https://github.com/user-attachments/assets/2e7fd530-cc80-4803-8851-e91204152c54" />
