### PR TITLE
After we copy the disks via storagecopy add image tags to boot correctly

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -194,6 +194,46 @@ func (migobj *Migrate) CreateVolumes(ctx context.Context, vminfo vm.VMInfo) (vm.
 	return vminfo, nil
 }
 
+// applyImageMetadataForXCOPYVolumes mirrors the metadata calls that CreateVolume
+// makes on the standard (non-accelerated) path.
+func (migobj *Migrate) applyImageMetadataForXCOPYVolumes(ctx context.Context, vminfo vm.VMInfo) error {
+	openstackops := migobj.Openstackclients
+	setRDMLabel := len(vminfo.RDMDisks) > 0
+
+	for idx := range vminfo.VMDisks {
+		vmdisk := vminfo.VMDisks[idx]
+		if vmdisk.OpenstackVol == nil {
+			return fmt.Errorf("XCOPY volume for disk %s has no OpenStack volume reference", vmdisk.Name)
+		}
+		volume := vmdisk.OpenstackVol
+
+		if vminfo.UEFI {
+			if err := openstackops.SetVolumeUEFI(ctx, volume); err != nil {
+				return errors.Wrapf(err, "failed to set UEFI metadata on XCOPY volume %s", volume.ID)
+			}
+		}
+
+		if strings.ToLower(vminfo.OSType) == constants.OSFamilyWindows {
+			if err := openstackops.SetVolumeImageMetadata(ctx, volume, setRDMLabel); err != nil {
+				return errors.Wrapf(err, "failed to set Windows image metadata on XCOPY volume %s", volume.ID)
+			}
+		}
+
+		if err := openstackops.EnableQGA(ctx, volume); err != nil {
+			return errors.Wrapf(err, "failed to enable QGA on XCOPY volume %s", volume.ID)
+		}
+
+		if vmdisk.Boot {
+			if err := openstackops.SetVolumeBootable(ctx, volume); err != nil {
+				return errors.Wrapf(err, "failed to set XCOPY volume %s as bootable", volume.ID)
+			}
+		}
+	}
+
+	migobj.logMessage("Applied image metadata to XCOPY-managed volumes")
+	return nil
+}
+
 func (migobj *Migrate) AttachVolume(ctx context.Context, disk vm.VMDisk) (string, error) {
 	openstackops := migobj.Openstackclients
 	migobj.logMessage(fmt.Sprintf("Attaching volumes to VM: %s", disk.Name))
@@ -1844,6 +1884,10 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 		// Perform the copy here.
 		if _, err := migobj.StorageAcceleratedCopyCopyDisks(ctx, vminfo); err != nil {
 			return errors.Wrap(err, "failed to perform StorageAcceleratedCopy copy")
+		}
+		// Apply image tags to the volumes we cinder managed.
+		if err := migobj.applyImageMetadataForXCOPYVolumes(ctx, vminfo); err != nil {
+			return errors.Wrap(err, "failed to apply image metadata to XCOPY volumes")
 		}
 
 	} else {


### PR DESCRIPTION
## What this PR does / why we need it
Adds image tags needed for the vm on pcd to bootup on the sam path after we do a cinder manage and copy.

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1869 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_