### PR TITLE
Bug: Use GetIsSimpleNetwork method instead of using stale env variable

### DIFF
--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -693,11 +693,13 @@ func (osclient *OpenStackClients) ValidateAndCreatePort(ctx context.Context, net
 		return Existingport, nil
 	}
 	PrintLog(fmt.Sprintf("Port with MAC address %s does not exist, creating new port, trying with same IP address: %v", mac, ipPerMac[mac]))
-
-	currentInstanceID := os.Getenv("CURRENT_INSTANCE_ID")
+	isL2Network, err := osclient.GetIsSimpleNetwork(ctx, network.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to check if network is L2")
+	}
 
 	// Check if subnet is valid to avoid panic.
-	if len(network.Subnets) == 0 && currentInstanceID == "" {
+	if len(network.Subnets) == 0 && !isL2Network {
 		return nil, fmt.Errorf("no subnets found for network: %s", network.ID)
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it
In previous implementation to get the instance ID the user used to pass Instance_UUID from the UI for vjb to function. So to understand if the network was L2 or no we used pass the instance uuid env that way we used to get to know if the target network was L2 or no. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1874 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_