### PR TITLE
increased version window for github tags

### DIFF
--- a/pkg/vpwned/upgrade/version_checker.go
+++ b/pkg/vpwned/upgrade/version_checker.go
@@ -91,7 +91,8 @@ func GetAllTags(ctx context.Context) ([]string, error) {
 
 func getAllTagsFromGitHub(ctx context.Context, owner, repo string) ([]string, error) {
 	client := newGitHubClient(ctx)
-	tags, _, err := client.Repositories.ListTags(ctx, owner, repo, nil)
+	// Use per_page=100 to fetch all tags in a single request (GitHub default is 30).
+	tags, _, err := client.Repositories.ListTags(ctx, owner, repo, &github.ListOptions{PerPage: 100})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch tags for repo %s/%s: %w", owner, repo, err)
 	}
@@ -123,7 +124,7 @@ func getAllTagsFromGitHub(ctx context.Context, owner, repo string) ([]string, er
 
 func getTagsGreaterThanVersion(ctx context.Context, owner, repo, currentVersion string) ([]string, error) {
 	client := newGitHubClient(ctx)
-	tags, _, err := client.Repositories.ListTags(ctx, owner, repo, nil)
+	tags, _, err := client.Repositories.ListTags(ctx, owner, repo, &github.ListOptions{PerPage: 100})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch tags for repo %s/%s: %w", owner, repo, err)
 	}


### PR DESCRIPTION
## What this PR does / why we need it
GitHub's tags API returns 30 tags per page by default, sorted by version:refname descending. Non-semver tags (e.g. 5545-61ee1af9) sort below all v-prefixed semver tags and fall onto page 2, making them invisible in the upgrade modal.

Fix: pass PerPage=100 in ListTags options, fetching all tags in a single request.


## Which issue(s) this PR fixes
fixes #1877 


## Testing done

<img width="1920" height="997" alt="image" src="https://github.com/user-attachments/assets/94c0b23a-c863-462c-a394-880c3d718adb" />
