### PR TITLE
Keepalive client mechanism

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -610,6 +610,20 @@ func (migobj *Migrate) WaitforAdminCutover(ctx context.Context, vminfo vm.VMInfo
 			// Reset state to start fresh each cycle
 			syncCtx.CurrentState = StateCleaningSnapshots
 
+			// Defensive: confirm the vCenter session is alive before doing any
+			// real work. The keepalive handler installed at login should already
+			// keep it warm, but if anything has gone wrong (e.g. session killed
+			// out-of-band, or a long pause between heartbeats), this forces a
+			// fresh login so the rest of the cycle doesn't fail half-way.
+			if err := migobj.Vcclient.EnsureSessionActive(ctx); err != nil {
+				syncCtx.LastError = err
+				syncCtx.WarningMessage = fmt.Sprintf("vCenter session refresh failed: %v. Will retry on next sync interval.", err)
+				syncCtx.CurrentState = StateIdle
+				migobj.logMessage(fmt.Sprintf("Periodic Sync: WARNING - %s", syncCtx.WarningMessage))
+				elapsed = time.Since(start)
+				continue
+			}
+
 			// State: CleaningSnapshots
 			err := utils.DoRetryWithExponentialBackoff(ctx, func() error {
 				return vmops.CleanUpSnapshots(false)
@@ -828,6 +842,14 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 				utils.PrintLog("Admin initiated cutover detected, skipping changed blocks copy")
 				if err := migobj.WaitforAdminCutover(ctx, vminfo); err != nil {
 					return vminfo, errors.Wrap(err, "failed to start VM Cutover")
+				}
+				// The wait above may have returned right between keepalive heartbeats
+				// (or after a long idle period if periodic sync is disabled), so the
+				// vCenter session might be stale before we issue the first cutover
+				// call. Force a session check + relogin so VMPowerOff and the final
+				// CBT copy don't fail on NotAuthenticated.
+				if err := migobj.Vcclient.EnsureSessionActive(ctx); err != nil {
+					return vminfo, errors.Wrap(err, "failed to refresh vCenter session post-cutover")
 				}
 				if migobj.MigrationType == "mock" {
 					utils.PrintLog("Mock migration detected, skipping VM power off")

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -610,11 +610,6 @@ func (migobj *Migrate) WaitforAdminCutover(ctx context.Context, vminfo vm.VMInfo
 			// Reset state to start fresh each cycle
 			syncCtx.CurrentState = StateCleaningSnapshots
 
-			// Defensive: confirm the vCenter session is alive before doing any
-			// real work. The keepalive handler installed at login should already
-			// keep it warm, but if anything has gone wrong (e.g. session killed
-			// out-of-band, or a long pause between heartbeats), this forces a
-			// fresh login so the rest of the cycle doesn't fail half-way.
 			if err := migobj.Vcclient.EnsureSessionActive(ctx); err != nil {
 				syncCtx.LastError = err
 				syncCtx.WarningMessage = fmt.Sprintf("vCenter session refresh failed: %v. Will retry on next sync interval.", err)
@@ -843,11 +838,6 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 				if err := migobj.WaitforAdminCutover(ctx, vminfo); err != nil {
 					return vminfo, errors.Wrap(err, "failed to start VM Cutover")
 				}
-				// The wait above may have returned right between keepalive heartbeats
-				// (or after a long idle period if periodic sync is disabled), so the
-				// vCenter session might be stale before we issue the first cutover
-				// call. Force a session check + relogin so VMPowerOff and the final
-				// CBT copy don't fail on NotAuthenticated.
 				if err := migobj.Vcclient.EnsureSessionActive(ctx); err != nil {
 					return vminfo, errors.Wrap(err, "failed to refresh vCenter session post-cutover")
 				}

--- a/v2v-helper/vcenter/vcenterops.go
+++ b/v2v-helper/vcenter/vcenterops.go
@@ -20,9 +20,16 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/session/cache"
+	"github.com/vmware/govmomi/session/keepalive"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/types"
 )
+
+// vCenterKeepaliveInterval is how often we send a SOAP heartbeat to keep the
+// vCenter session from expiring while v2v-helper is otherwise idle (notably
+// during the admin-initiated cutover wait). vCenter's default session idle
+// timeout is ~30 minutes; we ping well below that.
+const vCenterKeepaliveInterval = 10 * time.Minute
 
 //go:generate mockgen -source=../vcenter/vcenterops.go -destination=../vcenter/vcenterops_mock.go -package=vcenter
 
@@ -79,6 +86,26 @@ func validateVCenter(ctx context.Context, username, password, host string, disab
 			time.Sleep(baseDelay * time.Duration(1<<uint(attempt-1))) // Exponential backoff
 		}
 	}
+
+	// Install a keepalive handler on the SOAP RoundTripper. vCenter sessions expire
+	// after ~30 minutes of inactivity; without this, long idle periods (e.g. waiting
+	// for an admin-initiated cutover) leave the client with a dead session and any
+	// subsequent call fails with NotAuthenticated.
+	//
+	// cache.Session.Login replaces *c entirely (including c.RoundTripper), so the
+	// keepalive wrapper has to be re-installed on every relogin — hence the
+	// self-referencing closure.
+	var reloginAndWrap func() error
+	reloginAndWrap = func() error {
+		// Use Background so the keepalive's relogin survives cancellation of the
+		// original setup context.
+		if err := s.Login(context.Background(), c, nil); err != nil {
+			return fmt.Errorf("vcenter keepalive relogin failed: %v", err)
+		}
+		c.RoundTripper = keepalive.NewHandlerSOAP(c.RoundTripper, vCenterKeepaliveInterval, reloginAndWrap)
+		return nil
+	}
+	c.RoundTripper = keepalive.NewHandlerSOAP(c.RoundTripper, vCenterKeepaliveInterval, reloginAndWrap)
 
 	// Return both the client and the session for persistent re-authentication
 	return c, s, nil

--- a/v2v-helper/vcenter/vcenterops.go
+++ b/v2v-helper/vcenter/vcenterops.go
@@ -26,10 +26,6 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-// vCenterKeepaliveInterval is how often we send a SOAP heartbeat to keep the
-// vCenter session from expiring while v2v-helper is otherwise idle (notably
-// during the admin-initiated cutover wait). vCenter's default session idle
-// timeout is ~30 minutes; we ping well below that.
 const vCenterKeepaliveInterval = 10 * time.Minute
 
 //go:generate mockgen -source=../vcenter/vcenterops.go -destination=../vcenter/vcenterops_mock.go -package=vcenter
@@ -89,14 +85,6 @@ func validateVCenter(ctx context.Context, username, password, host string, disab
 		}
 	}
 
-	// Install a keepalive handler on the SOAP RoundTripper. vCenter sessions expire
-	// after ~30 minutes of inactivity; without this, long idle periods (e.g. waiting
-	// for an admin-initiated cutover) leave the client with a dead session and any
-	// subsequent call fails with NotAuthenticated.
-	//
-	// cache.Session.Login replaces *c entirely (including c.RoundTripper), so the
-	// keepalive wrapper has to be re-installed on every relogin — hence the
-	// self-referencing closure.
 	var reloginAndWrap func() error
 	reloginAndWrap = func() error {
 		// Use Background so the keepalive's relogin survives cancellation of the

--- a/v2v-helper/vcenter/vcenterops.go
+++ b/v2v-helper/vcenter/vcenterops.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/session/cache"
 	"github.com/vmware/govmomi/session/keepalive"
 	"github.com/vmware/govmomi/vim25"
@@ -38,6 +39,7 @@ type VCenterOperations interface {
 	GetVMByName(ctx context.Context, name string) (*object.VirtualMachine, error)
 	RunCommandOnEsxi(ctx context.Context, host object.HostSystem, command []string) ([]esx.Values, error)
 	GetDataStores(ctx context.Context, dataCenter *object.Datacenter, datastore string) (*object.Datastore, error)
+	EnsureSessionActive(ctx context.Context) error
 }
 
 type VCenterClient struct {
@@ -119,6 +121,21 @@ func VCenterClientBuilder(ctx context.Context, username, password, host string, 
 	finder := find.NewFinder(client, false)
 	pc := property.DefaultCollector(client)
 	return &VCenterClient{VCClient: client, VCFinder: finder, VCPropertyCollector: pc, Session: session}, nil
+}
+
+func (vcclient *VCenterClient) EnsureSessionActive(ctx context.Context) error {
+	sm := session.NewManager(vcclient.VCClient)
+	active, err := sm.SessionIsActive(ctx)
+	if err == nil && active {
+		return nil
+	}
+	if vcclient.Session == nil {
+		return fmt.Errorf("vcenter session check failed and no cached session available: %v", err)
+	}
+	if loginErr := vcclient.Session.Login(ctx, vcclient.VCClient, nil); loginErr != nil {
+		return fmt.Errorf("vcenter session refresh failed: check err=%v, login err=%v", err, loginErr)
+	}
+	return nil
 }
 
 func GetThumbprint(host string) (string, error) {


### PR DESCRIPTION
## What this PR does / why we need it

Added a keep alive mechanism to ensure persistent session between vcenter client and vJailbreak while waiting for admin cutover

fixes #

## Special notes for your reviewer


## Testing done

<img width="1903" height="1007" alt="image" src="https://github.com/user-attachments/assets/d82efce8-ce19-4ef5-a81f-951b9c2e2fba" />
