### PR TITLE
Bug: Fix unauthenticated error when doing vcenter operations after a long time. 

### DIFF
--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -139,6 +139,14 @@ func (vmops *VMOps) GetVCenterClient() *vcenter.VCenterClient {
 
 func (vmops *VMOps) RefreshVM() error {
 	if vmops.vmid != "" {
+		// GetVMByMOID only re-wraps the MOID around the existing vim25.Client; it does
+		// not refresh the session cookie. Force an explicit re-login so subsequent
+		// calls don't keep failing with NotAuthenticated.
+		if vmops.vcclient != nil && vmops.vcclient.Session != nil && vmops.vcclient.VCClient != nil {
+			if err := vmops.vcclient.Session.Login(vmops.ctx, vmops.vcclient.VCClient, nil); err != nil {
+				return fmt.Errorf("failed to re-login to vCenter during VM refresh: %s", err)
+			}
+		}
 		vmops.VMObj = vmops.vcclient.GetVMByMOID(vmops.vmid)
 		return nil
 	}

--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -139,9 +139,7 @@ func (vmops *VMOps) GetVCenterClient() *vcenter.VCenterClient {
 
 func (vmops *VMOps) RefreshVM() error {
 	if vmops.vmid != "" {
-		// GetVMByMOID only re-wraps the MOID around the existing vim25.Client; it does
-		// not refresh the session cookie. Force an explicit re-login so subsequent
-		// calls don't keep failing with NotAuthenticated.
+		// Re login to Vcenter to keep the client logged in when we return via vmid branch.
 		if vmops.vcclient != nil && vmops.vcclient.Session != nil && vmops.vcclient.VCClient != nil {
 			if err := vmops.vcclient.Session.Login(vmops.ctx, vmops.vcclient.VCClient, nil); err != nil {
 				return fmt.Errorf("failed to re-login to vCenter during VM refresh: %s", err)

--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -15,6 +15,7 @@ import (
 	"github.com/platform9/vjailbreak/pkg/common/constants"
 	"github.com/platform9/vjailbreak/v2v-helper/pkg/k8sutils"
 	"github.com/platform9/vjailbreak/v2v-helper/vcenter"
+	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/methods"
@@ -141,9 +142,13 @@ func (vmops *VMOps) RefreshVM() error {
 	if vmops.vmid != "" {
 		// Re login to Vcenter to keep the client logged in when we return via vmid branch.
 		if vmops.vcclient != nil && vmops.vcclient.Session != nil && vmops.vcclient.VCClient != nil {
-			if err := vmops.vcclient.Session.Login(vmops.ctx, vmops.vcclient.VCClient, nil); err != nil {
-				return fmt.Errorf("failed to re-login to vCenter during VM refresh: %s", err)
+			login := vmops.vcclient.Session.Login
+			if err := login(context.TODO(), vmops.vcclient.VCClient, nil); err != nil {
+				return fmt.Errorf("failed to re-login during datacenter refresh: %v", err)
 			}
+
+			// Create a new finder with the refreshed client
+			vmops.vcclient.VCFinder = find.NewFinder(vmops.vcclient.VCClient, false)
 		}
 		vmops.VMObj = vmops.vcclient.GetVMByMOID(vmops.vmid)
 		return nil


### PR DESCRIPTION
## What this PR does / why we need it
In the vmid != "" branch of RefreshVM, explicitly call Session.Login(ctx, VCClient, nil) 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1890


## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_