### PR TITLE
[1241] Disable port security on migrated ports when no security group is selected while migration

### DIFF
--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/volumeattach"
 	"github.com/gophercloud/gophercloud/v2/openstack/identity/v3/projects"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/portsecurity"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
@@ -773,6 +774,15 @@ func (osclient *OpenStackClients) CreatePort(ctx context.Context, networkid *net
 }
 
 func (osclient *OpenStackClients) createPortLowLevel(ctx context.Context, createOpts ports.CreateOpts) (*ports.Port, error) {
+	// When no security groups are selected, disable port security
+	if createOpts.SecurityGroups == nil || len(*createOpts.SecurityGroups) == 0 {
+		disabled := false
+		extOpts := portsecurity.PortCreateOptsExt{
+			CreateOptsBuilder:   createOpts,
+			PortSecurityEnabled: &disabled,
+		}
+		return ports.Create(ctx, osclient.NetworkingClient, extOpts).Extract()
+	}
 	return ports.Create(ctx, osclient.NetworkingClient, createOpts).Extract()
 }
 


### PR DESCRIPTION
## What this PR does / why we need it
When a user migrates a VM without selecting a security group, vjailbreak was creating the port with security_groups: [] — an empty list. Since PCD recently enabled port security on all networks, OpenStack interpreted this as "port security enabled, no rules," causing all traffic to be dropped post-migration.

**Fix:** When no security groups are selected, the port is now explicitly created with port_security_enabled: false. 

## Which issue(s) this PR fixes
fixes #1241 

## Testing done

- Selected no security group while creating migration
<img width="1579" height="208" alt="image" src="https://github.com/user-attachments/assets/30bfd6b1-736e-4e05-b766-6ea7f2bbdd93" />


- Selected one while creating migration
 
<img width="978" height="143" alt="image" src="https://github.com/user-attachments/assets/dbe752ac-fa5d-4043-bd41-530fa9553bf6" />
