### PR TITLE
Fixed migration issue for shared rdm disk

### DIFF
--- a/deploy/05controller-deployment.yaml
+++ b/deploy/05controller-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         envFrom:
         - configMapRef:
             name: pf9-env
-        image: quay.io/platform9/vjailbreak-controller:v0.4.4
+        image: quay.io/platform9/vjailbreak-controller:main
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/deploy/06vpwned-deployment.yaml
+++ b/deploy/06vpwned-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: pf9-env
-        image: quay.io/platform9/vjailbreak-vpwned:v0.4.4
+        image: quay.io/platform9/vjailbreak-vpwned:main
         imagePullPolicy: IfNotPresent
         name: vpwned
         ports:

--- a/deploy/07ui-deployment.yaml
+++ b/deploy/07ui-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: ui-manager-sa
       containers:
         - name: vjailbreak-ui-container
-          image: quay.io/platform9/vjailbreak-ui:v0.4.4
+          image: quay.io/platform9/vjailbreak-ui:main
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80

--- a/deploy/installer.yaml
+++ b/deploy/installer.yaml
@@ -4592,7 +4592,7 @@ spec:
         envFrom:
         - configMapRef:
             name: pf9-env
-        image: quay.io/platform9/vjailbreak-controller:v0.4.4
+        image: quay.io/platform9/vjailbreak-controller:main
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -4686,7 +4686,7 @@ spec:
       - envFrom:
         - configMapRef:
             name: pf9-env
-        image: quay.io/platform9/vjailbreak-vpwned:v0.4.4
+        image: quay.io/platform9/vjailbreak-vpwned:main
         imagePullPolicy: IfNotPresent
         name: vpwned
         ports:
@@ -4775,7 +4775,7 @@ spec:
       serviceAccountName: ui-manager-sa
       containers:
         - name: vjailbreak-ui-container
-          image: quay.io/platform9/vjailbreak-ui:v0.4.4
+          image: quay.io/platform9/vjailbreak-ui:main
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80

--- a/k8s/migration/config/addons/kustomization.yaml
+++ b/k8s/migration/config/addons/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: vpwned
   newName: quay.io/platform9/vjailbreak-vpwned
-  newTag: v0.4.4
+  newTag: main

--- a/k8s/migration/config/manager/kustomization.yaml
+++ b/k8s/migration/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/platform9/vjailbreak-controller
-  newTag: v0.4.4
+  newTag: main

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -2225,6 +2225,7 @@ func MergeLabels(a, b map[string]string) map[string]string {
 	return result
 }
 
+//nolint:gocyclo
 func (r *MigrationPlanReconciler) migrateRDMdisks(ctx context.Context, migrationplan *vjailbreakv1alpha1.MigrationPlan, vmMachines map[string]*vjailbreakv1alpha1.VMwareMachine, openstackcreds *vjailbreakv1alpha1.OpenstackCreds) error {
 	allRDMDisks := []*vjailbreakv1alpha1.RDMDisk{}
 	rdmDiskCRToBeUpdated := make([]vjailbreakv1alpha1.RDMDisk, 0)

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -2244,28 +2244,31 @@ func (r *MigrationPlanReconciler) migrateRDMdisks(ctx context.Context, migration
 				if err != nil {
 					return fmt.Errorf("failed to get RDMDisk CR: %w", err)
 				}
-				// Validate that all ownerVMs are present in parallelVMs
-				// This validation can be disabled via vjailbreak-settings ConfigMap
+				// Validate that all ownerVMs are present in parallelVMs or have
+				// already succeeded as part of this migration plan.
 				vjailbreakSettings, err := k8sutils.GetVjailbreakSettings(ctx, r.Client)
 				switch err {
 				case nil:
 					if vjailbreakSettings.ValidateRDMOwnerVMs {
 						for _, ownerVM := range rdmDiskCR.Spec.OwnerVMs {
 							if _, ok := vmMachines[ownerVM]; !ok {
-								log.FromContext(ctx).Error(fmt.Errorf("ownerVM %q in RDM disk %s not found in migration plan", ownerVM, rdmDisk), "verify migration plan")
-								return fmt.Errorf("ownerVM %q in RDM disk %s not found in migration plan", ownerVM, rdmDisk)
+								if !r.isVMSucceededInPlan(ctx, migrationplan, ownerVM) {
+									log.FromContext(ctx).Error(fmt.Errorf("ownerVM %q in RDM disk %s not found in migration plan", ownerVM, rdmDisk), "verify migration plan")
+									return fmt.Errorf("ownerVM %q in RDM disk %s not found in migration plan", ownerVM, rdmDisk)
+								}
 							}
 						}
 					} else {
 						log.FromContext(ctx).Info("RDM disk owner VM validation disabled via vjailbreak-settings", "rdmDisk", rdmDisk)
 					}
 				default:
-					// Successfully retrieved settings, proceed with validation
 					log.FromContext(ctx).Error(err, "Failed to get vjailbreak settings, using default validation behavior")
-					// Fall back to default behavior (validation enabled) if we can't get settings
 					for _, ownerVM := range rdmDiskCR.Spec.OwnerVMs {
 						if _, ok := vmMachines[ownerVM]; !ok {
-							log.FromContext(ctx).Error(fmt.Errorf("ownerVM %q in RDM disk %s not found in migration plan", ownerVM, rdmDisk), "verify migration plan")
+							if !r.isVMSucceededInPlan(ctx, migrationplan, ownerVM) {
+								log.FromContext(ctx).Error(fmt.Errorf("ownerVM %q in RDM disk %s not found in migration plan", ownerVM, rdmDisk), "verify migration plan")
+								return fmt.Errorf("ownerVM %q in RDM disk %s not found in migration plan", ownerVM, rdmDisk)
+							}
 						}
 					}
 				}
@@ -2498,6 +2501,25 @@ func (r *MigrationPlanReconciler) updateMigrationPhaseWithRetry(
 }
 
 // markMigrationValidationFailed updates a Migration status to ValidationFailed
+// isVMSucceededInPlan returns true if the given VM name has a Succeeded migration
+// in this plan. Used to allow ownerVM validation to pass for VMs that already
+// completed migration as part of the same plan.
+func (r *MigrationPlanReconciler) isVMSucceededInPlan(ctx context.Context, migrationplan *vjailbreakv1alpha1.MigrationPlan, vmName string) bool {
+	migrationList := &vjailbreakv1alpha1.MigrationList{}
+	if err := r.List(ctx, migrationList,
+		client.InNamespace(migrationplan.Namespace),
+		client.MatchingLabels{"migrationplan": migrationplan.Name},
+	); err != nil {
+		return false
+	}
+	for _, m := range migrationList.Items {
+		if m.Spec.VMName == vmName && m.Status.Phase == vjailbreakv1alpha1.VMMigrationPhaseSucceeded {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *MigrationPlanReconciler) markMigrationValidationFailed(ctx context.Context, migrationObj *vjailbreakv1alpha1.Migration, vmName string, message string) {
 	condition := corev1.PodCondition{
 		Type:               "Validated",


### PR DESCRIPTION
## What this PR does / why we need it
When an ownerVM completes migration before other VMs sharing the same RDM disk are processed, the remaining VMs incorrectly showed ValidationFailed. Added isVMSucceededInPlan to skip ownerVM validation for VMs that have already succeeded in the same plan.


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1900

## Special notes for your reviewer


## Testing done
<img width="1357" height="637" alt="image" src="https://github.com/user-attachments/assets/87e1135f-4d78-42f8-bb30-ad62ca219e6a" />


_please add testing details (logs, screenshots, etc.)_