### PR TITLE
[1907] Fix: fetch single VMwareMachine instead of entire list in migration detail query

### DIFF
--- a/ui/src/features/migration/SecurityGroupAndServerGroup.tsx
+++ b/ui/src/features/migration/SecurityGroupAndServerGroup.tsx
@@ -1,4 +1,4 @@
-import { Box, Alert, Autocomplete, Chip, TextField } from '@mui/material'
+import { Box, Alert, Autocomplete, Checkbox, Chip, TextField } from '@mui/material'
 import { useMemo, useEffect, useState } from 'react'
 import { Step, RHFAutocomplete } from 'src/shared/components/forms'
 import { FormGrid } from 'src/components'
@@ -188,6 +188,7 @@ export default function SecurityGroupAndServerGroup({
           />
           <Autocomplete
             multiple
+            disableCloseOnSelect
             size="small"
             loading={loadingProfiles}
             options={applicableProfiles}
@@ -227,8 +228,9 @@ export default function SecurityGroupAndServerGroup({
                 />
               ))
             }
-            renderOption={(props, option) => (
+            renderOption={(props, option, { selected }) => (
               <li {...props} key={option.metadata.name}>
+                <Checkbox style={{ marginRight: 8 }} checked={selected} size="small" />
                 <Box sx={{ display: 'flex', flexDirection: 'column' }}>
                   <Box component="span" sx={{ fontSize: 14 }}>{option.metadata.name}</Box>
                   <Box component="span" sx={{ fontSize: 12, color: 'text.secondary' }}>

--- a/ui/src/hooks/api/useMigrationDetailResourcesQuery.ts
+++ b/ui/src/hooks/api/useMigrationDetailResourcesQuery.ts
@@ -17,7 +17,7 @@ import { getRdmDisksList } from 'src/api/rdm-disks/rdmDisks'
 import type { StorageMapping } from 'src/api/storage-mappings/model'
 import { getStorageMapping } from 'src/api/storage-mappings/storageMappings'
 import type { VMwareMachine } from 'src/api/vmware-machines/model'
-import { getVMwareMachines } from 'src/api/vmware-machines/vmwareMachines'
+import { getVMwareMachine } from 'src/api/vmware-machines/vmwareMachines'
 import type { PCDCluster, PCDClusterList } from 'src/api/pcd-clusters/model'
 import { getPCDClusters } from 'src/api/pcd-clusters/pcdClusters'
 import type { Migration } from 'src/features/migration/api/migrations'
@@ -80,13 +80,6 @@ export const useMigrationDetailResourcesQuery = ({
       const namespace = migration?.metadata?.namespace
       const migrationSpec = migration?.spec as any
       const vmName = (migrationSpec?.vmName as string) || ''
-      const vmStableId =
-        (migrationSpec?.vmId as string) ||
-        (migrationSpec?.vmID as string) ||
-        (migrationSpec?.vmwareMachine as string) ||
-        (migrationSpec?.vmwareMachineName as string) ||
-        (migrationSpec?.vmwareMachineRef as string) ||
-        ''
       const migrationPlanName =
         (migrationSpec?.migrationPlan as string) ||
         (migration?.metadata as any)?.labels?.migrationplan
@@ -174,24 +167,10 @@ export const useMigrationDetailResourcesQuery = ({
           ? -1
           : 0
 
-      const vmwareMachinesList = await safeGet(() => getVMwareMachines(namespace, vmwareRef))
-      const vmwareMachines = vmwareMachinesList?.items || []
-
-      let vmwareMachine: VMwareMachine | null = null
-      if (vmwareMachines.length) {
-        vmwareMachine =
-          vmwareMachines.find((m) => vmStableId && m?.metadata?.name === vmStableId) ||
-          vmwareMachines.find((m) => {
-            const vms = (m?.spec as any)?.vms
-            const vmKey =
-              vms?.name && vms?.vmid
-                ? `${vms.name}-${String(vms.vmid).replace(/^vm-/, '')}`
-                : vms?.name
-            return vmName && vmKey === vmName
-          }) ||
-          vmwareMachines.find((m) => vmName && (m?.spec as any)?.vms?.name === vmName) ||
-          null
-      }
+      const vmwareMachineName = migration.metadata.name.replace(/^migration-/, '')
+      const vmwareMachine: VMwareMachine | null = vmwareMachineName
+        ? await safeGet(() => getVMwareMachine(vmwareMachineName, namespace))
+        : null
 
       const rdmDiskNames = ((vmwareMachine?.spec as any)?.vms?.rdmDisks as string[]) || []
       const effectiveVmName = vmName || ((vmwareMachine?.spec as any)?.vms?.name as string) || ''


### PR DESCRIPTION
## What this PR does / why we need it
- Previously, the migration detail modal fetched all VMwareMachine resources and filtered in-memory to find the relevant one. Since migration names are always migration-<vmwareMachineName>, we can derive the exact resource name and fetch only that single VMwareMachine directly via the Kubernetes API.

- Also added ability to multiselect profiles at once

## Which issue(s) this PR fixes
fixes #1907 

## Testing done

<img width="1439" height="811" alt="image" src="https://github.com/user-attachments/assets/1f2c818e-7b24-4b64-a6d5-72f40f0b83f0" />
