### PR TITLE
#1822: Display All VM IP Addresses in Migration Details Page (Assigned & Preserved IPs)

### DIFF
--- a/ui/src/components/design-system/ui/KeyValueGrid.stories.tsx
+++ b/ui/src/components/design-system/ui/KeyValueGrid.stories.tsx
@@ -29,3 +29,10 @@ export const Default: Story = {
     items: sampleItems
   }
 }
+
+export const ThreeColumnsOnMd: Story = {
+  args: {
+    items: sampleItems,
+    mdGrids: 3
+  }
+}

--- a/ui/src/components/design-system/ui/KeyValueGrid.tsx
+++ b/ui/src/components/design-system/ui/KeyValueGrid.tsx
@@ -11,22 +11,42 @@ export type KeyValueItem = {
 export interface KeyValueGridProps extends Omit<BoxProps, 'children'> {
   items: KeyValueItem[]
   labelWidth?: number
+  mdGrids?: number
 }
 
-export default function KeyValueGrid({ items, labelWidth = 220, ...boxProps }: KeyValueGridProps) {
+export default function KeyValueGrid({
+  items,
+  labelWidth = 150,
+  mdGrids = 2,
+  ...boxProps
+}: KeyValueGridProps) {
+  const normalizedMdGrids = Math.max(1, Math.floor(mdGrids))
+  const mdGridTemplateColumns =
+    normalizedMdGrids === 1
+      ? `${labelWidth}px 1fr`
+      : `${labelWidth}px 1.5fr ${Array.from({ length: normalizedMdGrids - 1 })
+          .map(() => `${labelWidth}px 1fr`)
+          .join(' ')}`
+
   return (
     <Box
       sx={{
         display: 'grid',
-        gridTemplateColumns: { xs: '1fr', sm: `${labelWidth}px 1fr` },
+        gridTemplateColumns: {
+          xs: '1fr',
+          sm: `${labelWidth}px 1fr`,
+          md: mdGridTemplateColumns
+        },
         columnGap: 2,
         rowGap: 1.5,
-        alignItems: 'start'
+        alignItems: 'center',
+        justifyContent: 'right'
       }}
       {...boxProps}
     >
       {items.map((item) => {
-        const value = item.value === undefined || item.value === null || item.value === '' ? '—' : item.value
+        const value =
+          item.value === undefined || item.value === null || item.value === '' ? '—' : item.value
 
         return (
           <Box

--- a/ui/src/components/migrations/MigrationDetailModal.tsx
+++ b/ui/src/components/migrations/MigrationDetailModal.tsx
@@ -193,7 +193,7 @@ export default function MigrationDetailModal({
           : nic?.preserveMAC !== false
 
       const ipType = preserveIP ? 'Preserved' : 'User Assigned'
-      const macType = preserveMAC ? 'Preserved' : 'User Assigned'
+      const macType = preserveMAC ? 'Preserved' : 'Auto Assigned'
 
       const mac = String(nic?.mac || '').trim()
 
@@ -678,12 +678,12 @@ export default function MigrationDetailModal({
                           <Table size="small" sx={{ tableLayout: 'fixed' }}>
                             <TableHead>
                               <TableRow>
-                                <TableCell sx={{ width: '20%' }}>
+                                <TableCell sx={{ width: '22%' }}>
                                   <Box
                                     sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
                                   >
                                     <Typography component="span" variant="inherit">
-                                      MAC Type
+                                      MAC Handling
                                     </Typography>
                                     <Tooltip
                                       slotProps={{
@@ -694,7 +694,7 @@ export default function MigrationDetailModal({
                                         }
                                       }}
                                       title={
-                                        "Preserved: keeps the VM's original MAC address. \nUser Assigned: uses the MAC address you provided in overrides."
+                                        "Preserved: keeps the VM's original MAC address. \nAuto Assigned: assigns a new MAC address at destination."
                                       }
                                       placement="top"
                                     >
@@ -704,13 +704,13 @@ export default function MigrationDetailModal({
                                     </Tooltip>
                                   </Box>
                                 </TableCell>
-                                <TableCell sx={{ width: '20%' }}>MAC</TableCell>
-                                <TableCell sx={{ width: '20%' }}>
+                                <TableCell sx={{ width: '20%' }}>MAC Address</TableCell>
+                                <TableCell sx={{ width: '22%' }}>
                                   <Box
                                     sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
                                   >
                                     <Typography component="span" variant="inherit">
-                                      IP Type
+                                      IP Handling
                                     </Typography>
                                     <Tooltip
                                       slotProps={{
@@ -731,7 +731,7 @@ export default function MigrationDetailModal({
                                     </Tooltip>
                                   </Box>
                                 </TableCell>
-                                <TableCell sx={{ width: '40%' }}>IP Addresses</TableCell>
+                                <TableCell sx={{ width: '36%' }}>IP Addresses</TableCell>
                               </TableRow>
                             </TableHead>
                             <TableBody>

--- a/ui/src/components/migrations/MigrationDetailModal.tsx
+++ b/ui/src/components/migrations/MigrationDetailModal.tsx
@@ -1,6 +1,7 @@
 import {
   Alert,
   Box,
+  Chip,
   CircularProgress,
   Divider,
   FormControlLabel,
@@ -133,7 +134,8 @@ export default function MigrationDetailModal({
   }, [open])
 
   const vmName = useMemo(() => ((migration?.spec as any)?.vmName as string) || '', [migration])
-  const vmKey = (migration?.metadata as any)?.labels?.['vjailbreak.k8s.pf9.io/vm-key'] as string || ''
+  const vmKey =
+    ((migration?.metadata as any)?.labels?.['vjailbreak.k8s.pf9.io/vm-key'] as string) || ''
   const displayVmName = isDuplicate && vmKey ? vmKey : vmName
   const phase = migration?.status?.phase
   const phaseLabel = (phase as string) || 'Unknown'
@@ -182,6 +184,60 @@ export default function MigrationDetailModal({
 
   const vmSpec = (data?.vmwareMachine?.spec as any)?.vms || {}
   const vmMeta = (data?.vmwareMachine?.metadata as any) || {}
+
+  const networkDetails = useMemo(() => {
+    const ifaces = Array.isArray(vmSpec?.networkInterfaces)
+      ? (vmSpec.networkInterfaces as any[])
+      : []
+
+    const rawOverrides = migrationSpec?.networkOverrides
+    let parsedOverrides: any[] = []
+    try {
+      parsedOverrides = Array.isArray(rawOverrides)
+        ? rawOverrides
+        : rawOverrides
+          ? JSON.parse(String(rawOverrides))
+          : []
+    } catch {
+      parsedOverrides = []
+    }
+
+    const overridesByIndex = new Map<number, any>()
+    if (Array.isArray(parsedOverrides)) {
+      for (const o of parsedOverrides) {
+        const idx = Number(o?.interfaceIndex)
+        if (!Number.isNaN(idx)) overridesByIndex.set(idx, o)
+      }
+    }
+
+    return ifaces.map((nic, index) => {
+      const override = overridesByIndex.get(index)
+      const preserveIP =
+        override?.preserveIP !== undefined
+          ? override.preserveIP !== false
+          : nic?.preserveIP !== false
+      const type = preserveIP ? 'Preserved' : 'Assigned'
+
+      const mac = String(nic?.mac || '').trim()
+
+      const preservedIps = Array.isArray(nic?.ipAddress)
+        ? nic.ipAddress.map((ip: any) => String(ip || '').trim()).filter(Boolean)
+        : []
+
+      const assignedIps = String(override?.UserAssignedIP || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+
+      const ips = preserveIP ? preservedIps : assignedIps
+
+      return {
+        mac: mac || 'N/A',
+        type,
+        ips
+      }
+    })
+  }, [migrationSpec?.networkOverrides, vmSpec?.networkInterfaces])
   const sourceDatacenter =
     (vmMeta?.annotations?.['vjailbreak.k8s.pf9.io/datacenter'] as string) ||
     (templateSpec?.source?.datacenter as string) ||
@@ -439,9 +495,7 @@ export default function MigrationDetailModal({
   const imageProfilesForVM = useMemo(() => {
     if (!selectedImageProfileNames.length || !Array.isArray(allProfiles)) return []
     const vmOs = String(guestOS || '').trim()
-    const byName = new Map(
-      allProfiles.map((p) => [String(p?.metadata?.name || ''), p] as const)
-    )
+    const byName = new Map(allProfiles.map((p) => [String(p?.metadata?.name || ''), p] as const))
     return selectedImageProfileNames
       .map((name) => byName.get(name))
       .filter(Boolean)
@@ -639,6 +693,60 @@ export default function MigrationDetailModal({
                 <SurfaceCard variant="card" title="General Info" subtitle="VM specifications">
                   <KeyValueGrid items={generalInfoItems} />
 
+                  {networkDetails.length ? (
+                    <Box sx={{ mt: 2 }}>
+                      <Divider sx={{ mb: 2 }} />
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                        <LanOutlinedIcon fontSize="small" color="action" />
+                        <Typography variant="subtitle2">Network Details</Typography>
+                      </Box>
+                      <TableContainer component={Paper} variant="outlined">
+                        <Table size="small" sx={{ tableLayout: 'fixed' }}>
+                          <TableHead>
+                            <TableRow>
+                              <TableCell sx={{ width: '30%' }}>MAC</TableCell>
+                              <TableCell sx={{ width: '25%' }}>Type</TableCell>
+                              <TableCell sx={{ width: '45%' }}>IP Addresses</TableCell>
+                            </TableRow>
+                          </TableHead>
+                          <TableBody>
+                            {networkDetails.map((row) => (
+                              <TableRow key={`${row.mac}-${row.type}`}>
+                                <TableCell>
+                                  <Typography variant="body2" sx={{ wordBreak: 'break-word' }}>
+                                    {row.mac}
+                                  </Typography>
+                                </TableCell>
+                                <TableCell>
+                                  <Typography variant="body2" color="text.secondary">
+                                    {row.type}
+                                  </Typography>
+                                </TableCell>
+                                <TableCell>
+                                  <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                                    {row.ips.length ? (
+                                      row.ips.map((ip) => (
+                                        <Chip
+                                          key={`${row.mac}-${ip}`}
+                                          label={ip}
+                                          size="small"
+                                          color="info"
+                                          variant="outlined"
+                                        />
+                                      ))
+                                    ) : (
+                                      <Chip label="N/A" size="small" variant="outlined" />
+                                    )}
+                                  </Box>
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                          </TableBody>
+                        </Table>
+                      </TableContainer>
+                    </Box>
+                  ) : null}
+
                   {data?.rdmDisks?.length ? (
                     <Box sx={{ mt: 2 }}>
                       <Divider sx={{ mb: 2 }} />
@@ -715,118 +823,118 @@ export default function MigrationDetailModal({
               </Box>
             ) : (
               <Box sx={{ display: 'grid', gap: 2 }}>
-              <SurfaceCard
-                variant="card"
-                title="Migration Policies"
-                subtitle="Flags and post-migration actions"
-              >
-                <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        size="small"
-                        checked={onlyShowOverrides}
-                        onChange={(e) => handleOnlyShowOverridesChange(e.target.checked)}
-                      />
-                    }
-                    label={<Typography variant="body2">View only enabled options</Typography>}
-                  />
-                </Box>
-
-                {visiblePolicyItems.length ? (
-                  <KeyValueGrid items={visiblePolicyItems} />
-                ) : (
-                  <Typography variant="body2">No advanced options configured.</Typography>
-                )}
-
-                {postMigrationScript || !onlyShowOverrides ? (
-                  <Box sx={{ mt: 2, display: 'grid', gap: 1.5 }}>
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'space-between',
-                        gap: 2
-                      }}
-                    >
-                      <FieldLabel label="Post-migration script" />
-                    </Box>
-
-                    {postMigrationScript ? (
-                      <Paper
-                        variant="outlined"
-                        sx={{
-                          p: 2,
-                          backgroundColor: (theme) => theme.palette.action.hover
-                        }}
-                      >
-                        <Typography
-                          variant="caption"
-                          component="pre"
-                          sx={{
-                            m: 0,
-                            whiteSpace: 'pre-wrap'
-                          }}
-                        >
-                          {postMigrationScript}
-                        </Typography>
-                      </Paper>
-                    ) : (
-                      <Typography variant="body2">N/A</Typography>
-                    )}
-                  </Box>
-                ) : null}
-              </SurfaceCard>
-
-              {selectedImageProfileNames.length ? (
                 <SurfaceCard
                   variant="card"
-                  title="Image Profiles"
-                  subtitle="Cinder volume image metadata applied to the boot volume"
+                  title="Migration Policies"
+                  subtitle="Flags and post-migration actions"
                 >
-                  {imageProfilesForVM.length ? (
-                    <Box sx={{ display: 'grid', gap: 1.5 }}>
-                      {imageProfilesForVM.map((profile) => {
-                        const name = profile.metadata?.name || ''
-                        const osLabel =
-                          OS_FAMILY_LABEL[profile.spec?.osFamily as string] ||
-                          profile.spec?.osFamily ||
-                          'N/A'
-                        const description = profile.spec?.description || ''
-                        const properties = profile.spec?.properties || {}
-                        const propertyItems = Object.entries(properties).map(([k, v]) => ({
-                          label: k,
-                          value: String(v ?? '')
-                        }))
-                        return (
-                          <SurfaceCard
-                            key={name}
-                            variant="section"
-                            title={name}
-                            subtitle={description || undefined}
-                            actions={
-                              <StatusChip label={osLabel} size="small" variant="outlined" />
-                            }
+                  <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          size="small"
+                          checked={onlyShowOverrides}
+                          onChange={(e) => handleOnlyShowOverridesChange(e.target.checked)}
+                        />
+                      }
+                      label={<Typography variant="body2">View only enabled options</Typography>}
+                    />
+                  </Box>
+
+                  {visiblePolicyItems.length ? (
+                    <KeyValueGrid items={visiblePolicyItems} />
+                  ) : (
+                    <Typography variant="body2">No advanced options configured.</Typography>
+                  )}
+
+                  {postMigrationScript || !onlyShowOverrides ? (
+                    <Box sx={{ mt: 2, display: 'grid', gap: 1.5 }}>
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                          gap: 2
+                        }}
+                      >
+                        <FieldLabel label="Post-migration script" />
+                      </Box>
+
+                      {postMigrationScript ? (
+                        <Paper
+                          variant="outlined"
+                          sx={{
+                            p: 2,
+                            backgroundColor: (theme) => theme.palette.action.hover
+                          }}
+                        >
+                          <Typography
+                            variant="caption"
+                            component="pre"
                             sx={{
-                              border: (theme) => `1px solid ${theme.palette.divider}`
+                              m: 0,
+                              whiteSpace: 'pre-wrap'
                             }}
                           >
-                            {propertyItems.length ? (
-                              <KeyValueGrid items={propertyItems} />
-                            ) : (
-                              <Typography variant="body2">No properties configured.</Typography>
-                            )}
-                          </SurfaceCard>
-                        )
-                      })}
+                            {postMigrationScript}
+                          </Typography>
+                        </Paper>
+                      ) : (
+                        <Typography variant="body2">N/A</Typography>
+                      )}
                     </Box>
-                  ) : (
-                    <Typography variant="body2">
-                      No image profiles apply to this VM's OS family.
-                    </Typography>
-                  )}
+                  ) : null}
                 </SurfaceCard>
-              ) : null}
+
+                {selectedImageProfileNames.length ? (
+                  <SurfaceCard
+                    variant="card"
+                    title="Image Profiles"
+                    subtitle="Cinder volume image metadata applied to the boot volume"
+                  >
+                    {imageProfilesForVM.length ? (
+                      <Box sx={{ display: 'grid', gap: 1.5 }}>
+                        {imageProfilesForVM.map((profile) => {
+                          const name = profile.metadata?.name || ''
+                          const osLabel =
+                            OS_FAMILY_LABEL[profile.spec?.osFamily as string] ||
+                            profile.spec?.osFamily ||
+                            'N/A'
+                          const description = profile.spec?.description || ''
+                          const properties = profile.spec?.properties || {}
+                          const propertyItems = Object.entries(properties).map(([k, v]) => ({
+                            label: k,
+                            value: String(v ?? '')
+                          }))
+                          return (
+                            <SurfaceCard
+                              key={name}
+                              variant="section"
+                              title={name}
+                              subtitle={description || undefined}
+                              actions={
+                                <StatusChip label={osLabel} size="small" variant="outlined" />
+                              }
+                              sx={{
+                                border: (theme) => `1px solid ${theme.palette.divider}`
+                              }}
+                            >
+                              {propertyItems.length ? (
+                                <KeyValueGrid items={propertyItems} />
+                              ) : (
+                                <Typography variant="body2">No properties configured.</Typography>
+                              )}
+                            </SurfaceCard>
+                          )
+                        })}
+                      </Box>
+                    ) : (
+                      <Typography variant="body2">
+                        No image profiles apply to this VM's OS family.
+                      </Typography>
+                    )}
+                  </SurfaceCard>
+                ) : null}
               </Box>
             )}
           </Section>

--- a/ui/src/components/migrations/MigrationDetailModal.tsx
+++ b/ui/src/components/migrations/MigrationDetailModal.tsx
@@ -48,16 +48,6 @@ export interface MigrationDetailModalProps {
   isDuplicate?: boolean
 }
 
-const formatCommaSeparated = (value: unknown) => {
-  if (!value) return 'N/A'
-  const parts = String(value)
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean)
-  if (!parts.length) return 'N/A'
-  return parts.join(', ')
-}
-
 const enabledOrNA = (value: unknown) => {
   return value === true ? 'Enabled' : 'N/A'
 }
@@ -151,28 +141,6 @@ export default function MigrationDetailModal({
   const planStrategy = (planSpec?.migrationStrategy as any) || {}
   const planAdvanced = (planSpec?.advancedOptions as any) || {}
   const planPostAction = (planSpec?.postMigrationAction as any) || {}
-
-  const assignedIpFromOverrides = useMemo(() => {
-    const rawOverrides = migrationSpec?.networkOverrides
-    if (!rawOverrides) return ''
-
-    let parsedOverrides: any[] = []
-    try {
-      parsedOverrides = Array.isArray(rawOverrides)
-        ? rawOverrides
-        : JSON.parse(String(rawOverrides))
-    } catch {
-      return ''
-    }
-
-    if (!Array.isArray(parsedOverrides) || parsedOverrides.length === 0) return ''
-
-    const ips = parsedOverrides
-      .map((item) => String(item?.UserAssignedIP || '').trim())
-      .filter(Boolean)
-    return ips.join(',')
-  }, [migrationSpec?.networkOverrides])
-  const assignedIps = formatCommaSeparated(assignedIpFromOverrides)
 
   const initiateCutoverEnabled = migrationSpec?.initiateCutover === true
 

--- a/ui/src/components/migrations/MigrationDetailModal.tsx
+++ b/ui/src/components/migrations/MigrationDetailModal.tsx
@@ -531,7 +531,6 @@ export default function MigrationDetailModal({
     () => [
       { label: 'VM Name', value: displayVmName || 'N/A' },
       { label: 'Migration Type', value: migrationType },
-      { label: 'Assigned IP(s)', value: assignedIps },
       { label: 'Created At', value: createdAt },
       { label: 'Guest OS', value: guestOS },
       { label: 'CPU', value: cpu },
@@ -542,7 +541,6 @@ export default function MigrationDetailModal({
       { label: 'RDM Disks', value: rdmDisksSummary }
     ],
     [
-      assignedIps,
       cpu,
       createdAt,
       diskCount,

--- a/ui/src/components/migrations/MigrationDetailModal.tsx
+++ b/ui/src/components/migrations/MigrationDetailModal.tsx
@@ -5,6 +5,7 @@ import {
   CircularProgress,
   Divider,
   FormControlLabel,
+  IconButton,
   Paper,
   Switch,
   Table,
@@ -13,8 +14,10 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Tooltip,
   Typography
 } from '@mui/material'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import LanOutlinedIcon from '@mui/icons-material/LanOutlined'
 import StorageOutlinedIcon from '@mui/icons-material/StorageOutlined'
 import { SyntheticEvent, useCallback, useEffect, useMemo, useState } from 'react'
@@ -184,7 +187,13 @@ export default function MigrationDetailModal({
         override?.preserveIP !== undefined
           ? override.preserveIP !== false
           : nic?.preserveIP !== false
-      const type = preserveIP ? 'Preserved' : 'Assigned'
+      const preserveMAC =
+        override?.preserveMAC !== undefined
+          ? override.preserveMAC !== false
+          : nic?.preserveMAC !== false
+
+      const ipType = preserveIP ? 'Preserved' : 'User Assigned'
+      const macType = preserveMAC ? 'Preserved' : 'User Assigned'
 
       const mac = String(nic?.mac || '').trim()
 
@@ -201,7 +210,8 @@ export default function MigrationDetailModal({
 
       return {
         mac: mac || 'N/A',
-        type,
+        macType,
+        ipType,
         ips
       }
     })
@@ -662,54 +672,110 @@ export default function MigrationDetailModal({
                   {networkDetails.length ? (
                     <Box sx={{ mt: 2 }}>
                       <Divider sx={{ mb: 2 }} />
-                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                        <LanOutlinedIcon fontSize="small" color="action" />
-                        <Typography variant="subtitle2">Network Details</Typography>
-                      </Box>
-                      <TableContainer component={Paper} variant="outlined">
-                        <Table size="small" sx={{ tableLayout: 'fixed' }}>
-                          <TableHead>
-                            <TableRow>
-                              <TableCell sx={{ width: '30%' }}>MAC</TableCell>
-                              <TableCell sx={{ width: '25%' }}>Type</TableCell>
-                              <TableCell sx={{ width: '45%' }}>IP Addresses</TableCell>
-                            </TableRow>
-                          </TableHead>
-                          <TableBody>
-                            {networkDetails.map((row) => (
-                              <TableRow key={`${row.mac}-${row.type}`}>
-                                <TableCell>
-                                  <Typography variant="body2" sx={{ wordBreak: 'break-word' }}>
-                                    {row.mac}
-                                  </Typography>
-                                </TableCell>
-                                <TableCell>
-                                  <Typography variant="body2" color="text.secondary">
-                                    {row.type}
-                                  </Typography>
-                                </TableCell>
-                                <TableCell>
-                                  <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-                                    {row.ips.length ? (
-                                      row.ips.map((ip) => (
-                                        <Chip
-                                          key={`${row.mac}-${ip}`}
-                                          label={ip}
-                                          size="small"
-                                          color="info"
-                                          variant="outlined"
-                                        />
-                                      ))
-                                    ) : (
-                                      <Chip label="N/A" size="small" variant="outlined" />
-                                    )}
+                      <Box sx={{ display: 'grid', gap: 1 }}>
+                        <FieldLabel label="Network Details" />
+                        <TableContainer component={Paper} variant="outlined">
+                          <Table size="small" sx={{ tableLayout: 'fixed' }}>
+                            <TableHead>
+                              <TableRow>
+                                <TableCell sx={{ width: '20%' }}>
+                                  <Box
+                                    sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+                                  >
+                                    <Typography component="span" variant="inherit">
+                                      MAC Type
+                                    </Typography>
+                                    <Tooltip
+                                      slotProps={{
+                                        tooltip: {
+                                          sx: {
+                                            whiteSpace: 'pre-line'
+                                          }
+                                        }
+                                      }}
+                                      title={
+                                        "Preserved: keeps the VM's original MAC address. \nUser Assigned: uses the MAC address you provided in overrides."
+                                      }
+                                      placement="top"
+                                    >
+                                      <IconButton size="small" sx={{ p: 0.25 }}>
+                                        <InfoOutlinedIcon fontSize="inherit" />
+                                      </IconButton>
+                                    </Tooltip>
                                   </Box>
                                 </TableCell>
+                                <TableCell sx={{ width: '20%' }}>MAC</TableCell>
+                                <TableCell sx={{ width: '20%' }}>
+                                  <Box
+                                    sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+                                  >
+                                    <Typography component="span" variant="inherit">
+                                      IP Type
+                                    </Typography>
+                                    <Tooltip
+                                      slotProps={{
+                                        tooltip: {
+                                          sx: {
+                                            whiteSpace: 'pre-line'
+                                          }
+                                        }
+                                      }}
+                                      title={
+                                        "Preserved: keeps the VM's original IP address. \nUser Assigned: uses the IP address you provided in overrides."
+                                      }
+                                      placement="top"
+                                    >
+                                      <IconButton size="small" sx={{ p: 0.25 }}>
+                                        <InfoOutlinedIcon fontSize="inherit" />
+                                      </IconButton>
+                                    </Tooltip>
+                                  </Box>
+                                </TableCell>
+                                <TableCell sx={{ width: '40%' }}>IP Addresses</TableCell>
                               </TableRow>
-                            ))}
-                          </TableBody>
-                        </Table>
-                      </TableContainer>
+                            </TableHead>
+                            <TableBody>
+                              {networkDetails.map((row) => (
+                                <TableRow key={`${row.mac}-${row.macType}-${row.ipType}`}>
+                                  <TableCell>
+                                    <Typography variant="body2" color="text.secondary">
+                                      {row.macType}
+                                    </Typography>
+                                  </TableCell>
+                                  <TableCell>
+                                    <Typography variant="body2" sx={{ wordBreak: 'break-word' }}>
+                                      {row.mac}
+                                    </Typography>
+                                  </TableCell>
+
+                                  <TableCell>
+                                    <Typography variant="body2" color="text.secondary">
+                                      {row.ipType}
+                                    </Typography>
+                                  </TableCell>
+                                  <TableCell>
+                                    <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                                      {row.ips.length ? (
+                                        row.ips.map((ip) => (
+                                          <Chip
+                                            key={`${row.mac}-${ip}`}
+                                            label={ip}
+                                            size="small"
+                                            color="info"
+                                            variant="outlined"
+                                          />
+                                        ))
+                                      ) : (
+                                        <Chip label="N/A" size="small" variant="outlined" />
+                                      )}
+                                    </Box>
+                                  </TableCell>
+                                </TableRow>
+                              ))}
+                            </TableBody>
+                          </Table>
+                        </TableContainer>
+                      </Box>
                     </Box>
                   ) : null}
 


### PR DESCRIPTION
## What this PR does / why we need it
- Modified the Migration Details drawer to display VM details with Assigned & preserved details
- Modify the UX to display key values in multiple grids to utilise the white space. 

## Which issue(s) this PR fixes
fixes  #1822 

## Testing done
<img width="1536" height="742" alt="Screenshot from 2026-05-07 14-47-27" src="https://github.com/user-attachments/assets/ca9f2491-1a35-43c7-adbd-3204a3187c41" />
<img width="1536" height="742" alt="Screenshot from 2026-05-07 14-47-41" src="https://github.com/user-attachments/assets/2bd17c82-4ffd-4e81-b21d-b28f03d50e94" />
<img width="1536" height="742" alt="Screenshot from 2026-05-07 14-47-49" src="https://github.com/user-attachments/assets/2a02a876-07ef-49c0-a861-caddefdae36e" />

<img width="1536" height="742" alt="Screenshot from 2026-05-07 14-48-08" src="https://github.com/user-attachments/assets/4c311459-a4aa-4ec2-bd3d-e72feb8fc872" />
<img width="1536" height="742" alt="Screenshot from 2026-05-07 14-48-11" src="https://github.com/user-attachments/assets/6ff33c99-f522-47d3-99d9-0fb831aa0253" />


