### PR TITLE
[1913] Fix: Skip VMwareMachine reconciliation for migrated VMs

### DIFF
--- a/k8s/migration/internal/controller/arraycreds_controller.go
+++ b/k8s/migration/internal/controller/arraycreds_controller.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/pkg/errors"
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
-	constants "github.com/platform9/vjailbreak/pkg/common/constants"
 	scope "github.com/platform9/vjailbreak/k8s/migration/pkg/scope"
 	utils "github.com/platform9/vjailbreak/k8s/migration/pkg/utils"
+	constants "github.com/platform9/vjailbreak/pkg/common/constants"
 	storagesdk "github.com/platform9/vjailbreak/pkg/vpwned/sdk/storage"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"

--- a/k8s/migration/internal/controller/bmconfig_controller.go
+++ b/k8s/migration/internal/controller/bmconfig_controller.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/pkg/errors"
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
-	constants "github.com/platform9/vjailbreak/pkg/common/constants"
 	scope "github.com/platform9/vjailbreak/k8s/migration/pkg/scope"
+	constants "github.com/platform9/vjailbreak/pkg/common/constants"
 	providers "github.com/platform9/vjailbreak/pkg/vpwned/sdk/providers"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/k8s/migration/internal/controller/esximigration_controller.go
+++ b/k8s/migration/internal/controller/esximigration_controller.go
@@ -29,9 +29,9 @@ import (
 
 	"github.com/pkg/errors"
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
-	"github.com/platform9/vjailbreak/pkg/common/constants"
 	"github.com/platform9/vjailbreak/k8s/migration/pkg/scope"
 	utils "github.com/platform9/vjailbreak/k8s/migration/pkg/utils"
+	"github.com/platform9/vjailbreak/pkg/common/constants"
 	providers "github.com/platform9/vjailbreak/pkg/vpwned/sdk/providers"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -457,7 +457,7 @@ func GetVMwareMachineForVM(ctx context.Context, r *MigrationPlanReconciler, vm s
 		return nil, errors.Errorf("VMwareMachine %s has incorrect VMwareCreds label: expected %s, got %s", vmMachine.Name, expectedLabel, actualLabel)
 	}
 
-	vmidSuffixed := vmMachine.Spec.VMInfo.Name + "-" + strings.TrimPrefix(vmMachine.Spec.VMInfo.VMID, "vm-")
+	vmidSuffixed := commonutils.GetVMUniqueKey(vmMachine.Spec.VMInfo.Name, vmMachine.Spec.VMInfo.VMID)
 	if vmidSuffixed != vm {
 		return nil, errors.Errorf("VMwareMachine %s VM key mismatch: expected %s, got %s", vmMachine.Name, vm, vmidSuffixed)
 	}
@@ -640,7 +640,7 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 
 		isValid := false
 		for _, v := range validVMs {
-			if v.Spec.VMInfo.Name+"-"+strings.TrimPrefix(v.Spec.VMInfo.VMID, "vm-") == vmName {
+			if commonutils.GetVMUniqueKey(v.Spec.VMInfo.Name, v.Spec.VMInfo.VMID) == vmName {
 				isValid = true
 				break
 			}
@@ -1455,8 +1455,7 @@ func (r *MigrationPlanReconciler) processAdvancedOptions(ctx context.Context,
 // to disambiguate (e.g. "vmname-31090")
 func computeSourceVMKey(vmMachine *vjailbreakv1alpha1.VMwareMachine, allGroups [][]string) string {
 	displayName := vmMachine.Spec.VMInfo.Name
-	moid := strings.TrimPrefix(vmMachine.Spec.VMInfo.VMID, "vm-")
-	currentKey := displayName + "-" + moid
+	currentKey := commonutils.GetVMUniqueKey(displayName, vmMachine.Spec.VMInfo.VMID)
 	for _, group := range allGroups {
 		for _, vmKey := range group {
 			if vmKey == currentKey {

--- a/k8s/migration/internal/controller/rdmdisk_controller.go
+++ b/k8s/migration/internal/controller/rdmdisk_controller.go
@@ -31,8 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
-	constants "github.com/platform9/vjailbreak/pkg/common/constants"
 	utils "github.com/platform9/vjailbreak/k8s/migration/pkg/utils"
+	constants "github.com/platform9/vjailbreak/pkg/common/constants"
 	v2vutils "github.com/platform9/vjailbreak/v2v-helper/pkg/utils"
 )
 

--- a/k8s/migration/internal/controller/rollingmigrationplan_controller.go
+++ b/k8s/migration/internal/controller/rollingmigrationplan_controller.go
@@ -35,9 +35,9 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
-	constants "github.com/platform9/vjailbreak/pkg/common/constants"
 	scope "github.com/platform9/vjailbreak/k8s/migration/pkg/scope"
 	utils "github.com/platform9/vjailbreak/k8s/migration/pkg/utils"
+	constants "github.com/platform9/vjailbreak/pkg/common/constants"
 )
 
 // RollingMigrationPlanReconciler reconciles a RollingMigrationPlan object

--- a/k8s/migration/internal/controller/vmwarecreds_controller.go
+++ b/k8s/migration/internal/controller/vmwarecreds_controller.go
@@ -33,9 +33,9 @@ import (
 
 	"github.com/pkg/errors"
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
-	constants "github.com/platform9/vjailbreak/pkg/common/constants"
 	scope "github.com/platform9/vjailbreak/k8s/migration/pkg/scope"
 	utils "github.com/platform9/vjailbreak/k8s/migration/pkg/utils"
+	constants "github.com/platform9/vjailbreak/pkg/common/constants"
 	vmwarevalidation "github.com/platform9/vjailbreak/pkg/common/validation/vmware"
 	"github.com/platform9/vjailbreak/v2v-helper/pkg/k8sutils"
 )

--- a/k8s/migration/pkg/sdk/resmgr/types.go
+++ b/k8s/migration/pkg/sdk/resmgr/types.go
@@ -45,24 +45,24 @@ type InterfaceAddress struct {
 type Host struct {
 	ID   string `json:"id"`
 	Info struct {
-		Hostname         string      `json:"hostname"`
-		OSFamily         string      `json:"os_family"`
-		Arch             string      `json:"arch"`
-		OSInfo           string      `json:"os_info"`
-		Responding       bool        `json:"responding"`
-		LastResponseTime interface{} `json:"last_response_time"`
+		Hostname         string          `json:"hostname"`
+		OSFamily         string          `json:"os_family"`
+		Arch             string          `json:"arch"`
+		OSInfo           string          `json:"os_info"`
+		Responding       bool            `json:"responding"`
+		LastResponseTime interface{}     `json:"last_response_time"`
 		CPUInfo          json.RawMessage `json:"cpu_info,omitempty"`
 	} `json:"info,omitempty"`
 	Roles              []string               `json:"roles,omitempty"`
 	RolesStatusDetails map[string]string      `json:"roles_status_details,omitempty"`
 	RoleStatus         string                 `json:"role_status,omitempty"`
 	RoleSettings       map[string]interface{} `json:"role_settings,omitempty"`
-	HypervisorInfo     json.RawMessage `json:"hypervisor_info,omitempty"`
-	RawExtensionData json.RawMessage   `json:"-"`
-	CAPIExtension    PF9CAPIExtensions `json:"-"`
-	Extensions       json.RawMessage `json:"extensions,omitempty"`
-	Message      interface{} `json:"message,omitempty"`
-	HostconfigID string      `json:"hostconfig_id,omitempty"`
+	HypervisorInfo     json.RawMessage        `json:"hypervisor_info,omitempty"`
+	RawExtensionData   json.RawMessage        `json:"-"`
+	CAPIExtension      PF9CAPIExtensions      `json:"-"`
+	Extensions         json.RawMessage        `json:"extensions,omitempty"`
+	Message            interface{}            `json:"message,omitempty"`
+	HostconfigID       string                 `json:"hostconfig_id,omitempty"`
 }
 
 // Cluster represents a group of hosts managed as a single entity in Platform9,

--- a/k8s/migration/pkg/utils/bmprovisionerutils.go
+++ b/k8s/migration/pkg/utils/bmprovisionerutils.go
@@ -15,11 +15,11 @@ import (
 
 	"github.com/pkg/errors"
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
-	"github.com/platform9/vjailbreak/pkg/common/constants"
 	scope "github.com/platform9/vjailbreak/k8s/migration/pkg/scope"
 	"github.com/platform9/vjailbreak/k8s/migration/pkg/sdk/keystone"
 	pcd "github.com/platform9/vjailbreak/k8s/migration/pkg/sdk/pcd"
 	"github.com/platform9/vjailbreak/k8s/migration/pkg/sdk/resmgr"
+	"github.com/platform9/vjailbreak/pkg/common/constants"
 	netutils "github.com/platform9/vjailbreak/pkg/common/utils"
 	"github.com/platform9/vjailbreak/pkg/vpwned/api/proto/v1/service"
 	providers "github.com/platform9/vjailbreak/pkg/vpwned/sdk/providers"

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -1017,6 +1017,17 @@ func CreateOrUpdateVMwareMachine(ctx context.Context, client client.Client,
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to get VMwareMachine: %w", err)
 	}
+	if err == nil && vmwvm.Status.Migrated {
+		log.FromContext(ctx).Info(
+			"Skipping VMwareMachine update because VM is already migrated",
+			"VMwareMachine", vmwvmKey.Name,
+			"vmName", vminfo.Name,
+			"vmid", vminfo.VMID,
+			"existingPowerState", vmwvm.Status.PowerState,
+			"refreshedPowerState", vminfo.VMState,
+		)
+		return nil
+	}
 
 	for _, data := range vmwvm.Spec.VMInfo.RDMDisks {
 		if !slices.Contains(vminfo.RDMDisks, data) {
@@ -1846,6 +1857,13 @@ func processSingleVM(ctx context.Context, scope *scope.VMwareCredsScope, vm *obj
 	default:
 		// Object exists
 		if vmwvm.Status.Migrated {
+			log.Info(
+				"Skipping VMwareMachine discovery because VM is already migrated",
+				"VMwareMachine", vmwvmKey.Name,
+				"vmName", vmProps.Config.Name,
+				"vmid", vm.Reference().Value,
+				"powerState", vmwvm.Status.PowerState,
+			)
 			return
 		}
 		if len(guestNetworksFromVmware) > 0 {

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -1272,6 +1272,14 @@ func FindVMwareMachinesNotInVcenter(ctx context.Context, client client.Client, v
 	}
 	var staleVMs []vjailbreakv1alpha1.VMwareMachine
 	for _, vm := range vmList.Items {
+		vmKey := k8stypes.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
+		skip, _, skipErr := ShouldSkipVMwareMachineReconciliation(ctx, client, vmKey, &vm)
+		if skipErr != nil {
+			return nil, errors.Wrap(skipErr, fmt.Sprintf("failed to decide whether VMwareMachine '%s' should be skipped during stale detection", vm.Name))
+		}
+		if skip {
+			continue
+		}
 		// skip vmware machine deletion if it is migrated
 		if !VMExistsInVcenter(vm.Spec.VMInfo.Name, vcenterVMs) && !vm.Status.Migrated {
 			staleVMs = append(staleVMs, vm)
@@ -1939,6 +1947,11 @@ func processSingleVM(ctx context.Context, scope *scope.VMwareCredsScope, vm *obj
 			return
 		}
 		if skip {
+			// Keep a marker in vminfo so stale-deletion paths that only check vcenterVMs
+			// don't treat this intentionally skipped VM as stale.
+			appendToVMInfoThreadSafe(vminfoMu, vminfo, vjailbreakv1alpha1.VMInfo{
+				Name: vmwvm.Spec.VMInfo.Name,
+			})
 			log.Info(
 				"Skipping VMwareMachine discovery because VM is already migrated",
 				"reason", reason,

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -1182,7 +1182,7 @@ func ShouldSkipVMwareMachineReconciliation(ctx context.Context, k8sClient client
 		return true, "vmwaremachine status.migrated is true", nil
 	}
 
-	vmKey := vmKeyForVMwareMachine(vmwvm)
+	vmKey := netutils.GetVMUniqueKey(vmwvm.Spec.VMInfo.Name, vmwvm.Spec.VMInfo.VMID)
 	migration := &vjailbreakv1alpha1.Migration{}
 	migrationKey := k8stypes.NamespacedName{
 		Name:      MigrationNameFromVMName(vmwvmKey.Name),
@@ -1223,13 +1223,6 @@ func ShouldSkipVMwareMachineReconciliation(ctx context.Context, k8sClient client
 	}
 
 	return false, "", nil
-}
-
-func vmKeyForVMwareMachine(vmwvm *vjailbreakv1alpha1.VMwareMachine) string {
-	if vmwvm.Spec.VMInfo.Name == "" || vmwvm.Spec.VMInfo.VMID == "" {
-		return ""
-	}
-	return fmt.Sprintf("%s-%s", vmwvm.Spec.VMInfo.Name, strings.TrimPrefix(vmwvm.Spec.VMInfo.VMID, "vm-"))
 }
 
 func migrationMatchesVMwareMachine(migration *vjailbreakv1alpha1.Migration, vmwvm *vjailbreakv1alpha1.VMwareMachine, vmKey string) bool {

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -987,20 +987,12 @@ func AppendUnique(slice []string, values ...string) []string {
 }
 
 // CreateOrUpdateVMwareMachine creates or updates a VMwareMachine object for the given VM
+//nolint:gocyclo
 func CreateOrUpdateVMwareMachine(ctx context.Context, client client.Client,
 	vmwcreds *vjailbreakv1alpha1.VMwareCreds, vminfo *vjailbreakv1alpha1.VMInfo, datacenter string) error {
 	sanitizedVMName, err := netutils.GetVMK8sCompatibleName(vminfo.Name, vminfo.VMID, vmwcreds.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get VM name: %w", err)
-	}
-	esxiK8sName, err := netutils.GetK8sCompatibleVMWareObjectName(vminfo.ESXiName, vmwcreds.Name)
-	if err != nil {
-		return errors.Wrap(err, "failed to convert ESXi name to k8s name")
-	}
-	clusterK8sID := GetClusterK8sID(vminfo.ClusterName, datacenter)
-	clusterK8sName, err := netutils.GetK8sCompatibleVMWareObjectName(clusterK8sID, vmwcreds.Name)
-	if err != nil {
-		return errors.Wrap(err, "failed to convert cluster name to k8s name")
 	}
 	// We need this flag because, there can be multiple VMwarecreds and each will
 	// trigger its own reconciliation loop,
@@ -1017,16 +1009,32 @@ func CreateOrUpdateVMwareMachine(ctx context.Context, client client.Client,
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to get VMwareMachine: %w", err)
 	}
-	if err == nil && vmwvm.Status.Migrated {
-		log.FromContext(ctx).Info(
-			"Skipping VMwareMachine update because VM is already migrated",
-			"VMwareMachine", vmwvmKey.Name,
-			"vmName", vminfo.Name,
-			"vmid", vminfo.VMID,
-			"existingPowerState", vmwvm.Status.PowerState,
-			"refreshedPowerState", vminfo.VMState,
-		)
-		return nil
+	if err == nil {
+		skip, reason, skipErr := ShouldSkipVMwareMachineReconciliation(ctx, client, vmwvmKey, vmwvm)
+		if skipErr != nil {
+			return skipErr
+		}
+		if skip {
+			log.FromContext(ctx).Info(
+				"Skipping VMwareMachine update during credentials refresh",
+				"reason", reason,
+				"VMwareMachine", vmwvmKey.Name,
+				"vmName", vminfo.Name,
+				"vmid", vminfo.VMID,
+				"existingPowerState", vmwvm.Status.PowerState,
+				"refreshedPowerState", vminfo.VMState,
+			)
+			return nil
+		}
+	}
+	esxiK8sName, err := netutils.GetK8sCompatibleVMWareObjectName(vminfo.ESXiName, vmwcreds.Name)
+	if err != nil {
+		return errors.Wrap(err, "failed to convert ESXi name to k8s name")
+	}
+	clusterK8sID := GetClusterK8sID(vminfo.ClusterName, datacenter)
+	clusterK8sName, err := netutils.GetK8sCompatibleVMWareObjectName(clusterK8sID, vmwcreds.Name)
+	if err != nil {
+		return errors.Wrap(err, "failed to convert cluster name to k8s name")
 	}
 
 	for _, data := range vmwvm.Spec.VMInfo.RDMDisks {
@@ -1136,6 +1144,75 @@ func CreateOrUpdateVMwareMachine(ctx context.Context, client client.Client,
 		return fmt.Errorf("failed to update VMwareMachine status: %w", err)
 	}
 	return nil
+}
+
+// ShouldSkipVMwareMachineReconciliation returns true when a VMwareMachine should not
+// be overwritten by a VMware credentials refresh.
+func ShouldSkipVMwareMachineReconciliation(ctx context.Context, k8sClient client.Client, vmwvmKey k8stypes.NamespacedName, vmwvm *vjailbreakv1alpha1.VMwareMachine) (bool, string, error) {
+	if vmwvm.Status.Migrated {
+		return true, "vmwaremachine status.migrated is true", nil
+	}
+
+	vmKey := vmKeyForVMwareMachine(vmwvm)
+	migration := &vjailbreakv1alpha1.Migration{}
+	migrationKey := k8stypes.NamespacedName{
+		Name:      MigrationNameFromVMName(vmwvmKey.Name),
+		Namespace: vmwvmKey.Namespace,
+	}
+	if err := k8sClient.Get(ctx, migrationKey, migration); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return false, "", fmt.Errorf("failed to get Migration %s while checking whether to skip VMwareMachine reconciliation: %w", migrationKey.Name, err)
+		}
+	} else if migrationMatchesVMwareMachine(migration, vmwvm, vmKey) {
+		log.FromContext(ctx).Info(
+			"Found Migration that prevents VMwareMachine reconciliation",
+			"VMwareMachine", vmwvmKey.Name,
+			"migration", migration.Name,
+			"migrationPhase", migration.Status.Phase,
+			"vmKey", vmKey,
+		)
+		return true, fmt.Sprintf("migration %s exists", migration.Name), nil
+	}
+
+	migrationList := &vjailbreakv1alpha1.MigrationList{}
+	if err := k8sClient.List(ctx, migrationList, client.InNamespace(vmwvmKey.Namespace)); err != nil {
+		return false, "", fmt.Errorf("failed to list Migrations while checking whether to skip VMwareMachine reconciliation: %w", err)
+	}
+	for i := range migrationList.Items {
+		migration := &migrationList.Items[i]
+		if !migrationMatchesVMwareMachine(migration, vmwvm, vmKey) {
+			continue
+		}
+		log.FromContext(ctx).Info(
+			"Found Migration that prevents VMwareMachine reconciliation",
+			"VMwareMachine", vmwvmKey.Name,
+			"migration", migration.Name,
+			"migrationPhase", migration.Status.Phase,
+			"vmKey", vmKey,
+		)
+		return true, fmt.Sprintf("migration %s exists", migration.Name), nil
+	}
+
+	return false, "", nil
+}
+
+func vmKeyForVMwareMachine(vmwvm *vjailbreakv1alpha1.VMwareMachine) string {
+	if vmwvm.Spec.VMInfo.Name == "" || vmwvm.Spec.VMInfo.VMID == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s-%s", vmwvm.Spec.VMInfo.Name, strings.TrimPrefix(vmwvm.Spec.VMInfo.VMID, "vm-"))
+}
+
+func migrationMatchesVMwareMachine(migration *vjailbreakv1alpha1.Migration, vmwvm *vjailbreakv1alpha1.VMwareMachine, vmKey string) bool {
+	if migration == nil {
+		return false
+	}
+	if vmKey != "" && migration.Labels[constants.MigrationVMKeyLabel] == vmKey {
+		return true
+	}
+	return migration.Labels[constants.MigrationVMKeyLabel] == "" &&
+		migration.Spec.VMName != "" &&
+		migration.Spec.VMName == vmwvm.Spec.VMInfo.Name
 }
 
 // CreateOrUpdateLabel creates or updates a label on a VMwareMachine resource
@@ -1856,9 +1933,15 @@ func processSingleVM(ctx context.Context, scope *scope.VMwareCredsScope, vm *obj
 
 	default:
 		// Object exists
-		if vmwvm.Status.Migrated {
+		skip, reason, skipErr := ShouldSkipVMwareMachineReconciliation(ctx, scope.Client, vmwvmKey, vmwvm)
+		if skipErr != nil {
+			appendToVMErrorsThreadSafe(errMu, vmErrors, vm.Name(), skipErr)
+			return
+		}
+		if skip {
 			log.Info(
 				"Skipping VMwareMachine discovery because VM is already migrated",
+				"reason", reason,
 				"VMwareMachine", vmwvmKey.Name,
 				"vmName", vmProps.Config.Name,
 				"vmid", vm.Reference().Value,

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -1005,11 +1005,11 @@ func CreateOrUpdateVMwareMachine(ctx context.Context, client client.Client,
 	vmwvmKey := k8stypes.NamespacedName{Name: sanitizedVMName, Namespace: vmwcreds.Namespace}
 
 	// Try to fetch existing resource
-	err = client.Get(ctx, vmwvmKey, vmwvm)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to get VMwareMachine: %w", err)
+	getErr := client.Get(ctx, vmwvmKey, vmwvm)
+	if getErr != nil && !apierrors.IsNotFound(getErr) {
+		return fmt.Errorf("failed to get VMwareMachine: %w", getErr)
 	}
-	if err == nil {
+	if getErr == nil {
 		skip, reason, skipErr := ShouldSkipVMwareMachineReconciliation(ctx, client, vmwvmKey, vmwvm)
 		if skipErr != nil {
 			return skipErr
@@ -1045,7 +1045,7 @@ func CreateOrUpdateVMwareMachine(ctx context.Context, client client.Client,
 	}
 
 	// Check if the object is present or not if not present create a new object and set init to true.
-	if apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(getErr) {
 		// If not found, create a new object
 		vmwvm = &vjailbreakv1alpha1.VMwareMachine{
 			ObjectMeta: metav1.ObjectMeta{

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -987,7 +987,6 @@ func AppendUnique(slice []string, values ...string) []string {
 }
 
 // CreateOrUpdateVMwareMachine creates or updates a VMwareMachine object for the given VM
-//nolint:gocyclo
 func CreateOrUpdateVMwareMachine(ctx context.Context, client client.Client,
 	vmwcreds *vjailbreakv1alpha1.VMwareCreds, vminfo *vjailbreakv1alpha1.VMInfo, datacenter string) error {
 	sanitizedVMName, err := netutils.GetVMK8sCompatibleName(vminfo.Name, vminfo.VMID, vmwcreds.Name)
@@ -1046,84 +1045,114 @@ func CreateOrUpdateVMwareMachine(ctx context.Context, client client.Client,
 
 	// Check if the object is present or not if not present create a new object and set init to true.
 	if apierrors.IsNotFound(getErr) {
-		// If not found, create a new object
-		vmwvm = &vjailbreakv1alpha1.VMwareMachine{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmwvmKey.Name,
-				Namespace: vmwcreds.Namespace,
-				Labels: map[string]string{
-					constants.VMwareCredsLabel:   vmwcreds.Name,
-					constants.ESXiNameLabel:      esxiK8sName,
-					constants.VMwareClusterLabel: clusterK8sName,
-				},
-				Annotations: map[string]string{
-					constants.VMwareDatacenterLabel: datacenter,
-				},
-			},
-			Spec: vjailbreakv1alpha1.VMwareMachineSpec{
-				VMInfo: *vminfo,
-			},
+		newVM, createErr := createNewVMwareMachine(ctx, client, vmwcreds, vminfo, vmwvmKey, esxiK8sName, clusterK8sName, datacenter)
+		if createErr != nil {
+			return createErr
 		}
-		// Create the new object
-		if err := client.Create(ctx, vmwvm); err != nil {
-			return fmt.Errorf("failed to create VMwareMachine: %w", err)
-		}
+		vmwvm = newVM
 		init = true
 	} else {
-		// Initialize labels map if needed
-		label := fmt.Sprintf("%s-%s", constants.VMwareCredsLabel, vmwcreds.Name)
-		currentOSFamily := vmwvm.Spec.VMInfo.OSFamily
-		// Check if label already exists with same value
-		if vmwvm.Labels == nil || vmwvm.Labels[label] != trueString {
-			// Initialize labels map if needed
-			if vmwvm.Labels == nil {
-				vmwvm.Labels = make(map[string]string)
-			}
-			vmwvm.Labels[label] = trueString
-			// Update only if we made changes
-			if err = client.Update(ctx, vmwvm); err != nil {
-				return fmt.Errorf("failed to update VMwareMachine label: %w", err)
-			}
-		}
-		// Set the new label
-		vmwvm.Labels[constants.VMwareCredsLabel] = vmwcreds.Name
-
-		if !reflect.DeepEqual(vmwvm.Spec.VMInfo, *vminfo) || !reflect.DeepEqual(vmwvm.Labels[constants.ESXiNameLabel], esxiK8sName) || !reflect.DeepEqual(vmwvm.Labels[constants.VMwareClusterLabel], clusterK8sName) {
-			// update vminfo in case the VM has been moved by vMotion
-			assignedIP := ""
-			osType := ""
-
-			if vmwvm.Spec.VMInfo.AssignedIP != "" {
-				assignedIP = vmwvm.Spec.VMInfo.AssignedIP
-			}
-			if vmwvm.Spec.VMInfo.OSFamily != "" {
-				osType = vmwvm.Spec.VMInfo.OSFamily
-			}
-			vmwvm.Spec.VMInfo = *vminfo
-			if assignedIP != "" {
-				vmwvm.Spec.VMInfo.AssignedIP = assignedIP
-			}
-			if osType != "" && vmwvm.Spec.VMInfo.OSFamily == "" {
-				vmwvm.Spec.VMInfo.OSFamily = osType
-			}
-			vmwvm.Labels[constants.ESXiNameLabel] = esxiK8sName
-			vmwvm.Labels[constants.VMwareClusterLabel] = clusterK8sName
-
-			if vmwvm.Annotations == nil {
-				vmwvm.Annotations = make(map[string]string)
-			}
-			vmwvm.Annotations[constants.VMwareDatacenterLabel] = datacenter
-
-			if vmwvm.Spec.VMInfo.OSFamily == "" {
-				vmwvm.Spec.VMInfo.OSFamily = currentOSFamily
-			}
-			// Update only if we made changes
-			if err = client.Update(ctx, vmwvm); err != nil {
-				return fmt.Errorf("failed to update VMwareMachine: %w", err)
-			}
+		if err := updateExistingVMwareMachine(ctx, client, vmwcreds, vminfo, vmwvm, esxiK8sName, clusterK8sName, datacenter); err != nil {
+			return err
 		}
 	}
 
+	return updateVMwareMachineStatus(ctx, client, vmwvm, vminfo, init)
+}
+
+// createNewVMwareMachine constructs and creates a new VMwareMachine object.
+func createNewVMwareMachine(ctx context.Context, client client.Client,
+	vmwcreds *vjailbreakv1alpha1.VMwareCreds, vminfo *vjailbreakv1alpha1.VMInfo,
+	vmwvmKey k8stypes.NamespacedName, esxiK8sName, clusterK8sName, datacenter string,
+) (*vjailbreakv1alpha1.VMwareMachine, error) {
+	vmwvm := &vjailbreakv1alpha1.VMwareMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vmwvmKey.Name,
+			Namespace: vmwcreds.Namespace,
+			Labels: map[string]string{
+				constants.VMwareCredsLabel:   vmwcreds.Name,
+				constants.ESXiNameLabel:      esxiK8sName,
+				constants.VMwareClusterLabel: clusterK8sName,
+			},
+			Annotations: map[string]string{
+				constants.VMwareDatacenterLabel: datacenter,
+			},
+		},
+		Spec: vjailbreakv1alpha1.VMwareMachineSpec{
+			VMInfo: *vminfo,
+		},
+	}
+	// Create the new object
+	if err := client.Create(ctx, vmwvm); err != nil {
+		return nil, fmt.Errorf("failed to create VMwareMachine: %w", err)
+	}
+	return vmwvm, nil
+}
+
+// updateExistingVMwareMachine refreshes labels, annotations and spec on an existing VMwareMachine.
+func updateExistingVMwareMachine(ctx context.Context, client client.Client,
+	vmwcreds *vjailbreakv1alpha1.VMwareCreds, vminfo *vjailbreakv1alpha1.VMInfo,
+	vmwvm *vjailbreakv1alpha1.VMwareMachine, esxiK8sName, clusterK8sName, datacenter string,
+) error {
+	// Initialize labels map if needed
+	label := fmt.Sprintf("%s-%s", constants.VMwareCredsLabel, vmwcreds.Name)
+	currentOSFamily := vmwvm.Spec.VMInfo.OSFamily
+	// Check if label already exists with same value
+	if vmwvm.Labels == nil || vmwvm.Labels[label] != trueString {
+		// Initialize labels map if needed
+		if vmwvm.Labels == nil {
+			vmwvm.Labels = make(map[string]string)
+		}
+		vmwvm.Labels[label] = trueString
+		// Update only if we made changes
+		if err := client.Update(ctx, vmwvm); err != nil {
+			return fmt.Errorf("failed to update VMwareMachine label: %w", err)
+		}
+	}
+	// Set the new label
+	vmwvm.Labels[constants.VMwareCredsLabel] = vmwcreds.Name
+
+	if !reflect.DeepEqual(vmwvm.Spec.VMInfo, *vminfo) || !reflect.DeepEqual(vmwvm.Labels[constants.ESXiNameLabel], esxiK8sName) || !reflect.DeepEqual(vmwvm.Labels[constants.VMwareClusterLabel], clusterK8sName) {
+		// update vminfo in case the VM has been moved by vMotion
+		assignedIP := ""
+		osType := ""
+
+		if vmwvm.Spec.VMInfo.AssignedIP != "" {
+			assignedIP = vmwvm.Spec.VMInfo.AssignedIP
+		}
+		if vmwvm.Spec.VMInfo.OSFamily != "" {
+			osType = vmwvm.Spec.VMInfo.OSFamily
+		}
+		vmwvm.Spec.VMInfo = *vminfo
+		if assignedIP != "" {
+			vmwvm.Spec.VMInfo.AssignedIP = assignedIP
+		}
+		if osType != "" && vmwvm.Spec.VMInfo.OSFamily == "" {
+			vmwvm.Spec.VMInfo.OSFamily = osType
+		}
+		vmwvm.Labels[constants.ESXiNameLabel] = esxiK8sName
+		vmwvm.Labels[constants.VMwareClusterLabel] = clusterK8sName
+
+		if vmwvm.Annotations == nil {
+			vmwvm.Annotations = make(map[string]string)
+		}
+		vmwvm.Annotations[constants.VMwareDatacenterLabel] = datacenter
+
+		if vmwvm.Spec.VMInfo.OSFamily == "" {
+			vmwvm.Spec.VMInfo.OSFamily = currentOSFamily
+		}
+		// Update only if we made changes
+		if err := client.Update(ctx, vmwvm); err != nil {
+			return fmt.Errorf("failed to update VMwareMachine: %w", err)
+		}
+	}
+	return nil
+}
+
+// updateVMwareMachineStatus writes status.powerState/migrated, preserving migrated for existing objects.
+func updateVMwareMachineStatus(ctx context.Context, client client.Client,
+	vmwvm *vjailbreakv1alpha1.VMwareMachine, vminfo *vjailbreakv1alpha1.VMInfo, init bool,
+) error {
 	// Assumption is if init is true, the object is new and it is not migrated hence mark migrated to false.
 	if init {
 		vmwvm.Status = vjailbreakv1alpha1.VMwareMachineStatus{

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -1822,7 +1822,7 @@ func processSingleVM(ctx context.Context, scope *scope.VMwareCredsScope, vm *obj
 	}
 
 	// Convert VM name to Kubernetes-safe name
-	vmName, err := netutils.GetK8sCompatibleVMWareObjectName(vmProps.Config.Name, scope.Name())
+	vmName, err := netutils.GetVMK8sCompatibleName(vmProps.Config.Name, vm.Reference().Value, scope.Name())
 	if err != nil {
 		appendToVMErrorsThreadSafe(errMu, vmErrors, vm.Name(), fmt.Errorf("failed to convert vm name: %w", err))
 	}
@@ -1845,6 +1845,9 @@ func processSingleVM(ctx context.Context, scope *scope.VMwareCredsScope, vm *obj
 
 	default:
 		// Object exists
+		if vmwvm.Status.Migrated {
+			return
+		}
 		if len(guestNetworksFromVmware) > 0 {
 			// Only update if we got fresh data from vCenter
 			guestNetworks = guestNetworksFromVmware

--- a/k8s/migration/pkg/utils/credutils_test.go
+++ b/k8s/migration/pkg/utils/credutils_test.go
@@ -1,0 +1,151 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
+	"github.com/platform9/vjailbreak/pkg/common/constants"
+	netutils "github.com/platform9/vjailbreak/pkg/common/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := vjailbreakv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+	return scheme
+}
+
+func TestCreateOrUpdateVMwareMachine_CreatesWhenMissing(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+
+	vmwcreds := &vjailbreakv1alpha1.VMwareCreds{
+		ObjectMeta: metav1.ObjectMeta{Name: "vmware", Namespace: constants.NamespaceMigrationSystem},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&vjailbreakv1alpha1.VMwareMachine{}).
+		Build()
+
+	vminfo := &vjailbreakv1alpha1.VMInfo{
+		Name:        "win2k12-vjtest",
+		VMID:        "vm-3539",
+		ESXiName:    "10.96.11.240",
+		ClusterName: "cell-1",
+		VMState:     "running",
+	}
+
+	if err := CreateOrUpdateVMwareMachine(ctx, k8sClient, vmwcreds, vminfo, "prison"); err != nil {
+		t.Fatalf("CreateOrUpdateVMwareMachine failed: %v", err)
+	}
+
+	vmName, err := netutils.GetVMK8sCompatibleName(vminfo.Name, vminfo.VMID, vmwcreds.Name)
+	if err != nil {
+		t.Fatalf("failed to compute vm name: %v", err)
+	}
+	got := &vjailbreakv1alpha1.VMwareMachine{}
+	if err := k8sClient.Get(ctx, k8stypes.NamespacedName{Name: vmName, Namespace: constants.NamespaceMigrationSystem}, got); err != nil {
+		t.Fatalf("expected VMwareMachine to be created: %v", err)
+	}
+}
+
+func TestShouldSkipVMwareMachineReconciliation_WhenMigrationExists(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+
+	vmwvm := &vjailbreakv1alpha1.VMwareMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: "sarika-centos7-vj-test-4369-cf786", Namespace: constants.NamespaceMigrationSystem},
+		Spec: vjailbreakv1alpha1.VMwareMachineSpec{
+			VMInfo: vjailbreakv1alpha1.VMInfo{Name: "sarika-centos7-vj-test", VMID: "vm-4369"},
+		},
+	}
+	migration := &vjailbreakv1alpha1.Migration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "migration-sarika-centos7-vj-test-4369-cf786",
+			Namespace: constants.NamespaceMigrationSystem,
+			Labels: map[string]string{
+				constants.MigrationVMKeyLabel: "sarika-centos7-vj-test-4369",
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(vmwvm, migration).
+		Build()
+
+	skip, reason, err := ShouldSkipVMwareMachineReconciliation(
+		ctx, k8sClient,
+		k8stypes.NamespacedName{Name: vmwvm.Name, Namespace: vmwvm.Namespace},
+		vmwvm,
+	)
+	if err != nil {
+		t.Fatalf("ShouldSkipVMwareMachineReconciliation failed: %v", err)
+	}
+	if !skip {
+		t.Fatalf("expected skip=true, got false (reason=%q)", reason)
+	}
+}
+
+func TestFindVMwareMachinesNotInVcenter_SkipsMachineWithMigration(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme(t)
+
+	vmwcreds := &vjailbreakv1alpha1.VMwareCreds{
+		ObjectMeta: metav1.ObjectMeta{Name: "vmware", Namespace: constants.NamespaceMigrationSystem},
+	}
+
+	protectedVM := &vjailbreakv1alpha1.VMwareMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sarika-centos7-vj-test-4369-cf786",
+			Namespace: constants.NamespaceMigrationSystem,
+			Labels: map[string]string{
+				constants.VMwareCredsLabel: vmwcreds.Name,
+			},
+		},
+		Spec: vjailbreakv1alpha1.VMwareMachineSpec{
+			VMInfo: vjailbreakv1alpha1.VMInfo{Name: "sarika-centos7-vj-test", VMID: "vm-4369"},
+		},
+	}
+	ordinaryVM := &vjailbreakv1alpha1.VMwareMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ordinary-vm-0001",
+			Namespace: constants.NamespaceMigrationSystem,
+			Labels: map[string]string{
+				constants.VMwareCredsLabel: vmwcreds.Name,
+			},
+		},
+		Spec: vjailbreakv1alpha1.VMwareMachineSpec{
+			VMInfo: vjailbreakv1alpha1.VMInfo{Name: "ordinary-vm"},
+		},
+	}
+	migration := &vjailbreakv1alpha1.Migration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "migration-sarika-centos7-vj-test-4369-cf786",
+			Namespace: constants.NamespaceMigrationSystem,
+			Labels: map[string]string{
+				constants.MigrationVMKeyLabel: "sarika-centos7-vj-test-4369",
+			},
+		},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(protectedVM, ordinaryVM, migration).
+		Build()
+
+	stale, err := FindVMwareMachinesNotInVcenter(ctx, k8sClient, vmwcreds, nil)
+	if err != nil {
+		t.Fatalf("FindVMwareMachinesNotInVcenter failed: %v", err)
+	}
+	if len(stale) != 1 || stale[0].Name != ordinaryVM.Name {
+		t.Fatalf("expected only ordinary VM to be stale, got %#v", stale)
+	}
+}

--- a/k8s/migration/pkg/utils/maintenance_mode.go
+++ b/k8s/migration/pkg/utils/maintenance_mode.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
-	"github.com/platform9/vjailbreak/pkg/common/constants"
 	"github.com/platform9/vjailbreak/k8s/migration/pkg/scope"
+	"github.com/platform9/vjailbreak/pkg/common/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 

--- a/pkg/common/utils/k8scompat.go
+++ b/pkg/common/utils/k8scompat.go
@@ -84,9 +84,17 @@ func GetK8sCompatibleVMWareObjectName(vCenterObjectName, credName string) (strin
 	return name[:min(len(name), constants.K8sNameMaxLength)], nil
 }
 
+// GetVMUniqueKey returns the stable VM key in "name-<moid>" format.
+func GetVMUniqueKey(vmName, vmid string) string {
+	if vmName == "" || vmid == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s-%s", vmName, strings.TrimPrefix(vmid, "vm-"))
+}
+
 // GetVMK8sCompatibleName returns a k8s compatible name for a VM, using name-<moid> as
 // the stable unique key before hashing. This ensures uniqueness even when two VMs share the same display name.
 func GetVMK8sCompatibleName(vmName, vmid, credName string) (string, error) {
-	vmNameForK8s := fmt.Sprintf("%s-%s", vmName, strings.TrimPrefix(vmid, "vm-"))
+	vmNameForK8s := GetVMUniqueKey(vmName, vmid)
 	return GetK8sCompatibleVMWareObjectName(vmNameForK8s, credName)
 }


### PR DESCRIPTION
## What this PR does / why we need it
When a migrated VM is powered off, VMware reports no IP addresses. During VMwareCreds reconciliation (hourly or manual revalidate), the VMwareMachine spec was being overwritten with this empty data, causing IP addresses to disappear from the Migration Details modal.

Fix:

Add early return when `vmwvm.Status.Migrated == true `to skip reconciliation entirely for migrated VMs
Covers both manual revalidation (UI button) and automatic hourly reconciliation

## Which issue(s) this PR fixes
fixes #1913

## Testing done

- triggered migration of `sarika-centos7-vj-test-4369-cf786 `

<img width="735" height="77" alt="image" src="https://github.com/user-attachments/assets/ab10cf77-cb21-4800-af6f-047664b206b8" />
<img width="1437" height="814" alt="image" src="https://github.com/user-attachments/assets/041d029b-4f09-4bcd-8ed9-3b4a7b727d86" />


- when migration succeeded, the vm was turned off on source. i tried revalidating vmware cred

<img width="1438" height="96" alt="image" src="https://github.com/user-attachments/assets/2e68a13a-a62b-4e92-ba66-fdbb8b07dcf0" />


- migrated vm was skipped in reconcilation

<img width="754" height="74" alt="image" src="https://github.com/user-attachments/assets/04041510-7195-42c7-bf01-a83cbe252eed" />
<img width="1440" height="810" alt="image" src="https://github.com/user-attachments/assets/43af9b70-3b41-41ec-b44a-a2373b207b53" />


- when new creds are added or existing creds gets requeued after defined time, in the discovery also this migrated vm is skipped.

<img width="1440" height="128" alt="image" src="https://github.com/user-attachments/assets/6c0ca57f-d4b5-46b3-9184-105630353490" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/1912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->