### PR TITLE
Bug: Filter Flavor Selection on AZ and flavours without AZ 

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -1544,6 +1544,14 @@ func (r *MigrationPlanReconciler) determineAndSetTargetFlavor(ctx context.Contex
 		return errors.Wrap(err, "failed to list all flavors")
 	}
 
+	// Restrict to flavors that can schedule onto the user-selected target PCD
+	// cluster. In PCD the cluster name is the availability zone, and a flavor
+	// is bound to a cluster via its `availability_zone` extra_spec property.
+	// Flavors without that property are global and remain eligible.
+	if utils.IsOpenstackPCD(*openstackcreds) {
+		allFlavors = openstackpkg.FilterFlavorsByAvailabilityZone(allFlavors, migrationtemplate.Spec.TargetPCDClusterName)
+	}
+
 	useGPUFlavor := migrationtemplate.Spec.UseGPUFlavor && utils.IsOpenstackPCD(*openstackcreds)
 	passthroughGPUCount := vmMachine.Spec.VMInfo.GPU.PassthroughCount
 	vgpuCount := vmMachine.Spec.VMInfo.GPU.VGPUCount

--- a/pkg/common/openstack/flavor.go
+++ b/pkg/common/openstack/flavor.go
@@ -11,6 +11,31 @@ import (
 	"github.com/platform9/vjailbreak/pkg/common/constants"
 )
 
+// AvailabilityZoneExtraSpecKey is the flavor property PCD uses to bind a
+// flavor to a target cluster (the cluster name is the availability zone).
+// A flavor without this property is global and can land on any cluster.
+const AvailabilityZoneExtraSpecKey = "availability_zone"
+
+// FilterFlavorsByAvailabilityZone returns the subset of flavors that can
+// schedule onto targetAZ. A flavor is kept when it has no `availability_zone`
+// property (global) or its property equals targetAZ. Flavors bound to a
+// different AZ are dropped — Nova would otherwise reject placement on the
+// target cluster's hosts. An empty targetAZ disables filtering.
+func FilterFlavorsByAvailabilityZone(allFlavors []flavors.Flavor, targetAZ string) []flavors.Flavor {
+	if targetAZ == "" {
+		return allFlavors
+	}
+	filtered := make([]flavors.Flavor, 0, len(allFlavors))
+	for _, flavor := range allFlavors {
+		flavorAZ, hasAZ := flavor.ExtraSpecs[AvailabilityZoneExtraSpecKey]
+		if hasAZ && flavorAZ != targetAZ {
+			continue
+		}
+		filtered = append(filtered, flavor)
+	}
+	return filtered
+}
+
 // GetClosestFlavour gets the closest flavor for the given CPU, memory, and GPU requirements.
 // useGPUFlavor controls GPU flavor filtering:
 //   - true: Only consider GPU-enabled flavors (even if GPU count = 0)

--- a/pkg/common/openstack/flavor_test.go
+++ b/pkg/common/openstack/flavor_test.go
@@ -126,6 +126,69 @@ func TestGetVGPUCount(t *testing.T) {
 	}
 }
 
+func TestFilterFlavorsByAvailabilityZone(t *testing.T) {
+	global := flavors.Flavor{ID: "global"}
+	gpuOnly := flavors.Flavor{
+		ID:         "gpu-only",
+		ExtraSpecs: map[string]string{"resources:VGPU": "1"},
+	}
+	azTest := flavors.Flavor{
+		ID:         "az-test",
+		ExtraSpecs: map[string]string{"availability_zone": "vjb-test"},
+	}
+	azProd := flavors.Flavor{
+		ID:         "az-prod",
+		ExtraSpecs: map[string]string{"availability_zone": "vjb-prod", "pf9-managed": "true"},
+	}
+	all := []flavors.Flavor{global, gpuOnly, azTest, azProd}
+
+	tests := []struct {
+		name     string
+		targetAZ string
+		want     []string
+	}{
+		{
+			name:     "vjb-test target keeps global, gpu-only, and az-test",
+			targetAZ: "vjb-test",
+			want:     []string{"global", "gpu-only", "az-test"},
+		},
+		{
+			name:     "vjb-prod target keeps global, gpu-only, and az-prod",
+			targetAZ: "vjb-prod",
+			want:     []string{"global", "gpu-only", "az-prod"},
+		},
+		{
+			name:     "unknown AZ keeps only AZ-less flavors",
+			targetAZ: "vjb-other",
+			want:     []string{"global", "gpu-only"},
+		},
+		{
+			name:     "empty targetAZ disables filtering",
+			targetAZ: "",
+			want:     []string{"global", "gpu-only", "az-test", "az-prod"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterFlavorsByAvailabilityZone(all, tt.targetAZ)
+			gotIDs := make([]string, len(got))
+			for i, f := range got {
+				gotIDs[i] = f.ID
+			}
+			if len(gotIDs) != len(tt.want) {
+				t.Fatalf("got %v, want %v", gotIDs, tt.want)
+			}
+			for i := range gotIDs {
+				if gotIDs[i] != tt.want[i] {
+					t.Errorf("got %v, want %v", gotIDs, tt.want)
+					return
+				}
+			}
+		})
+	}
+}
+
 func TestGetClosestFlavourWithGPU(t *testing.T) {
 	allFlavors := []flavors.Flavor{
 		{


### PR DESCRIPTION
## What this PR does / why we need it
So As of now we don't filter flavours based on AZ, All we try to do is select the best flavour for that VM, but there might be a case where the best flavour selected might have AZ: AZ-X but we are migrating to AZ-Y so when we use this flavour to create VM on AZ-Y Nova fails to place this VM. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1878

## Special notes for your reviewer


## Testing done
Created a VMware VM with:

10 vCPU
12 GB RAM

Created multiple PCD flavors to validate flavor auto-selection behavior across AZs/clusters.

Scenario 1 — Flavor Tagged to Different AZ/Cluster

Created flavor test-flavor-cluster mapped to cluster/AZ vjb-test.

a3eb2d20-c993-4e77-9309-83b83c7cced5 | test-flavor-cluster | 12288 | 20 | 0 | 10

Migration target cluster: vjb

Before Fix

vJailbreak incorrectly selected the flavor tied to a different AZ/cluster:

TARGET_FLAVOR_ID: a3eb2d20-c993-4e77-9309-83b83c7cced5

Result:

Nova could not find a valid host in target cluster vjb
VM failed to spawn after disk conversion
After Fix

vJailbreak correctly ignored the incompatible flavor and selected a flavor without AZ restriction:

TARGET_FLAVOR_ID: df33ac70-98a5-426a-88a9-da36cbb7d410
openstack flavor list --insecure | grep df33
| df33ac70-98a5-426a-88a9-da36cbb7d410 | test-flavor-correct | 13312 | 20 | 0 | 11 | True |

Migration completed successfully.

Scenario 2 — Flavor Tagged to Same AZ/Cluster

Created flavor test-flavor-sameaz mapped to the same target AZ/cluster (vjb).

TARGET_FLAVOR_ID: f9876242-e71e-4fe0-86fd-b158404379b6
openstack flavor list --insecure | grep f987
| f9876242-e71e-4fe0-86fd-b158404379b6 | test-flavor-sameaz | 12288 | 20 | 0 | 10 | True |

Result:

Correct flavor selected
VM scheduled successfully
Migration completed successfully
Validation Summary
Flavor tied to a different AZ/cluster is no longer selected
Flavor without AZ restriction is selected correctly
Flavor tied to the target AZ/cluster is selected correctly

_please add testing details (logs, screenshots, etc.)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/1916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->