### PR TITLE
[1920] Added warnings for selected VMs with missing IPs

### DIFF
--- a/ui/src/features/migration/RollingMigrationForm.tsx
+++ b/ui/src/features/migration/RollingMigrationForm.tsx
@@ -35,6 +35,8 @@ import { useKeyboardSubmit } from 'src/hooks/ui/useKeyboardSubmit'
 import { CustomSearchToolbar } from 'src/components/grid'
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism'
 import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism'
+import { MissingInterfaceIpWarningAlert } from './components/MissingInterfaceIpWarningAlert'
+import { getMissingInterfaceIpWarnings } from './components/missingInterfaceIpWarnings'
 import { getVMwareHosts, patchVMwareHost } from 'src/api/vmware-hosts/vmwareHosts'
 import { getVMwareMachines, patchVMwareMachine } from 'src/api/vmware-machines/vmwareMachines'
 import { VMwareHost } from 'src/api/vmware-hosts/model'
@@ -2050,6 +2052,14 @@ export default function RollingMigrationFormDrawer({
     return Array.from(new Set(availableVmwareNetworks))
   }, [availableVmwareNetworks])
 
+  const missingInterfaceIpWarnings = useMemo(
+    () =>
+      getMissingInterfaceIpWarnings(
+        vmsWithAssignments.filter((vm) => selectedVMs.includes(vm.id))
+      ),
+    [selectedVMs, vmsWithAssignments]
+  )
+
   const unmappedNetworksCount = useMemo(() => {
     return uniqueVmwareNetworks.filter((n) => !networkMappings.some((m) => m.source === n)).length
   }, [uniqueVmwareNetworks, networkMappings])
@@ -3575,6 +3585,10 @@ export default function RollingMigrationFormDrawer({
                       loading={loadingVMs}
                     />
                   </Paper>
+                  <MissingInterfaceIpWarningAlert
+                    warnings={missingInterfaceIpWarnings}
+                    sx={{ mt: 2 }}
+                  />
                   {vmIpValidationError && (
                     <Alert severity="warning" sx={{ mt: 2 }}>
                       {vmIpValidationError}

--- a/ui/src/features/migration/VmsSelectionStep.tsx
+++ b/ui/src/features/migration/VmsSelectionStep.tsx
@@ -53,6 +53,8 @@ import { patchRdmDisk } from 'src/api/rdm-disks/rdmDisks'
 import { RdmDisk } from 'src/api/rdm-disks/model'
 import axios from 'axios'
 import { RdmDiskConfigurationPanel } from './components'
+import { MissingInterfaceIpWarningAlert } from './components/MissingInterfaceIpWarningAlert'
+import { getMissingInterfaceIpWarnings } from './components/missingInterfaceIpWarnings'
 import { FieldLabel } from 'src/components'
 import { ActionButton } from 'src/components'
 import { TextField as SharedTextField } from 'src/shared/components/forms'
@@ -2000,6 +2002,11 @@ function VmsSelectionStep({
     [selectedVMs, vmsWithFlavor]
   )
 
+  const missingInterfaceIpWarnings = React.useMemo(
+    () => getMissingInterfaceIpWarnings(vmsWithFlavor.filter((vm) => selectedVMs.has(vm.id))),
+    [selectedVMs, vmsWithFlavor]
+  )
+
   return (
     <VmsSelectionStepContainer>
       {showHeader ? <Step stepNumber="2" label="Select Virtual Machines to Migrate" /> : null}
@@ -2116,6 +2123,7 @@ function VmsSelectionStep({
             />
           </Paper>
         </Box>
+        <MissingInterfaceIpWarningAlert warnings={missingInterfaceIpWarnings} sx={{ mt: 2 }} />
         {error && <FormHelperText error>{error}</FormHelperText>}
         {/* Separate RDM Error Messages */}
         {rdmValidation.hasSelectionError && (

--- a/ui/src/features/migration/components/MissingInterfaceIpWarningAlert.tsx
+++ b/ui/src/features/migration/components/MissingInterfaceIpWarningAlert.tsx
@@ -1,0 +1,45 @@
+import { Alert, Box, SxProps, Theme, Typography } from '@mui/material'
+import type { MissingInterfaceIpWarning } from './missingInterfaceIpWarnings'
+
+interface MissingInterfaceIpWarningAlertProps {
+  warnings: MissingInterfaceIpWarning[]
+  sx?: SxProps<Theme>
+}
+
+export function MissingInterfaceIpWarningAlert({
+  warnings,
+  sx
+}: MissingInterfaceIpWarningAlertProps) {
+  if (warnings.length === 0) return null
+
+  const visibleWarnings = warnings.slice(0, 5)
+  const hiddenWarningCount = warnings.length - visibleWarnings.length
+
+  return (
+    <Alert severity="warning" sx={sx} data-testid="missing-interface-ip-warning">
+      <Box sx={{ display: 'grid', gap: 0.75 }}>
+        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+          Some selected VM interfaces do not have IP addresses from vCenter.
+        </Typography>
+        <Typography variant="body2">
+          If these interfaces have IPs on the source VMs, wait until they appear in the vCenter UI,
+          then revalidate the VMware credential so the latest IP details sync before migration.
+        </Typography>
+        <Typography variant="body2">IP addresses are not found for the following:</Typography>
+        <Box component="ul" sx={{ m: 0, pl: 3, listStyleType: 'disc' }}>
+          {visibleWarnings.map((warning) => (
+            <Typography component="li" variant="body2" key={warning.key} sx={{ display: 'list-item' }}>
+              Interface with MAC {warning.macAddress} for VM {warning.vmName}
+            </Typography>
+          ))}
+          {hiddenWarningCount > 0 && (
+            <Typography component="li" variant="body2" sx={{ display: 'list-item' }}>
+              {hiddenWarningCount} more interface{hiddenWarningCount === 1 ? '' : 's'} with missing
+              IP address information.
+            </Typography>
+          )}
+        </Box>
+      </Box>
+    </Alert>
+  )
+}

--- a/ui/src/features/migration/components/MissingInterfaceIpWarningAlert.tsx
+++ b/ui/src/features/migration/components/MissingInterfaceIpWarningAlert.tsx
@@ -12,33 +12,21 @@ export function MissingInterfaceIpWarningAlert({
 }: MissingInterfaceIpWarningAlertProps) {
   if (warnings.length === 0) return null
 
-  const visibleWarnings = warnings.slice(0, 5)
-  const hiddenWarningCount = warnings.length - visibleWarnings.length
+  const vmNames = warnings.map((warning) => warning.vmName).join(', ')
 
   return (
     <Alert severity="warning" sx={sx} data-testid="missing-interface-ip-warning">
       <Box sx={{ display: 'grid', gap: 0.75 }}>
         <Typography variant="body2" sx={{ fontWeight: 600 }}>
-          Some selected VM interfaces do not have IP addresses from vCenter.
+          Some selected VMs are missing IP addresses from vCenter.
         </Typography>
         <Typography variant="body2">
-          If these interfaces have IPs on the source VMs, wait until they appear in the vCenter UI,
+          If these selected VMs have IPs on the source, wait until they appear in the vCenter UI,
           then revalidate the VMware credential so the latest IP details sync before migration.
         </Typography>
-        <Typography variant="body2">IP addresses are not found for the following:</Typography>
-        <Box component="ul" sx={{ m: 0, pl: 3, listStyleType: 'disc' }}>
-          {visibleWarnings.map((warning) => (
-            <Typography component="li" variant="body2" key={warning.key} sx={{ display: 'list-item' }}>
-              Interface with MAC {warning.macAddress} for VM {warning.vmName}
-            </Typography>
-          ))}
-          {hiddenWarningCount > 0 && (
-            <Typography component="li" variant="body2" sx={{ display: 'list-item' }}>
-              {hiddenWarningCount} more interface{hiddenWarningCount === 1 ? '' : 's'} with missing
-              IP address information.
-            </Typography>
-          )}
-        </Box>
+        <Typography variant="body2">
+          IP addresses are not found for the following VMs: {vmNames}
+        </Typography>
       </Box>
     </Alert>
   )

--- a/ui/src/features/migration/components/missingInterfaceIpWarnings.ts
+++ b/ui/src/features/migration/components/missingInterfaceIpWarnings.ts
@@ -1,0 +1,55 @@
+type NetworkInterfaceWithIp = {
+  mac?: string
+  network?: string
+  ipAddress?: string[] | string | null
+}
+
+type VmWithNetworkInterfaces = {
+  id?: string
+  name?: string
+  powerState?: string
+  vmState?: string
+  networkInterfaces?: NetworkInterfaceWithIp[]
+}
+
+export type MissingInterfaceIpWarning = {
+  key: string
+  vmName: string
+  macAddress: string
+  networkName?: string
+}
+
+const hasDiscoveredIp = (ipAddress?: string[] | string | null) => {
+  if (Array.isArray(ipAddress)) {
+    return ipAddress.some((ip) => Boolean(ip?.trim()))
+  }
+
+  return Boolean(ipAddress?.trim())
+}
+
+const isPoweredOnVm = (vm: VmWithNetworkInterfaces) => {
+  return vm.powerState === 'powered-on' || vm.vmState === 'running'
+}
+
+export const getMissingInterfaceIpWarnings = (
+  selectedVms: VmWithNetworkInterfaces[]
+): MissingInterfaceIpWarning[] => {
+  return selectedVms.filter(isPoweredOnVm).flatMap((vm) => {
+    const vmName = vm.name || vm.id || 'Unknown VM'
+    const interfaces = Array.isArray(vm.networkInterfaces) ? vm.networkInterfaces : []
+
+    return interfaces
+      .map((networkInterface, interfaceIndex) => ({ networkInterface, interfaceIndex }))
+      .filter(({ networkInterface }) => !hasDiscoveredIp(networkInterface.ipAddress))
+      .map(({ networkInterface, interfaceIndex }) => {
+        const macAddress = networkInterface.mac || 'MAC unavailable'
+
+        return {
+          key: `${vm.id || vmName}-${interfaceIndex}-${macAddress}`,
+          vmName,
+          macAddress,
+          networkName: networkInterface.network
+        }
+      })
+  })
+}

--- a/ui/src/features/migration/components/missingInterfaceIpWarnings.ts
+++ b/ui/src/features/migration/components/missingInterfaceIpWarnings.ts
@@ -1,6 +1,4 @@
 type NetworkInterfaceWithIp = {
-  mac?: string
-  network?: string
   ipAddress?: string[] | string | null
 }
 
@@ -13,10 +11,7 @@ type VmWithNetworkInterfaces = {
 }
 
 export type MissingInterfaceIpWarning = {
-  key: string
   vmName: string
-  macAddress: string
-  networkName?: string
 }
 
 const hasDiscoveredIp = (ipAddress?: string[] | string | null) => {
@@ -34,22 +29,13 @@ const isPoweredOnVm = (vm: VmWithNetworkInterfaces) => {
 export const getMissingInterfaceIpWarnings = (
   selectedVms: VmWithNetworkInterfaces[]
 ): MissingInterfaceIpWarning[] => {
-  return selectedVms.filter(isPoweredOnVm).flatMap((vm) => {
-    const vmName = vm.name || vm.id || 'Unknown VM'
-    const interfaces = Array.isArray(vm.networkInterfaces) ? vm.networkInterfaces : []
+  const vmNames = selectedVms
+    .filter(isPoweredOnVm)
+    .filter((vm) => {
+      const interfaces = Array.isArray(vm.networkInterfaces) ? vm.networkInterfaces : []
+      return interfaces.some((networkInterface) => !hasDiscoveredIp(networkInterface.ipAddress))
+    })
+    .map((vm) => vm.name || vm.id || 'Unknown VM')
 
-    return interfaces
-      .map((networkInterface, interfaceIndex) => ({ networkInterface, interfaceIndex }))
-      .filter(({ networkInterface }) => !hasDiscoveredIp(networkInterface.ipAddress))
-      .map(({ networkInterface, interfaceIndex }) => {
-        const macAddress = networkInterface.mac || 'MAC unavailable'
-
-        return {
-          key: `${vm.id || vmName}-${interfaceIndex}-${macAddress}`,
-          vmName,
-          macAddress,
-          networkName: networkInterface.network
-        }
-      })
-  })
+  return Array.from(new Set(vmNames)).map((vmName) => ({ vmName }))
 }


### PR DESCRIPTION
## What this PR does / why we need it
This adds a warning in VM selection flows when a selected powered-on VM has one or more network interfaces without discovered IP addresses.

The warning is non-blocking and lists the affected VM/interface MAC addresses. It guides users to wait until the IPs appear in the vCenter UI and then revalidate the VMware credential so the latest IP details sync before migration.

## Which issue(s) this PR fixes
fixes #1920 

## Testing done
- Turned this VM on but without waiting for IPs to come up on Vcenter UI, i revalidated the creds
<img width="2880" height="1016" alt="image" src="https://github.com/user-attachments/assets/f687cabd-342b-488b-acc5-ba89a915c1cb" />

- warning 
<img width="1303" height="678" alt="image" src="https://github.com/user-attachments/assets/7a8b7a51-f149-479e-85bd-ecbd83e965a5" />


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/1918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->