### PR TITLE
[1925] ci: Shift nightly build trigger to 01:00 IST

### DIFF
--- a/.github/workflows/nightly-build-trigger.yml
+++ b/.github/workflows/nightly-build-trigger.yml
@@ -2,8 +2,8 @@ name: Nightly Build Trigger
 
 on:
   schedule:
-    # Run at 00:00 UTC every day
-    - cron: '0 0 * * *'
+    # Run at 19:30 UTC every day (01:00 IST)
+    - cron: '30 19 * * *'
   # Allow manual triggering
   workflow_dispatch:
 


### PR DESCRIPTION
## What this PR does / why we need it
Shift nightly build trigger to 01:00 IST so test reports ready by morning


## Which issue(s) this PR fixes
fixes #1925

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/1924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->