### PR TITLE
[1840] Added the ability to migrate the VMs with no interface

### DIFF
--- a/k8s/migration/api/v1alpha1/migrationtemplate_types.go
+++ b/k8s/migration/api/v1alpha1/migrationtemplate_types.go
@@ -39,8 +39,11 @@ type MigrationTemplateSpec struct {
 	OSFamily string `json:"osFamily,omitempty"`
 	// VirtioWinDriver is the driver to be used for the virtual machine
 	VirtioWinDriver string `json:"virtioWinDriver,omitempty"`
-	// NetworkMapping is the reference to the NetworkMapping resource that defines source to destination network mappings
-	NetworkMapping string `json:"networkMapping"`
+	// NetworkMapping is the reference to the NetworkMapping resource that defines source to destination network mappings.
+	// Optional: when the selected VMs have no attached VMware networks, no NetworkMapping is required and this field
+	// may be empty. The controller will skip network reconciliation in that case.
+	// +optional
+	NetworkMapping string `json:"networkMapping,omitempty"`
 	// StorageMapping is the reference to the StorageMapping resource that defines source to destination storage mappings
 	// This is used for normal data copy method
 	StorageMapping string `json:"storageMapping,omitempty"`

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationtemplates.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationtemplates.yaml
@@ -62,8 +62,10 @@ spec:
                 - openstackRef
                 type: object
               networkMapping:
-                description: NetworkMapping is the reference to the NetworkMapping
-                  resource that defines source to destination network mappings
+                description: |-
+                  NetworkMapping is the reference to the NetworkMapping resource that defines source to destination network mappings.
+                  Optional: when the selected VMs have no attached VMware networks, no NetworkMapping is required and this field
+                  may be empty. The controller will skip network reconciliation in that case.
                 type: string
               osFamily:
                 description: OSFamily is the OS type of the virtual machine
@@ -113,7 +115,6 @@ spec:
                 type: string
             required:
             - destination
-            - networkMapping
             - source
             type: object
         type: object

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -1828,6 +1828,22 @@ func (r *MigrationPlanReconciler) reconcileNetwork(ctx context.Context,
 	openstackcreds *vjailbreakv1alpha1.OpenstackCreds,
 	vmnws []string,
 ) ([]string, error) {
+	// If the VM has no networks attached and no NetworkMapping is configured on
+	// the template, there is nothing to reconcile. This supports submitting
+	// migrations for VMs with no NICs where the UI also skipped creating a
+	// NetworkMapping resource.
+	if len(vmnws) == 0 && migrationtemplate.Spec.NetworkMapping == "" {
+		return []string{}, nil
+	}
+
+	// A NetworkMapping must exist if the VM has at least one network.
+	if migrationtemplate.Spec.NetworkMapping == "" {
+		return nil, errors.Errorf(
+			"VM has %d network(s) but MigrationTemplate %s has no NetworkMapping configured",
+			len(vmnws), migrationtemplate.Name,
+		)
+	}
+
 	var err error
 	// Fetch the networkmap
 	networkmap := &vjailbreakv1alpha1.NetworkMapping{}

--- a/ui/src/features/migration/MigrationForm.tsx
+++ b/ui/src/features/migration/MigrationForm.tsx
@@ -45,6 +45,7 @@ import { flatten } from 'ramda'
 import { useClusterData } from './useClusterData'
 import { useErrorHandler } from 'src/hooks/useErrorHandler'
 import { useRdmConfigValidation } from 'src/hooks/useRdmConfigValidation'
+import { useNetworkMappingValidation } from 'src/hooks/useNetworkMappingValidation'
 import { useRdmDisksQuery } from 'src/hooks/api/useRdmDisksQuery'
 import { useAmplitude } from 'src/hooks/useAmplitude'
 import { AMPLITUDE_EVENTS } from 'src/types/amplitude'
@@ -566,6 +567,16 @@ export default function MigrationFormDrawer({
     return uniq(flatten(params.vms.map((vm) => vm.datastores || []))).sort(stringsCompareFn)
   }, [params.vms])
 
+  // Network-mapping validation. When none of the selected VMs have an
+  // interface, network mapping is not required and the form must not block
+  // on params.networkMappings being empty.
+  const networkMappingValidation = useNetworkMappingValidation({
+    selectedVMs: params.vms || [],
+    networkMappings: params.networkMappings || [],
+    availableVmwareNetworks
+  })
+  const networkMappingRequired = networkMappingValidation.required
+
   const createNetworkMapping = async (networkMappingParams) => {
     const body = createNetworkMappingJson({
       networkMappings: networkMappingParams
@@ -1077,10 +1088,12 @@ export default function MigrationFormDrawer({
     !vmwareCredsValidated ||
     !openstackCredsValidated ||
     isNilOrEmpty(params.vms) ||
-    isNilOrEmpty(params.networkMappings) ||
+    // Network mapping is only required when at least one selected VM has
+    // an interface. NIC-less VMs skip this gate entirely.
+    (networkMappingRequired && isNilOrEmpty(params.networkMappings)) ||
     isNilOrEmpty(params.vmwareCluster) ||
     isNilOrEmpty(params.pcdCluster) ||
-    // Check if all networks are mapped
+    // Check if all networks (if any) are mapped
     availableVmwareNetworks.some(
       (network) => !params.networkMappings?.some((mapping) => mapping.source === network)
     ) ||
@@ -1203,9 +1216,14 @@ export default function MigrationFormDrawer({
     if (!params.vms || params.vms.length === 0) return false
     if (fieldErrors['networksMapping'] || fieldErrors['storageMapping']) return false
 
-    const networkMapped = availableVmwareNetworks.every((network) =>
-      (params.networkMappings || []).some((m) => m.source === network)
-    )
+    // Treat the network mapping sub-step as complete when no source networks
+    // exist (all selected VMs are NIC-less) — there is nothing for the user
+    // to map.
+    const networkMapped =
+      availableVmwareNetworks.length === 0 ||
+      availableVmwareNetworks.every((network) =>
+        (params.networkMappings || []).some((m) => m.source === network)
+      )
 
     const currentStorageCopyMethod = params.storageCopyMethod || 'normal'
     const storageMapped =

--- a/ui/src/features/migration/MigrationForm.tsx
+++ b/ui/src/features/migration/MigrationForm.tsx
@@ -661,9 +661,16 @@ export default function MigrationFormDrawer({
 
     const updatedMigrationTemplateFields: any = {
       spec: {
-        networkMapping: networkMappings.metadata.name,
         storageCopyMethod
       }
+    }
+
+    // Only include networkMapping if one was actually created.
+    // When networkMappingRequired is false (no VMware networks to map),
+    // networkMappings will be null/undefined and the backend treats the
+    // networkMapping field as optional.
+    if (networkMappings?.metadata?.name) {
+      updatedMigrationTemplateFields.spec.networkMapping = networkMappings.metadata.name
     }
 
     // Add either arrayCredsMapping or storageMapping based on method
@@ -922,12 +929,18 @@ export default function MigrationFormDrawer({
 
     const storageCopyMethod = params.storageCopyMethod || 'normal'
 
-    // Create NetworkMapping
-    const networkMappings = await createNetworkMapping(params.networkMappings)
-
-    if (!networkMappings) {
-      setSubmitting(false)
-      return
+    // Create NetworkMapping only if required.
+    // When networkMappingRequired is false (no VMware networks attached to the
+    // selected VMs), there is nothing to map, so we skip creating the
+    // NetworkMapping resource entirely and pass null through to
+    // updateMigrationTemplate.
+    let networkMappings: any = null
+    if (networkMappingRequired) {
+      networkMappings = await createNetworkMapping(params.networkMappings)
+      if (!networkMappings) {
+        setSubmitting(false)
+        return
+      }
     }
 
     let storageMappings: any = null
@@ -975,6 +988,7 @@ export default function MigrationFormDrawer({
     params.storageMappings,
     params.arrayCredsMappings,
     params.storageCopyMethod,
+    networkMappingRequired,
     migrationTemplate,
     createNetworkMapping,
     createStorageMapping,

--- a/ui/src/features/migration/MigrationForm.tsx
+++ b/ui/src/features/migration/MigrationForm.tsx
@@ -567,9 +567,6 @@ export default function MigrationFormDrawer({
     return uniq(flatten(params.vms.map((vm) => vm.datastores || []))).sort(stringsCompareFn)
   }, [params.vms])
 
-  // Network-mapping validation. When none of the selected VMs have an
-  // interface, network mapping is not required and the form must not block
-  // on params.networkMappings being empty.
   const networkMappingValidation = useNetworkMappingValidation({
     selectedVMs: params.vms || [],
     networkMappings: params.networkMappings || [],
@@ -1088,12 +1085,9 @@ export default function MigrationFormDrawer({
     !vmwareCredsValidated ||
     !openstackCredsValidated ||
     isNilOrEmpty(params.vms) ||
-    // Network mapping is only required when at least one selected VM has
-    // an interface. NIC-less VMs skip this gate entirely.
     (networkMappingRequired && isNilOrEmpty(params.networkMappings)) ||
     isNilOrEmpty(params.vmwareCluster) ||
     isNilOrEmpty(params.pcdCluster) ||
-    // Check if all networks (if any) are mapped
     availableVmwareNetworks.some(
       (network) => !params.networkMappings?.some((mapping) => mapping.source === network)
     ) ||
@@ -1216,9 +1210,6 @@ export default function MigrationFormDrawer({
     if (!params.vms || params.vms.length === 0) return false
     if (fieldErrors['networksMapping'] || fieldErrors['storageMapping']) return false
 
-    // Treat the network mapping sub-step as complete when no source networks
-    // exist (all selected VMs are NIC-less) — there is nothing for the user
-    // to map.
     const networkMapped =
       availableVmwareNetworks.length === 0 ||
       availableVmwareNetworks.every((network) =>

--- a/ui/src/features/migration/NetworkAndStorageMappingStep.tsx
+++ b/ui/src/features/migration/NetworkAndStorageMappingStep.tsx
@@ -370,7 +370,10 @@ export default function NetworkAndStorageMappingStep({
   }, [vmWareStorage, params.storageMappings, params.arrayCredsMappings, storageCopyMethod])
 
   // Calculate completion status
-  const networksFullyMapped = unmappedNetworks.length === 0 && vmwareNetworks.length > 0
+  // Selected VMs may not contribute any source networks (e.g. NIC-less VMs).
+  // In that case there is nothing to map and the sub-step is treated as N/A.
+  const hasSourceNetworks = vmwareNetworks.length > 0
+  const networksFullyMapped = hasSourceNetworks && unmappedNetworks.length === 0
   const storageFullyMapped = unmappedStorage.length === 0 && vmWareStorage.length > 0
 
   return (
@@ -392,8 +395,16 @@ export default function NetworkAndStorageMappingStep({
                   mb: 1
                 }}
               >
-                <FieldLabel label="Map Networks" required align="flex-start" />
-                {networksFullyMapped ? (
+                <FieldLabel
+                  label="Map Networks"
+                  required={hasSourceNetworks}
+                  align="flex-start"
+                />
+                {!hasSourceNetworks ? (
+                  <Typography variant="body2" color="text.secondary">
+                    Not required
+                  </Typography>
+                ) : networksFullyMapped ? (
                   <Typography variant="body2" color="success.main">
                     All networks mapped ✓
                   </Typography>
@@ -403,25 +414,34 @@ export default function NetworkAndStorageMappingStep({
                   </Typography>
                 )}
               </Box>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                Select source and target networks to automatically create mappings. All networks
-                must be mapped to proceed.
-              </Typography>
-              <ResourceMappingTable
-                sourceItems={vmwareNetworks}
-                targetItems={openstackNetworkNames}
-                sourceLabel="VMware Network"
-                targetLabel="PCD Network"
-                values={params.networkMappings || []}
-                onChange={(value) => onChange('networkMappings')(value)}
-                oneToManyMapping
-                fieldPrefix="networkMapping"
-              />
-              {Object.entries(subnetWarnings).map(([sourceNetwork, warning]) => (
-                <Alert key={sourceNetwork} severity="warning" sx={{ mt: 1 }}>
-                  <strong>{sourceNetwork}:</strong> {warning}
+              {hasSourceNetworks ? (
+                <>
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                    Select source and target networks to automatically create mappings. All
+                    networks must be mapped to proceed.
+                  </Typography>
+                  <ResourceMappingTable
+                    sourceItems={vmwareNetworks}
+                    targetItems={openstackNetworkNames}
+                    sourceLabel="VMware Network"
+                    targetLabel="PCD Network"
+                    values={params.networkMappings || []}
+                    onChange={(value) => onChange('networkMappings')(value)}
+                    oneToManyMapping
+                    fieldPrefix="networkMapping"
+                  />
+                  {Object.entries(subnetWarnings).map(([sourceNetwork, warning]) => (
+                    <Alert key={sourceNetwork} severity="warning" sx={{ mt: 1 }}>
+                      <strong>{sourceNetwork}:</strong> {warning}
+                    </Alert>
+                  ))}
+                </>
+              ) : (
+                <Alert severity="info" sx={{ mt: 1 }}>
+                  None of the selected VMs have network interfaces. Network mapping is not
+                  required for this plan — you can proceed to the next step.
                 </Alert>
-              ))}
+              )}
               {networkMappingError && <FormHelperText error>{networkMappingError}</FormHelperText>}
             </FormControl>
             <FormControl error={!!storageMappingError}>

--- a/ui/src/features/migration/NetworkAndStorageMappingStep.tsx
+++ b/ui/src/features/migration/NetworkAndStorageMappingStep.tsx
@@ -370,8 +370,6 @@ export default function NetworkAndStorageMappingStep({
   }, [vmWareStorage, params.storageMappings, params.arrayCredsMappings, storageCopyMethod])
 
   // Calculate completion status
-  // Selected VMs may not contribute any source networks (e.g. NIC-less VMs).
-  // In that case there is nothing to map and the sub-step is treated as N/A.
   const hasSourceNetworks = vmwareNetworks.length > 0
   const networksFullyMapped = hasSourceNetworks && unmappedNetworks.length === 0
   const storageFullyMapped = unmappedStorage.length === 0 && vmWareStorage.length > 0

--- a/ui/src/features/migration/RollingMigrationForm.tsx
+++ b/ui/src/features/migration/RollingMigrationForm.tsx
@@ -78,6 +78,7 @@ import LinuxIcon from 'src/assets/linux_icon.svg'
 import WarningIcon from '@mui/icons-material/Warning'
 import { useClusterData } from './useClusterData'
 import { useErrorHandler } from 'src/hooks/useErrorHandler'
+import { vmHasInterface } from 'src/features/migration/utils/vmNetworking'
 
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import ErrorIcon from '@mui/icons-material/Error'
@@ -1149,7 +1150,9 @@ export default function RollingMigrationFormDrawer({
     }
   }
 
-  // Validate IP addresses for selected VMs
+  // Validate IP addresses for selected VMs.
+  // VMs without any network interface are exempt — there is nothing to assign
+  // an IP to, and they are valid migration targets (e.g. disk-only appliances).
   const vmIpValidation = useMemo(() => {
     if (selectedVMs.length === 0) {
       setVmIpValidationError('Please select VMs to assign IP addresses.')
@@ -1157,10 +1160,11 @@ export default function RollingMigrationFormDrawer({
     }
 
     const selectedVMsData = vmsWithAssignments.filter((vm) => selectedVMs.includes(vm.id))
-    const vmsWithoutIPs = selectedVMsData.filter((vm) => vm.ip === '—' || !vm.ip)
+    const vmsRequiringIp = selectedVMsData.filter(vmHasInterface)
+    const vmsWithoutIPs = vmsRequiringIp.filter((vm) => vm.ip === '—' || !vm.ip)
 
     if (vmsWithoutIPs.length > 0) {
-      const errorMessage = `Cannot proceed with Migration: ${vmsWithoutIPs.length} selected VM${vmsWithoutIPs.length === 1 ? '' : 's'} do not have IP addresses assigned. Please assign IP addresses to all selected VMs before continuing.`
+      const errorMessage = `Cannot proceed with Migration: ${vmsWithoutIPs.length} selected VM${vmsWithoutIPs.length === 1 ? '' : 's'} with network interfaces do not have IP addresses assigned. Please assign IP addresses to all selected VMs before continuing.`
       setVmIpValidationError(errorMessage)
       return { hasError: true, vmsWithoutIPs }
     } else {

--- a/ui/src/features/migration/RollingMigrationForm.tsx
+++ b/ui/src/features/migration/RollingMigrationForm.tsx
@@ -1150,9 +1150,7 @@ export default function RollingMigrationFormDrawer({
     }
   }
 
-  // Validate IP addresses for selected VMs.
-  // VMs without any network interface are exempt — there is nothing to assign
-  // an IP to, and they are valid migration targets (e.g. disk-only appliances).
+  // Validate IP addresses for selected VMs
   const vmIpValidation = useMemo(() => {
     if (selectedVMs.length === 0) {
       setVmIpValidationError('Please select VMs to assign IP addresses.')

--- a/ui/src/features/migration/utils/vmNetworking.ts
+++ b/ui/src/features/migration/utils/vmNetworking.ts
@@ -1,0 +1,49 @@
+/**
+ * Minimal structural shape required by the network predicates.
+ *
+ * Several VM types in the UI (VmData from migration-templates, the local VM
+ * type in RollingMigrationForm) share these fields but not their NIC types,
+ * so the predicates use a structural shape rather than a concrete import.
+ */
+interface VmLike {
+  networks?: string[]
+  networkInterfaces?: unknown[]
+}
+
+interface VmIpLike {
+  assignedIPs?: string
+  ipAddress?: string
+  networkInterfaces?: { ipAddress?: string[] | unknown }[]
+}
+
+/**
+ * A VM "has an interface" when it contributes at least one source network
+ * (vm.networks) or has any networkInterfaces entries. NIC-less VMs are
+ * legitimate migration targets — they simply don't participate in network
+ * mapping or per-VM IP assignment.
+ */
+export const vmHasInterface = (vm: VmLike): boolean =>
+  Boolean(
+    (vm.networks && vm.networks.length > 0) ||
+    (vm.networkInterfaces && vm.networkInterfaces.length > 0)
+  )
+
+/**
+ * Returns true when the VM has at least one usable IP address — either an
+ * assigned (override) IP, the discovered ipAddress field, or a non-empty
+ * IP on one of its NICs.
+ *
+ * Note: this is intentionally lenient and is meant to gate "does this VM
+ * need an IP assigned?" checks; it is NOT a syntactic IP validator.
+ */
+export const vmHasIp = (vm: VmIpLike): boolean => {
+  if (vm.assignedIPs && vm.assignedIPs.trim() !== '') return true
+  if (vm.ipAddress && vm.ipAddress !== '—' && vm.ipAddress.trim() !== '') return true
+  return Boolean(
+    vm.networkInterfaces?.some(
+      (nic) =>
+        Array.isArray(nic.ipAddress) &&
+        (nic.ipAddress as string[]).some((ip) => ip && ip.trim() !== '')
+    )
+  )
+}

--- a/ui/src/features/migration/utils/vmNetworking.ts
+++ b/ui/src/features/migration/utils/vmNetworking.ts
@@ -1,10 +1,3 @@
-/**
- * Minimal structural shape required by the network predicates.
- *
- * Several VM types in the UI (VmData from migration-templates, the local VM
- * type in RollingMigrationForm) share these fields but not their NIC types,
- * so the predicates use a structural shape rather than a concrete import.
- */
 interface VmLike {
   networks?: string[]
   networkInterfaces?: unknown[]
@@ -16,26 +9,12 @@ interface VmIpLike {
   networkInterfaces?: { ipAddress?: string[] | unknown }[]
 }
 
-/**
- * A VM "has an interface" when it contributes at least one source network
- * (vm.networks) or has any networkInterfaces entries. NIC-less VMs are
- * legitimate migration targets — they simply don't participate in network
- * mapping or per-VM IP assignment.
- */
 export const vmHasInterface = (vm: VmLike): boolean =>
   Boolean(
     (vm.networks && vm.networks.length > 0) ||
     (vm.networkInterfaces && vm.networkInterfaces.length > 0)
   )
 
-/**
- * Returns true when the VM has at least one usable IP address — either an
- * assigned (override) IP, the discovered ipAddress field, or a non-empty
- * IP on one of its NICs.
- *
- * Note: this is intentionally lenient and is meant to gate "does this VM
- * need an IP assigned?" checks; it is NOT a syntactic IP validator.
- */
 export const vmHasIp = (vm: VmIpLike): boolean => {
   if (vm.assignedIPs && vm.assignedIPs.trim() !== '') return true
   if (vm.ipAddress && vm.ipAddress !== '—' && vm.ipAddress.trim() !== '') return true

--- a/ui/src/hooks/useNetworkMappingValidation.ts
+++ b/ui/src/hooks/useNetworkMappingValidation.ts
@@ -1,0 +1,59 @@
+import { useMemo } from 'react'
+import { vmHasInterface } from 'src/features/migration/utils/vmNetworking'
+
+interface ResourceMap {
+  source: string
+  target: string
+}
+
+interface NetworkMappingVmShape {
+  networks?: string[]
+  networkInterfaces?: unknown[]
+}
+
+interface NetworkMappingValidationProps {
+  selectedVMs: NetworkMappingVmShape[]
+  networkMappings: ResourceMap[]
+  availableVmwareNetworks: string[]
+}
+
+interface NetworkMappingValidationResult {
+  /** True when at least one selected VM has an interface AND there are source networks to map. */
+  required: boolean
+  /** Source VMware networks that have not been mapped yet. */
+  unmapped: string[]
+  /** True when mapping is required but at least one source network is unmapped. */
+  hasError: boolean
+  /** True when mapping is either not required (no NICs) or all source networks are mapped. */
+  isComplete: boolean
+}
+
+/**
+ * Centralised validation for the Network Mapping step of the Create Migration
+ * Plan flows. Returns `required: false` when none of the selected VMs have an
+ * interface, allowing the UI to skip the mapping step instead of trapping the
+ * user behind an unsatisfiable "All networks must be mapped" gate.
+ *
+ * Mirrors the shape of useRdmConfigValidation so call-sites can read uniformly.
+ */
+export const useNetworkMappingValidation = ({
+  selectedVMs,
+  networkMappings,
+  availableVmwareNetworks
+}: NetworkMappingValidationProps): NetworkMappingValidationResult =>
+  useMemo(() => {
+    const vmsWithInterfaces = selectedVMs.filter(vmHasInterface)
+    const required =
+      vmsWithInterfaces.length > 0 && availableVmwareNetworks.length > 0
+
+    const unmapped = availableVmwareNetworks.filter(
+      (network) => !networkMappings.some((m) => m.source === network)
+    )
+
+    return {
+      required,
+      unmapped,
+      hasError: required && unmapped.length > 0,
+      isComplete: !required || unmapped.length === 0
+    }
+  }, [selectedVMs, networkMappings, availableVmwareNetworks])

--- a/ui/src/hooks/useNetworkMappingValidation.ts
+++ b/ui/src/hooks/useNetworkMappingValidation.ts
@@ -18,24 +18,12 @@ interface NetworkMappingValidationProps {
 }
 
 interface NetworkMappingValidationResult {
-  /** True when at least one selected VM has an interface AND there are source networks to map. */
   required: boolean
-  /** Source VMware networks that have not been mapped yet. */
   unmapped: string[]
-  /** True when mapping is required but at least one source network is unmapped. */
   hasError: boolean
-  /** True when mapping is either not required (no NICs) or all source networks are mapped. */
   isComplete: boolean
 }
 
-/**
- * Centralised validation for the Network Mapping step of the Create Migration
- * Plan flows. Returns `required: false` when none of the selected VMs have an
- * interface, allowing the UI to skip the mapping step instead of trapping the
- * user behind an unsatisfiable "All networks must be mapped" gate.
- *
- * Mirrors the shape of useRdmConfigValidation so call-sites can read uniformly.
- */
 export const useNetworkMappingValidation = ({
   selectedVMs,
   networkMappings,

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -813,7 +813,18 @@ func (osclient *OpenStackClients) CreateVM(ctx context.Context, flavor *flavors.
 		SecurityGroups: securityGroups,
 	}
 	if len(networkIDs) == 0 {
+		// Nova's "networks":"none" sentinel was added in compute API
+		// microversion 2.37. Without this header bump the request goes out at
+		// the default microversion (2.1) and Nova rejects the body with
+		// 400 ("'none' is not of type 'array'") because pre-2.37 the
+		// networks field is schema-typed as an array. The RDM path below
+		// bumps to "2.60" when needed; "2.37" is the floor for "none".
+		osclient.ComputeClient.Microversion = "2.37"
 		serverCreateOpts.Networks = "none"
+		PrintLog(fmt.Sprintf(
+			"VM %s has no network interfaces; creating server with networks='none' at compute microversion 2.37",
+			vminfo.Name,
+		))
 	}
 	if useFlavorless {
 		PrintLog(fmt.Sprintf("Using flavorless provisioning. Adding hotplug metadata: CPU=%d, Memory=%dMB", vminfo.CPU, vminfo.Memory))

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -800,6 +800,8 @@ func (osclient *OpenStackClients) CreateVM(ctx context.Context, flavor *flavors.
 
 	// Create the server
 	openstacknws := []servers.Network{}
+	networkIDs = []string{}
+	portIDs = []string{}
 	for idx := range networkIDs {
 		openstacknws = append(openstacknws, servers.Network{
 			UUID: networkIDs[idx],

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -800,8 +800,6 @@ func (osclient *OpenStackClients) CreateVM(ctx context.Context, flavor *flavors.
 
 	// Create the server
 	openstacknws := []servers.Network{}
-	networkIDs = []string{}
-	portIDs = []string{}
 	for idx := range networkIDs {
 		openstacknws = append(openstacknws, servers.Network{
 			UUID: networkIDs[idx],

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -812,7 +812,9 @@ func (osclient *OpenStackClients) CreateVM(ctx context.Context, flavor *flavors.
 		Networks:       openstacknws,
 		SecurityGroups: securityGroups,
 	}
-
+	if len(networkIDs) == 0 {
+		serverCreateOpts.Networks = "none"
+	}
 	if useFlavorless {
 		PrintLog(fmt.Sprintf("Using flavorless provisioning. Adding hotplug metadata: CPU=%d, Memory=%dMB", vminfo.CPU, vminfo.Memory))
 		serverCreateOpts.Metadata = map[string]string{


### PR DESCRIPTION
## What this PR does / why we need it

Allowing the migration of VMs with no interfaces from vmware to pcd 


fixes #1840 

## Testing done

<img width="1437" height="807" alt="image" src="https://github.com/user-attachments/assets/ab86d8dc-3096-4e83-a582-c9a050531475" />


### Destination 
<img width="1440" height="792" alt="image" src="https://github.com/user-attachments/assets/6f0410f1-079b-4a7f-825c-e44f0b374ac6" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/1927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->