### PR TITLE
Updating the compute api version to support multi-attach volumes 

### DIFF
--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -280,11 +280,11 @@ func (osclient *OpenStackClients) WaitForVolume(ctx context.Context, volumeID st
 func (osclient *OpenStackClients) AttachVolumeToVM(ctx context.Context, volumeID string) error {
 	instanceID, err := GetCurrentInstanceUUID()
 
-	osclient.ComputeClient.Microversion = "2.60"
 	if err != nil {
 		return fmt.Errorf("failed to get instance ID: %s", err)
 	}
 	PrintLog(fmt.Sprintf("OPENSTACK API: Attaching volume %s to VM %s, authurl %s, tenant %s", volumeID, instanceID, osclient.AuthURL, osclient.Tenant))
+	osclient.ComputeClient.Microversion = "2.60"
 
 	vjailbreakSettings, err := k8sutils.GetVjailbreakSettings(ctx, osclient.K8sClient)
 	if err != nil {

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -279,6 +279,8 @@ func (osclient *OpenStackClients) WaitForVolume(ctx context.Context, volumeID st
 
 func (osclient *OpenStackClients) AttachVolumeToVM(ctx context.Context, volumeID string) error {
 	instanceID, err := GetCurrentInstanceUUID()
+
+	osclient.ComputeClient.Microversion = "2.60"
 	if err != nil {
 		return fmt.Errorf("failed to get instance ID: %s", err)
 	}


### PR DESCRIPTION
## What this PR does / why we need it

Earlier the volumes were not able to attach if they were  created with such a volume type which supports multi-attach,
In this PR the compute api version has been updated for attaching the volumes, which supports this operation

## Which issue(s) this PR fixes

fixes #1727 

## Testing done

### For normal Volume types

<img width="853" height="393" alt="image" src="https://github.com/user-attachments/assets/3da47420-01b6-4317-a738-d1c4a8a156e7" />


### For multiattach Volume types 

<img width="865" height="404" alt="image" src="https://github.com/user-attachments/assets/fc6bf5e4-cc1b-4cb3-8b91-205efde46c7e" />

### Migration Succeeding 

<img width="1132" height="359" alt="image" src="https://github.com/user-attachments/assets/de5b2709-8436-4105-b219-8c6c44cb963c" />
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/1932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->