### PR TITLE
[1888] refactor: Remove direct pod permissions

### DIFF
--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -4672,17 +4672,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
   - configmaps
   verbs:
   - create
@@ -4695,17 +4684,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - configmaps/status
-  - pods/status
   verbs:
   - get
 - apiGroups:
@@ -4716,13 +4695,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods/log
-  verbs:
-  - get
-  - list
 - apiGroups:
   - vjailbreak.k8s.pf9.io
   resources:

--- a/deploy/installer.yaml
+++ b/deploy/installer.yaml
@@ -4888,17 +4888,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
   - configmaps
   verbs:
   - create
@@ -4911,17 +4900,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - configmaps/status
-  - pods/status
   verbs:
   - get
 - apiGroups:
@@ -4932,13 +4911,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods/log
-  verbs:
-  - get
-  - list
 - apiGroups:
   - vjailbreak.k8s.pf9.io
   resources:

--- a/pkg/vpwned/server/k8s_proxy_handler.go
+++ b/pkg/vpwned/server/k8s_proxy_handler.go
@@ -23,11 +23,33 @@ const (
 	tokenCacheTTL         = 60 * time.Second
 )
 
-// allowedK8sPath restricts proxy access to pods and pod logs in migration-system only.
-// Allowed: GET /api/v1/namespaces/migration-system/pods[/{podName}[/log]]
-var allowedK8sPath = regexp.MustCompile(
-	`^/api/v1/namespaces/migration-system/pods(/[^/?]+(/log)?)?$`,
-)
+// allowedRoute pairs an HTTP method with a path pattern.
+// All patterns are anchored to migration-system namespace.
+type allowedRoute struct {
+	method  string
+	pattern *regexp.Regexp
+}
+
+// allowedRoutes is the exact set of K8s API calls the UI makes through this proxy.
+var allowedRoutes = []allowedRoute{
+	// Pods — read and admin-cutover patch
+	{http.MethodGet, regexp.MustCompile(`^/api/v1/namespaces/migration-system/pods(/[^/?]+(/log)?)?$`)},
+	{http.MethodPatch, regexp.MustCompile(`^/api/v1/namespaces/migration-system/pods/[^/?]+$`)},
+	// Secrets — full CRUD, migration-system only
+	{http.MethodGet, regexp.MustCompile(`^/api/v1/namespaces/migration-system/secrets(/[^/?]+)?$`)},
+	{http.MethodPost, regexp.MustCompile(`^/api/v1/namespaces/migration-system/secrets$`)},
+	{http.MethodPut, regexp.MustCompile(`^/api/v1/namespaces/migration-system/secrets/[^/?]+$`)},
+	{http.MethodDelete, regexp.MustCompile(`^/api/v1/namespaces/migration-system/secrets/[^/?]+$`)},
+}
+
+func isAllowedRoute(method, k8sPath string) bool {
+	for _, r := range allowedRoutes {
+		if r.method == method && r.pattern.MatchString(k8sPath) {
+			return true
+		}
+	}
+	return false
+}
 
 var (
 	k8sReverseProxy *httputil.ReverseProxy
@@ -134,13 +156,9 @@ func HandleK8sProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Method != http.MethodGet {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
 	k8sPath := strings.TrimPrefix(r.URL.Path, "/vpw/v1/k8s")
-	if !allowedK8sPath.MatchString(k8sPath) {
-		logrus.Warnf("k8s proxy: forbidden path: %s", k8sPath)
+	if !isAllowedRoute(r.Method, k8sPath) {
+		logrus.Warnf("k8s proxy: forbidden %s %s", r.Method, k8sPath)
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}

--- a/pkg/vpwned/server/k8s_proxy_handler.go
+++ b/pkg/vpwned/server/k8s_proxy_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +21,12 @@ import (
 const (
 	allowedServiceAccount = "system:serviceaccount:migration-system:ui-manager-sa"
 	tokenCacheTTL         = 60 * time.Second
+)
+
+// allowedK8sPath restricts proxy access to pods and pod logs in migration-system only.
+// Allowed: GET /api/v1/namespaces/migration-system/pods[/{podName}[/log]]
+var allowedK8sPath = regexp.MustCompile(
+	`^/api/v1/namespaces/migration-system/pods(/[^/?]+(/log)?)?$`,
 )
 
 var (
@@ -124,6 +131,17 @@ func HandleK8sProxy(w http.ResponseWriter, r *http.Request) {
 	if err := validateUIToken(token); err != nil {
 		logrus.Warnf("k8s proxy: rejected request: %v", err)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	k8sPath := strings.TrimPrefix(r.URL.Path, "/vpw/v1/k8s")
+	if !allowedK8sPath.MatchString(k8sPath) {
+		logrus.Warnf("k8s proxy: forbidden path: %s", k8sPath)
+		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
 

--- a/pkg/vpwned/server/k8s_proxy_handler.go
+++ b/pkg/vpwned/server/k8s_proxy_handler.go
@@ -1,19 +1,36 @@
 package server
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
-var k8sReverseProxy *httputil.ReverseProxy
+const (
+	allowedServiceAccount = "system:serviceaccount:migration-system:ui-manager-sa"
+	tokenCacheTTL         = 60 * time.Second
+)
 
-// InitK8sProxy builds a reverse proxy that forwards /vpw/v1/k8s/* requests to the
-// Kubernetes API server using the pod's ServiceAccount credentials.
+var (
+	k8sReverseProxy *httputil.ReverseProxy
+	k8sAuthClient   kubernetes.Interface
+	tokenCache      sync.Map // map[string]time.Time — token → cache expiry
+)
+
+// InitK8sProxy builds a reverse proxy that forwards /vpw/v1/k8s/* to the K8s
+// API server using the pod's ServiceAccount credentials, and initialises a
+// Kubernetes client for incoming Bearer token validation.
 func InitK8sProxy() error {
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
@@ -30,30 +47,85 @@ func InitK8sProxy() error {
 		return err
 	}
 
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	k8sAuthClient = client
+
 	k8sReverseProxy = &httputil.ReverseProxy{
 		FlushInterval: -1,
 		Transport:     transport,
 		Director: func(req *http.Request) {
-			// Strip /vpw/v1/k8s prefix so /vpw/v1/k8s/api/v1/... → /api/v1/...
+			// Strip /vpw/v1/k8s prefix: /vpw/v1/k8s/api/v1/... → /api/v1/...
 			req.URL.Path = strings.TrimPrefix(req.URL.Path, "/vpw/v1/k8s")
 			if req.URL.RawPath != "" {
 				req.URL.RawPath = strings.TrimPrefix(req.URL.RawPath, "/vpw/v1/k8s")
 			}
 			req.URL.Host = target.Host
 			req.URL.Scheme = target.Scheme
+			// Replace browser's Authorization with the pod's SA token.
 			req.Header.Del("Authorization")
 		},
 	}
 	return nil
 }
 
-// HandleK8sProxy forwards the request to the Kubernetes API server via the
-// reverse proxy initialised by InitK8sProxy.
+// validateUIToken calls the K8s TokenReview API to verify the token is
+// authentic and belongs to the ui-manager-sa service account.
+// Successful validations are cached for tokenCacheTTL to avoid repeated calls.
+func validateUIToken(token string) error {
+	if exp, ok := tokenCache.Load(token); ok {
+		if time.Now().Before(exp.(time.Time)) {
+			return nil
+		}
+		tokenCache.Delete(token)
+	}
+
+	if k8sAuthClient == nil {
+		return fmt.Errorf("k8s client not initialized")
+	}
+
+	result, err := k8sAuthClient.AuthenticationV1().TokenReviews().Create(
+		context.Background(),
+		&authv1.TokenReview{Spec: authv1.TokenReviewSpec{Token: token}},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("token review request failed: %w", err)
+	}
+	if !result.Status.Authenticated {
+		return fmt.Errorf("token not authenticated")
+	}
+	if result.Status.User.Username != allowedServiceAccount {
+		return fmt.Errorf("unauthorized service account: %s", result.Status.User.Username)
+	}
+
+	tokenCache.Store(token, time.Now().Add(tokenCacheTTL))
+	return nil
+}
+
+// HandleK8sProxy validates the caller's Bearer token (must be ui-manager-sa),
+// then forwards the request to the K8s API using the pod's own SA credentials.
 func HandleK8sProxy(w http.ResponseWriter, r *http.Request) {
 	if k8sReverseProxy == nil {
 		logrus.Warn("k8s proxy not initialised — is the server running in-cluster?")
 		http.Error(w, "k8s proxy unavailable", http.StatusServiceUnavailable)
 		return
 	}
+
+	authHeader := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+	if err := validateUIToken(token); err != nil {
+		logrus.Warnf("k8s proxy: rejected request: %v", err)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	k8sReverseProxy.ServeHTTP(w, r)
 }

--- a/pkg/vpwned/server/k8s_proxy_handler.go
+++ b/pkg/vpwned/server/k8s_proxy_handler.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+)
+
+var k8sReverseProxy *httputil.ReverseProxy
+
+// InitK8sProxy builds a reverse proxy that forwards /vpw/v1/k8s/* requests to the
+// Kubernetes API server using the pod's ServiceAccount credentials.
+func InitK8sProxy() error {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return err
+	}
+
+	target, err := url.Parse(cfg.Host)
+	if err != nil {
+		return err
+	}
+
+	transport, err := rest.TransportFor(cfg)
+	if err != nil {
+		return err
+	}
+
+	k8sReverseProxy = &httputil.ReverseProxy{
+		FlushInterval: -1,
+		Transport:     transport,
+		Director: func(req *http.Request) {
+			// Strip /vpw/v1/k8s prefix so /vpw/v1/k8s/api/v1/... → /api/v1/...
+			req.URL.Path = strings.TrimPrefix(req.URL.Path, "/vpw/v1/k8s")
+			if req.URL.RawPath != "" {
+				req.URL.RawPath = strings.TrimPrefix(req.URL.RawPath, "/vpw/v1/k8s")
+			}
+			req.URL.Host = target.Host
+			req.URL.Scheme = target.Scheme
+			req.Header.Del("Authorization")
+		},
+	}
+	return nil
+}
+
+// HandleK8sProxy forwards the request to the Kubernetes API server via the
+// reverse proxy initialised by InitK8sProxy.
+func HandleK8sProxy(w http.ResponseWriter, r *http.Request) {
+	if k8sReverseProxy == nil {
+		logrus.Warn("k8s proxy not initialised — is the server running in-cluster?")
+		http.Error(w, "k8s proxy unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	k8sReverseProxy.ServeHTTP(w, r)
+}

--- a/pkg/vpwned/server/k8s_proxy_handler_test.go
+++ b/pkg/vpwned/server/k8s_proxy_handler_test.go
@@ -199,6 +199,59 @@ func TestHandleK8sProxy_ValidToken_ProxiesToBackend(t *testing.T) {
 	}
 }
 
+// --- Path allowlist tests ---
+
+func TestHandleK8sProxy_AllowedPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int
+	}{
+		{"list pods", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods", http.StatusOK},
+		{"get pod", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods/my-pod", http.StatusOK},
+		{"stream pod logs", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods/my-pod/log", http.StatusOK},
+		{"post forbidden", http.MethodPost, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods", http.StatusMethodNotAllowed},
+		{"delete forbidden", http.MethodDelete, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods/my-pod", http.StatusMethodNotAllowed},
+		{"secrets forbidden", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/kube-system/secrets", http.StatusForbidden},
+		{"other namespace forbidden", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/default/pods", http.StatusForbidden},
+		{"clusterroles forbidden", http.MethodGet, "/vpw/v1/k8s/apis/rbac.authorization.k8s.io/v1/clusterroles", http.StatusForbidden},
+		{"path traversal forbidden", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods/../secrets", http.StatusForbidden},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearTokenCache()
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer backend.Close()
+
+			fakeClient := fake.NewSimpleClientset()
+			fakeClient.PrependReactor("create", "tokenreviews",
+				makeTokenReviewReactor(true, allowedServiceAccount))
+
+			origProxy := k8sReverseProxy
+			origClient := k8sAuthClient
+			k8sReverseProxy = makeTestProxy(backend)
+			k8sAuthClient = fakeClient
+			defer func() {
+				k8sReverseProxy = origProxy
+				k8sAuthClient = origClient
+			}()
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req.Header.Set("Authorization", "Bearer valid-token")
+			w := httptest.NewRecorder()
+			HandleK8sProxy(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("path %s method %s: expected %d, got %d", tt.path, tt.method, tt.wantStatus, w.Code)
+			}
+		})
+	}
+}
+
 // --- validateUIToken tests ---
 
 func TestValidateUIToken_ClientNotInitialized(t *testing.T) {

--- a/pkg/vpwned/server/k8s_proxy_handler_test.go
+++ b/pkg/vpwned/server/k8s_proxy_handler_test.go
@@ -1,0 +1,326 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	authv1 "k8s.io/api/authentication/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// clearTokenCache drains the package-level token cache between tests.
+func clearTokenCache() {
+	tokenCache.Range(func(k, v any) bool {
+		tokenCache.Delete(k)
+		return true
+	})
+}
+
+// makeTokenReviewReactor returns a fake reactor for the TokenReview create action.
+func makeTokenReviewReactor(authenticated bool, username string) k8stesting.ReactionFunc {
+	return func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &authv1.TokenReview{
+			Status: authv1.TokenReviewStatus{
+				Authenticated: authenticated,
+				User:          authv1.UserInfo{Username: username},
+			},
+		}, nil
+	}
+}
+
+// makeTestProxy builds a reverse proxy pointing at a test backend server.
+func makeTestProxy(backend *httptest.Server) *httputil.ReverseProxy {
+	target, _ := url.Parse(backend.URL)
+	return &httputil.ReverseProxy{
+		FlushInterval: -1,
+		Director: func(req *http.Request) {
+			req.URL.Path = strings.TrimPrefix(req.URL.Path, "/vpw/v1/k8s")
+			req.URL.Host = target.Host
+			req.URL.Scheme = target.Scheme
+			req.Header.Del("Authorization")
+		},
+	}
+}
+
+// --- HandleK8sProxy tests ---
+
+func TestHandleK8sProxy_ProxyNotInitialized(t *testing.T) {
+	orig := k8sReverseProxy
+	k8sReverseProxy = nil
+	defer func() { k8sReverseProxy = orig }()
+
+	req := httptest.NewRequest(http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods", nil)
+	w := httptest.NewRecorder()
+	HandleK8sProxy(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestHandleK8sProxy_MissingAuthHeader(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	origProxy := k8sReverseProxy
+	k8sReverseProxy = makeTestProxy(backend)
+	defer func() { k8sReverseProxy = origProxy }()
+
+	req := httptest.NewRequest(http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods", nil)
+	w := httptest.NewRecorder()
+	HandleK8sProxy(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestHandleK8sProxy_NonBearerAuth(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	origProxy := k8sReverseProxy
+	k8sReverseProxy = makeTestProxy(backend)
+	defer func() { k8sReverseProxy = origProxy }()
+
+	req := httptest.NewRequest(http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	w := httptest.NewRecorder()
+	HandleK8sProxy(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestHandleK8sProxy_TokenNotAuthenticated(t *testing.T) {
+	clearTokenCache()
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.PrependReactor("create", "tokenreviews",
+		makeTokenReviewReactor(false, ""))
+
+	origProxy := k8sReverseProxy
+	origClient := k8sAuthClient
+	k8sReverseProxy = makeTestProxy(backend)
+	k8sAuthClient = fakeClient
+	defer func() {
+		k8sReverseProxy = origProxy
+		k8sAuthClient = origClient
+	}()
+
+	req := httptest.NewRequest(http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods", nil)
+	req.Header.Set("Authorization", "Bearer invalidtoken")
+	w := httptest.NewRecorder()
+	HandleK8sProxy(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestHandleK8sProxy_WrongServiceAccount(t *testing.T) {
+	clearTokenCache()
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.PrependReactor("create", "tokenreviews",
+		makeTokenReviewReactor(true, "system:serviceaccount:default:some-other-sa"))
+
+	origProxy := k8sReverseProxy
+	origClient := k8sAuthClient
+	k8sReverseProxy = makeTestProxy(backend)
+	k8sAuthClient = fakeClient
+	defer func() {
+		k8sReverseProxy = origProxy
+		k8sAuthClient = origClient
+	}()
+
+	req := httptest.NewRequest(http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods", nil)
+	req.Header.Set("Authorization", "Bearer sometoken")
+	w := httptest.NewRecorder()
+	HandleK8sProxy(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestHandleK8sProxy_ValidToken_ProxiesToBackend(t *testing.T) {
+	clearTokenCache()
+	const backendStatus = http.StatusOK
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify Authorization header was stripped before reaching backend.
+		if r.Header.Get("Authorization") != "" {
+			t.Error("Authorization header should have been stripped by proxy Director")
+		}
+		w.WriteHeader(backendStatus)
+	}))
+	defer backend.Close()
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.PrependReactor("create", "tokenreviews",
+		makeTokenReviewReactor(true, allowedServiceAccount))
+
+	origProxy := k8sReverseProxy
+	origClient := k8sAuthClient
+	k8sReverseProxy = makeTestProxy(backend)
+	k8sAuthClient = fakeClient
+	defer func() {
+		k8sReverseProxy = origProxy
+		k8sAuthClient = origClient
+	}()
+
+	req := httptest.NewRequest(http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods", nil)
+	req.Header.Set("Authorization", "Bearer valid-ui-manager-sa-token")
+	w := httptest.NewRecorder()
+	HandleK8sProxy(w, req)
+
+	if w.Code != backendStatus {
+		t.Errorf("expected %d from backend, got %d", backendStatus, w.Code)
+	}
+}
+
+// --- validateUIToken tests ---
+
+func TestValidateUIToken_ClientNotInitialized(t *testing.T) {
+	clearTokenCache()
+	orig := k8sAuthClient
+	k8sAuthClient = nil
+	defer func() { k8sAuthClient = orig }()
+
+	err := validateUIToken("anytoken")
+	if err == nil {
+		t.Error("expected error when k8s client is nil")
+	}
+}
+
+func TestValidateUIToken_NotAuthenticated(t *testing.T) {
+	clearTokenCache()
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.PrependReactor("create", "tokenreviews",
+		makeTokenReviewReactor(false, ""))
+
+	orig := k8sAuthClient
+	k8sAuthClient = fakeClient
+	defer func() { k8sAuthClient = orig }()
+
+	err := validateUIToken("badtoken")
+	if err == nil {
+		t.Error("expected error for unauthenticated token")
+	}
+}
+
+func TestValidateUIToken_WrongServiceAccount(t *testing.T) {
+	clearTokenCache()
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.PrependReactor("create", "tokenreviews",
+		makeTokenReviewReactor(true, "system:serviceaccount:kube-system:default"))
+
+	orig := k8sAuthClient
+	k8sAuthClient = fakeClient
+	defer func() { k8sAuthClient = orig }()
+
+	err := validateUIToken("wrongsatoken")
+	if err == nil {
+		t.Error("expected error for wrong service account")
+	}
+	if err != nil && !strings.Contains(err.Error(), "unauthorized service account") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestValidateUIToken_ValidToken(t *testing.T) {
+	clearTokenCache()
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.PrependReactor("create", "tokenreviews",
+		makeTokenReviewReactor(true, allowedServiceAccount))
+
+	orig := k8sAuthClient
+	k8sAuthClient = fakeClient
+	defer func() { k8sAuthClient = orig }()
+
+	err := validateUIToken("valid-token")
+	if err != nil {
+		t.Errorf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateUIToken_CacheHit_SkipsTokenReview(t *testing.T) {
+	clearTokenCache()
+	callCount := 0
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		callCount++
+		return true, &authv1.TokenReview{
+			Status: authv1.TokenReviewStatus{
+				Authenticated: true,
+				User:          authv1.UserInfo{Username: allowedServiceAccount},
+			},
+		}, nil
+	})
+
+	orig := k8sAuthClient
+	k8sAuthClient = fakeClient
+	defer func() { k8sAuthClient = orig }()
+
+	const token = "cached-token"
+	if err := validateUIToken(token); err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+	if err := validateUIToken(token); err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+
+	if callCount != 1 {
+		t.Errorf("TokenReview called %d times, expected 1 (cache should prevent second call)", callCount)
+	}
+}
+
+func TestValidateUIToken_ExpiredCache_RevalidatesToken(t *testing.T) {
+	clearTokenCache()
+	// Pre-populate cache with an already-expired entry.
+	const token = "expired-token"
+	tokenCache.Store(token, time.Now().Add(-2*tokenCacheTTL))
+
+	callCount := 0
+	fakeClient := fake.NewSimpleClientset()
+	fakeClient.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		callCount++
+		return true, &authv1.TokenReview{
+			Status: authv1.TokenReviewStatus{
+				Authenticated: true,
+				User:          authv1.UserInfo{Username: allowedServiceAccount},
+			},
+		}, nil
+	})
+
+	orig := k8sAuthClient
+	k8sAuthClient = fakeClient
+	defer func() { k8sAuthClient = orig }()
+
+	if err := validateUIToken(token); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("TokenReview called %d times, expected 1 (should re-validate after expiry)", callCount)
+	}
+}

--- a/pkg/vpwned/server/k8s_proxy_handler_test.go
+++ b/pkg/vpwned/server/k8s_proxy_handler_test.go
@@ -208,14 +208,26 @@ func TestHandleK8sProxy_AllowedPaths(t *testing.T) {
 		path       string
 		wantStatus int
 	}{
+		// pods — allowed
 		{"list pods", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods", http.StatusOK},
 		{"get pod", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods/my-pod", http.StatusOK},
 		{"stream pod logs", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods/my-pod/log", http.StatusOK},
-		{"post forbidden", http.MethodPost, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods", http.StatusMethodNotAllowed},
-		{"delete forbidden", http.MethodDelete, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods/my-pod", http.StatusMethodNotAllowed},
-		{"secrets forbidden", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/kube-system/secrets", http.StatusForbidden},
-		{"other namespace forbidden", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/default/pods", http.StatusForbidden},
+		{"patch pod (admin cutover)", http.MethodPatch, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods/my-pod", http.StatusOK},
+		// secrets — allowed CRUD
+		{"list secrets", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/secrets", http.StatusOK},
+		{"get secret", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/secrets/my-secret", http.StatusOK},
+		{"create secret", http.MethodPost, "/vpw/v1/k8s/api/v1/namespaces/migration-system/secrets", http.StatusOK},
+		{"replace secret", http.MethodPut, "/vpw/v1/k8s/api/v1/namespaces/migration-system/secrets/my-secret", http.StatusOK},
+		{"delete secret", http.MethodDelete, "/vpw/v1/k8s/api/v1/namespaces/migration-system/secrets/my-secret", http.StatusOK},
+		// blocked — wrong namespace
+		{"secrets kube-system forbidden", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/kube-system/secrets", http.StatusForbidden},
+		{"pods default ns forbidden", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/default/pods", http.StatusForbidden},
+		// blocked — disallowed methods on pods
+		{"post pods forbidden", http.MethodPost, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods", http.StatusForbidden},
+		{"delete pod forbidden", http.MethodDelete, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods/my-pod", http.StatusForbidden},
+		// blocked — entirely different resource
 		{"clusterroles forbidden", http.MethodGet, "/vpw/v1/k8s/apis/rbac.authorization.k8s.io/v1/clusterroles", http.StatusForbidden},
+		// blocked — path traversal
 		{"path traversal forbidden", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods/../secrets", http.StatusForbidden},
 	}
 

--- a/pkg/vpwned/server/server.go
+++ b/pkg/vpwned/server/server.go
@@ -117,6 +117,14 @@ func getHTTPServer(ctx context.Context, port, grpcSocket string) (*http.ServeMux
 	// Register subnet compatibility check handler
 	mux.HandleFunc("/vpw/v1/check_network_subnet_compatibility", HandleCheckNetworkSubnetCompatibility)
 
+	// Register K8s reverse proxy — forwards /vpw/v1/k8s/* to the K8s API server
+	// using the pod ServiceAccount token.  UI secret/pod calls route through here
+	// instead of holding direct RBAC permissions on ui-manager-sa.
+	if err := InitK8sProxy(); err != nil {
+		logrus.Warnf("k8s proxy init skipped (non-cluster env): %v", err)
+	}
+	mux.HandleFunc("/vpw/v1/k8s/", HandleK8sProxy)
+
 	//gatewayMuxer
 	gatewayMuxer := runtime.NewServeMux() //runtime.WithErrorHandler(gRPCErrHandler))
 	option := []grpc.DialOption{
@@ -158,6 +166,11 @@ func getHTTPServer(ctx context.Context, port, grpcSocket string) (*http.ServeMux
 		// Skip subnet compatibility check - handled by plain HTTP handler
 		if r.URL.Path == "/vpw/v1/check_network_subnet_compatibility" {
 			HandleCheckNetworkSubnetCompatibility(w, r)
+			return
+		}
+		// Skip k8s proxy - registered with its own prefix handler above
+		if strings.HasPrefix(r.URL.Path, "/vpw/v1/k8s/") {
+			HandleK8sProxy(w, r)
 			return
 		}
 		APILogger(gatewayMuxer).ServeHTTP(w, r)

--- a/ui/deploy/ui.yaml
+++ b/ui/deploy/ui.yaml
@@ -147,17 +147,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
   - configmaps
   verbs:
   - create
@@ -170,17 +159,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - configmaps/status
-  - pods/status
   verbs:
   - get
 - apiGroups:
@@ -191,13 +170,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods/log
-  verbs:
-  - get
-  - list
 - apiGroups:
   - vjailbreak.k8s.pf9.io
   resources:

--- a/ui/src/api/constants.ts
+++ b/ui/src/api/constants.ts
@@ -4,3 +4,10 @@ export const VJAILBREAK_API_BASE_URL = import.meta.env.MODE === 'development' ? 
 export const VJAILBREAK_API_BASE_PATH = '/apis/vjailbreak.k8s.pf9.io/v1alpha1'
 export const KUBERNETES_API_BASE_PATH = '/api/v1'
 export const VJAILBREAK_DEFAULT_NAMESPACE = 'migration-system'
+
+// K8s API calls for Secrets and Pods are routed through the vpwned proxy so that
+// ui-manager-sa does not need direct secrets/pods RBAC permissions.
+// The /dev-api/sdk prefix is handled by the nginx ingress rewrite in production
+// (strips it and forwards to the vpwned service) and by the vite dev-server proxy
+// in development (strips /dev-api and forwards to VITE_API_HOST which then hits the ingress).
+export const K8S_PROXY_BASE_PATH = '/dev-api/sdk/vpw/v1/k8s/api/v1'

--- a/ui/src/api/kubernetes/pods.ts
+++ b/ui/src/api/kubernetes/pods.ts
@@ -1,5 +1,5 @@
 import { Pod, PodListResponse } from './model'
-import { KUBERNETES_API_BASE_PATH } from '../constants'
+import { K8S_PROXY_BASE_PATH } from '../constants'
 import axios from '../axios'
 
 /**
@@ -8,7 +8,7 @@ import axios from '../axios'
  * @param labelSelector - Optional label selector to filter pods
  */
 export const fetchPods = async (namespace: string, labelSelector?: string): Promise<Pod[]> => {
-  const endpoint = `${KUBERNETES_API_BASE_PATH}/namespaces/${namespace}/pods`
+  const endpoint = `${K8S_PROXY_BASE_PATH}/namespaces/${namespace}/pods`
 
   const config = labelSelector
     ? {
@@ -44,7 +44,7 @@ export const streamPodLogs = async (
 ): Promise<Response> => {
   const { follow = true, tailLines = '100', limitBytes = 500000, signal } = options
 
-  const endpoint = `${KUBERNETES_API_BASE_PATH}/namespaces/${namespace}/pods/${podName}/log`
+  const endpoint = `${K8S_PROXY_BASE_PATH}/namespaces/${namespace}/pods/${podName}/log`
 
   const params = new URLSearchParams({
     follow: follow.toString(),
@@ -52,22 +52,11 @@ export const streamPodLogs = async (
     limitBytes: limitBytes.toString()
   })
 
-  const url = `${endpoint}?${params.toString()}`
 
-  // For streaming endpoints, we need to use raw fetch instead of axios
-  const authToken = import.meta.env.VITE_API_TOKEN
-  const headers = {
-    'Content-Type': 'application/json;charset=UTF-8',
-    ...(authToken && { Authorization: `Bearer ${authToken}` })
-  }
+  const basePrefix = import.meta.env.MODE === 'development' ? '/dev-api' : ''
+  const fullUrl = `${basePrefix}${endpoint}?${params.toString()}`
 
-  const baseUrl = import.meta.env.MODE === 'development' ? '/dev-api' : ''
-  const fullUrl = `${baseUrl}${url}`
-
-  const response = await fetch(fullUrl, {
-    headers,
-    signal
-  })
+  const response = await fetch(fullUrl, { signal })
 
   if (!response.ok) {
     throw new Error(

--- a/ui/src/api/kubernetes/pods.ts
+++ b/ui/src/api/kubernetes/pods.ts
@@ -56,7 +56,13 @@ export const streamPodLogs = async (
   const basePrefix = import.meta.env.MODE === 'development' ? '/dev-api' : ''
   const fullUrl = `${basePrefix}${endpoint}?${params.toString()}`
 
-  const response = await fetch(fullUrl, { signal })
+  const authToken = import.meta.env.VITE_API_TOKEN
+  const response = await fetch(fullUrl, {
+    signal,
+    headers: {
+      ...(authToken && { Authorization: `Bearer ${authToken}` })
+    }
+  })
 
   if (!response.ok) {
     throw new Error(

--- a/ui/src/api/migrations/migrations.ts
+++ b/ui/src/api/migrations/migrations.ts
@@ -1,5 +1,5 @@
 import axios from '../axios'
-import { VJAILBREAK_API_BASE_PATH, VJAILBREAK_DEFAULT_NAMESPACE } from '../constants'
+import { K8S_PROXY_BASE_PATH, VJAILBREAK_API_BASE_PATH, VJAILBREAK_DEFAULT_NAMESPACE } from '../constants'
 import { GetMigrationsList, Migration } from './model'
 
 export const getMigrations = async (
@@ -47,7 +47,7 @@ export const triggerAdminCutover = async (
     }
 
     // List all pods in the namespace
-    const podsEndpoint = `/api/v1/namespaces/${namespace}/pods`
+    const podsEndpoint = `${K8S_PROXY_BASE_PATH}/namespaces/${namespace}/pods`
     const podsResponse = await axios.get<{
       items: Array<{
         metadata: {
@@ -81,7 +81,7 @@ export const triggerAdminCutover = async (
       }
     }
 
-    const endpoint = `/api/v1/namespaces/${namespace}/pods/${podName}`
+    const endpoint = `${K8S_PROXY_BASE_PATH}/namespaces/${namespace}/pods/${podName}`
 
     await axios.patch({
       endpoint,

--- a/ui/src/api/secrets/secrets.ts
+++ b/ui/src/api/secrets/secrets.ts
@@ -1,5 +1,5 @@
 import axios from '../axios'
-import { VJAILBREAK_DEFAULT_NAMESPACE } from '../constants'
+import { K8S_PROXY_BASE_PATH, VJAILBREAK_DEFAULT_NAMESPACE } from '../constants'
 import { Secret, SecretList } from './model'
 import { encodeUtf8ToBase64, decodeBase64ToUtf8 } from '../../utils/base64encoding'
 
@@ -36,8 +36,7 @@ export const createSecret = async (
 ) => {
   const secretBody = buildSecretBody(name, data, namespace)
 
-  // Use the Kubernetes API endpoint for secrets
-  const endpoint = `/api/v1/namespaces/${namespace}/secrets`
+  const endpoint = `${K8S_PROXY_BASE_PATH}/namespaces/${namespace}/secrets`
 
   const response = await axios.post({
     endpoint,
@@ -55,7 +54,7 @@ export const replaceSecret = async (
   try {
     const secretBody = buildSecretBody(name, data, namespace)
 
-    const endpoint = `/api/v1/namespaces/${namespace}/secrets/${name}`
+    const endpoint = `${K8S_PROXY_BASE_PATH}/namespaces/${namespace}/secrets/${name}`
     const response = await axios.put({
       endpoint,
       data: secretBody
@@ -220,7 +219,7 @@ export const getSecret = async (
   name: string,
   namespace = VJAILBREAK_DEFAULT_NAMESPACE
 ): Promise<Secret> => {
-  const endpoint = `/api/v1/namespaces/${namespace}/secrets/${name}`
+  const endpoint = `${K8S_PROXY_BASE_PATH}/namespaces/${namespace}/secrets/${name}`
 
   try {
     const response: Secret = await axios.get({
@@ -258,19 +257,19 @@ export const getSecret = async (
 }
 
 export const deleteSecret = async (name: string, namespace = VJAILBREAK_DEFAULT_NAMESPACE) => {
-  const endpoint = `/api/v1/namespaces/${namespace}/secrets/${name}`
+  const endpoint = `${K8S_PROXY_BASE_PATH}/namespaces/${namespace}/secrets/${name}`
   const response = await axios.del({ endpoint })
   return response
 }
 
 export const getSecrets = async (namespace = VJAILBREAK_DEFAULT_NAMESPACE) => {
-  const endpoint = `/api/v1/namespaces/${namespace}/secrets`
+  const endpoint = `${K8S_PROXY_BASE_PATH}/namespaces/${namespace}/secrets`
   const response = await axios.get({ endpoint })
   return response
 }
 
 export const listSecrets = async (namespace = VJAILBREAK_DEFAULT_NAMESPACE): Promise<Secret[]> => {
-  const endpoint = `/api/v1/namespaces/${namespace}/secrets`
+  const endpoint = `${K8S_PROXY_BASE_PATH}/namespaces/${namespace}/secrets`
   const response = await axios.get<SecretList>({ endpoint })
 
   const items = Array.isArray(response?.items) ? response.items : []


### PR DESCRIPTION
## What this PR does / why we need it

**Before:** ui-manager-sa had direct Kubernetes RBAC for secrets (full CRUD) and pods (get/list/watch/patch). Any compromise of this service account could directly read/modify secrets and pods.

**After:** Those RBAC rules are removed from ui-manager-role. The UI still works because all secret and pod operations are routed through the vpwned API server (running as migration-controller-manager) via a reverse proxy at /vpw/v1/k8s/*. A compromised ui-manager-sa token has no direct K8s API access for secrets or pods.

### Two layers enforced before any request is forwarded:

- Layer 1 — TokenReview gate: vpwned calls the K8s TokenReview API to verify the incoming Authorization: Bearer token is (a) cryptographically valid and (b) belongs specifically to system:serviceaccount:migration-system:ui-manager-sa. Invalid or missing tokens → 401. Valid tokens cached 60 seconds.

- Layer 2 — Path + method allowlist: Even with a valid token, only the exact set of K8s API calls the UI makes are allowed through. Everything else → 403.


Resource | Methods allowed
-- | --
pods | GET (list/get/log), PATCH (admin cutover)
secrets | GET, POST, PUT, DELETE
anything else | blocked



## Which issue(s) this PR fixes
fixes #1888

## Testing done
did migrations with admin initiated cutover from the fresh build
<img width="1057" height="810" alt="image" src="https://github.com/user-attachments/assets/f6dd2357-b02b-4d2c-b992-4d969d71a625" />
