### PR TITLE
[1933] Don't restart ui when listing users

### DIFF
--- a/image_builder/scripts/pf9-htpasswd.sh
+++ b/image_builder/scripts/pf9-htpasswd.sh
@@ -257,9 +257,6 @@ _pf9_ht_main() {
           ;;
         list)
           list_users
-          if [[ $no_restart -eq 0 ]]; then
-            sudo kubectl -n migration-system rollout restart deployment vjailbreak-ui
-          fi
           ;;
         refresh|reload)
           sudo kubectl -n migration-system rollout restart deployment vjailbreak-ui


### PR DESCRIPTION
## What this PR does / why we need it
While running vjbctl list users we were restarting ui, since this only a read operation it should not do that. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1933

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/1939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->