### PR TITLE
if No VDDK found, should not create job

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -1088,6 +1088,73 @@ func (r *MigrationPlanReconciler) CreateJob(ctx context.Context,
 		return errors.Wrap(err, "failed to get vjailbreak settings for pod resources")
 	}
 
+	// Storage-accelerated copy uses the array's native copy path and does not need
+	// the VDDK libraries inside the v2v-helper pod. Skip mounting the VDDK hostPath
+	// so kubelet doesn't fail the pod when /home/ubuntu/vmware-vix-disklib-distrib is absent.
+	isStorageAccelerated := migrationtemplate.Spec.StorageCopyMethod == StorageCopyMethod
+
+	volumeMounts := []corev1.VolumeMount{
+		{Name: "dev", MountPath: "/dev"},
+		{Name: "firstboot", MountPath: "/home/fedora/scripts"},
+		{Name: "logs", MountPath: "/var/log/pf9"},
+		{Name: "virtio-driver", MountPath: "/home/fedora/virtio-win"},
+	}
+	volumes := []corev1.Volume{
+		{
+			Name: "dev",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/dev",
+					Type: utils.NewHostPathType("Directory"),
+				},
+			},
+		},
+		{
+			Name: "firstboot",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: firstbootconfigMapName,
+					},
+				},
+			},
+		},
+		{
+			Name: "logs",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/var/log/pf9",
+					Type: utils.NewHostPathType("DirectoryOrCreate"),
+				},
+			},
+		},
+		{
+			Name: "virtio-driver",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/home/ubuntu/virtio-win",
+					Type: utils.NewHostPathType("DirectoryOrCreate"),
+				},
+			},
+		},
+	}
+	if !isStorageAccelerated {
+		volumeMounts = append([]corev1.VolumeMount{
+			{Name: "vddk", MountPath: "/home/fedora/vmware-vix-disklib-distrib"},
+		}, volumeMounts...)
+		volumes = append([]corev1.Volume{
+			{
+				Name: "vddk",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: VDDKDirectory,
+						Type: utils.NewHostPathType("Directory"),
+					},
+				},
+			},
+		}, volumes...)
+	}
+
 	job := &batchv1.Job{}
 	err = r.Get(ctx, types.NamespacedName{Name: jobName, Namespace: migrationplan.Namespace}, job)
 	if err != nil && apierrors.IsNotFound(err) {
@@ -1176,28 +1243,7 @@ func (r *MigrationPlanReconciler) CreateJob(ctx context.Context,
 									})
 									return envFrom
 								}(),
-								VolumeMounts: []corev1.VolumeMount{
-									{
-										Name:      "vddk",
-										MountPath: "/home/fedora/vmware-vix-disklib-distrib",
-									},
-									{
-										Name:      "dev",
-										MountPath: "/dev",
-									},
-									{
-										Name:      "firstboot",
-										MountPath: "/home/fedora/scripts",
-									},
-									{
-										Name:      "logs",
-										MountPath: "/var/log/pf9",
-									},
-									{
-										Name:      "virtio-driver",
-										MountPath: "/home/fedora/virtio-win",
-									},
-								},
+								VolumeMounts: volumeMounts,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceCPU:              resource.MustParse(vjailbreakSettings.V2VHelperPodCPURequest),
@@ -1212,54 +1258,7 @@ func (r *MigrationPlanReconciler) CreateJob(ctx context.Context,
 								},
 							},
 						},
-						Volumes: []corev1.Volume{
-							{
-								Name: "vddk",
-								VolumeSource: corev1.VolumeSource{
-									HostPath: &corev1.HostPathVolumeSource{
-										Path: "/home/ubuntu/vmware-vix-disklib-distrib",
-										Type: utils.NewHostPathType("Directory"),
-									},
-								},
-							},
-							{
-								Name: "dev",
-								VolumeSource: corev1.VolumeSource{
-									HostPath: &corev1.HostPathVolumeSource{
-										Path: "/dev",
-										Type: utils.NewHostPathType("Directory"),
-									},
-								},
-							},
-							{
-								Name: "firstboot",
-								VolumeSource: corev1.VolumeSource{
-									ConfigMap: &corev1.ConfigMapVolumeSource{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: firstbootconfigMapName,
-										},
-									},
-								},
-							},
-							{
-								Name: "logs",
-								VolumeSource: corev1.VolumeSource{
-									HostPath: &corev1.HostPathVolumeSource{
-										Path: "/var/log/pf9",
-										Type: utils.NewHostPathType("DirectoryOrCreate"),
-									},
-								},
-							},
-							{
-								Name: "virtio-driver",
-								VolumeSource: corev1.VolumeSource{
-									HostPath: &corev1.HostPathVolumeSource{
-										Path: "/home/ubuntu/virtio-win",
-										Type: utils.NewHostPathType("DirectoryOrCreate"),
-									},
-								},
-							},
-						},
+						Volumes: volumes,
 					},
 				},
 			},

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -2045,9 +2045,13 @@ func (r *MigrationPlanReconciler) TriggerMigration(ctx context.Context,
 		if err != nil {
 			return errors.Wrapf(err, "failed to create Firstboot ConfigMap for VM %s", vm)
 		}
-		//nolint:gocritic // err is already declared above
-		if err = r.validateVDDKPresence(ctx, migrationobj, ctxlog); err != nil {
-			return err
+		// Storage-accelerated copy uses the array's native copy path (Pure XCOPY / NetApp)
+		// and does not require VDDK on the appliance, so skip the VDDK validation entirely.
+		if migrationtemplate.Spec.StorageCopyMethod != StorageCopyMethod {
+			//nolint:gocritic // err is already declared above
+			if err = r.validateVDDKPresence(ctx, migrationobj, ctxlog); err != nil {
+				return err
+			}
 		}
 
 		arraycredsSecretRef := ""
@@ -2182,7 +2186,7 @@ func (r *MigrationPlanReconciler) validateVDDKPresence(
 			}
 		}
 
-		return errors.Wrap(err, "VDDK_MISSING: directory is empty")
+		return errors.New("VDDK_MISSING: directory is empty")
 	}
 
 	// Clear previous VDDKCheck condition if directory is valid

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -2080,9 +2080,6 @@ func (r *MigrationPlanReconciler) TriggerMigration(ctx context.Context,
 		}
 	}
 
-	if hotplugFlavorMissing {
-		return nil
-	}
 	return nil
 }
 
@@ -2162,7 +2159,7 @@ func (r *MigrationPlanReconciler) validateVDDKPresence(
 			return errors.Wrap(err, "failed to update migration status after missing VDDK dir")
 		}
 
-		return errors.Wrap(err, "VDDK_MISSING: directory could not be read")
+		return errors.New("VDDK_MISSING: directory could not be read")
 	}
 
 	if len(files) == 0 {


### PR DESCRIPTION
## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #

## Special notes for your reviewer


## Testing done

root@main-test:~# kubectl get pods -n migration-system 
NAME                                            READY   STATUS    RESTARTS   AGE
migration-controller-manager-644cdd8f7d-xm4fn   1/1     Running   0          21m
migration-vpwned-sdk-8667f9f477-kv82t           1/1     Running   0          77m
vjailbreak-ui-56bd97d499-v5x58                  1/1     Running   0          77m

status:
    conditions:
    - lastTransitionTime: "2026-05-15T08:53:22Z"
      message: VDDK directory is empty. Please upload the required files.
      reason: VDDKDirectoryEmpty
      status: "False"
      type: VDDKCheck
    - lastTransitionTime: "2026-05-15T08:53:22Z"
      message: VDDK directory is empty. Please upload the required files.
      reason: VDDKDirectoryEmpty
      status: "False"
      type: VDDKCheck

No pods scheduled. 
After adding vddk automatically job got created:
root@main-test:~# kubectl get pods -n migration-system 
NAME                                                       READY   STATUS              RESTARTS   AGE
migration-controller-manager-5c556bcc6f-lgnk7              1/1     Running             0          11s
migration-vpwned-sdk-67868c94b7-vm8hx                      1/1     Running             0          42s
v2v-helper-ubuntu-customer-config-8124-55a9a-e740f-rtm65   0/1     ContainerCreating   0          10s
vjailbreak-ui-56bd97d499-v5x58                             1/1     Running             0          79m




_please add testing details (logs, screenshots, etc.)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/1942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->