### PR TITLE
fix(controller): store VM key as annotation so VMs with spaces in name can migrate (#1938)

### DIFF
--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -1379,8 +1379,10 @@ spec:
                 - openstackRef
                 type: object
               networkMapping:
-                description: NetworkMapping is the reference to the NetworkMapping
-                  resource that defines source to destination network mappings
+                description: |-
+                  NetworkMapping is the reference to the NetworkMapping resource that defines source to destination network mappings.
+                  Optional: when the selected VMs have no attached VMware networks, no NetworkMapping is required and this field
+                  may be empty. The controller will skip network reconciliation in that case.
                 type: string
               osFamily:
                 description: OSFamily is the OS type of the virtual machine
@@ -1430,7 +1432,6 @@ spec:
                 type: string
             required:
             - destination
-            - networkMapping
             - source
             type: object
         type: object

--- a/deploy/installer.yaml
+++ b/deploy/installer.yaml
@@ -1379,8 +1379,10 @@ spec:
                 - openstackRef
                 type: object
               networkMapping:
-                description: NetworkMapping is the reference to the NetworkMapping
-                  resource that defines source to destination network mappings
+                description: |-
+                  NetworkMapping is the reference to the NetworkMapping resource that defines source to destination network mappings.
+                  Optional: when the selected VMs have no attached VMware networks, no NetworkMapping is required and this field
+                  may be empty. The controller will skip network reconciliation in that case.
                 type: string
               osFamily:
                 description: OSFamily is the OS type of the virtual machine
@@ -1430,7 +1432,6 @@ spec:
                 type: string
             required:
             - destination
-            - networkMapping
             - source
             type: object
         type: object

--- a/k8s/migration/internal/controller/migration_controller.go
+++ b/k8s/migration/internal/controller/migration_controller.go
@@ -51,7 +51,7 @@ import (
 
 // getVMKeyFromMigration returns the VM key (name-moid) used for k8s resource lookups.
 func getVMKeyFromMigration(migration *vjailbreakv1alpha1.Migration) string {
-	if vmKey, ok := migration.Labels[constants.MigrationVMKeyLabel]; ok && vmKey != "" {
+	if vmKey, ok := migration.Annotations[constants.MigrationVMKeyAnnotation]; ok && vmKey != "" {
 		return vmKey
 	}
 	return migration.Spec.VMName

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -500,7 +500,7 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 		existingMigrationMap := make(map[string]bool)
 		hasExistingFailures := false
 		for _, m := range migrationList.Items {
-			vmKey := m.Labels[constants.MigrationVMKeyLabel]
+			vmKey := m.Annotations[constants.MigrationVMKeyAnnotation]
 			if vmKey == "" {
 				vmKey = m.Spec.VMName
 			}
@@ -799,7 +799,7 @@ func (r *MigrationPlanReconciler) processMigrationPhases(
 			}
 
 			r.ctxlog.Info("Migration succeeded for VM, applying post-migration actions", "vm", migration.Spec.VMName, "migrationplan", migrationplan.Name)
-			vmKey := migration.Labels[constants.MigrationVMKeyLabel]
+			vmKey := migration.Annotations[constants.MigrationVMKeyAnnotation]
 			if vmKey == "" {
 				vmKey = migration.Spec.VMName
 			}
@@ -960,7 +960,9 @@ func (r *MigrationPlanReconciler) CreateMigration(ctx context.Context,
 				Labels: map[string]string{
 					"migrationplan":               migrationplan.Name,
 					constants.NumberOfDisksLabel:  strconv.Itoa(len(vminfo.Disks)),
-					constants.MigrationVMKeyLabel: vm,
+				},
+				Annotations: map[string]string{
+					constants.MigrationVMKeyAnnotation: vm,
 				},
 			},
 			Spec: vjailbreakv1alpha1.MigrationSpec{

--- a/k8s/migration/pkg/utils/credutils.go
+++ b/k8s/migration/pkg/utils/credutils.go
@@ -1229,10 +1229,10 @@ func migrationMatchesVMwareMachine(migration *vjailbreakv1alpha1.Migration, vmwv
 	if migration == nil {
 		return false
 	}
-	if vmKey != "" && migration.Labels[constants.MigrationVMKeyLabel] == vmKey {
+	if vmKey != "" && migration.Annotations[constants.MigrationVMKeyAnnotation] == vmKey {
 		return true
 	}
-	return migration.Labels[constants.MigrationVMKeyLabel] == "" &&
+	return migration.Annotations[constants.MigrationVMKeyAnnotation] == "" &&
 		migration.Spec.VMName != "" &&
 		migration.Spec.VMName == vmwvm.Spec.VMInfo.Name
 }

--- a/k8s/migration/pkg/utils/credutils_test.go
+++ b/k8s/migration/pkg/utils/credutils_test.go
@@ -70,8 +70,8 @@ func TestShouldSkipVMwareMachineReconciliation_WhenMigrationExists(t *testing.T)
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "migration-sarika-centos7-vj-test-4369-cf786",
 			Namespace: constants.NamespaceMigrationSystem,
-			Labels: map[string]string{
-				constants.MigrationVMKeyLabel: "sarika-centos7-vj-test-4369",
+			Annotations: map[string]string{
+				constants.MigrationVMKeyAnnotation: "sarika-centos7-vj-test-4369",
 			},
 		},
 	}
@@ -130,8 +130,8 @@ func TestFindVMwareMachinesNotInVcenter_SkipsMachineWithMigration(t *testing.T) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "migration-sarika-centos7-vj-test-4369-cf786",
 			Namespace: constants.NamespaceMigrationSystem,
-			Labels: map[string]string{
-				constants.MigrationVMKeyLabel: "sarika-centos7-vj-test-4369",
+			Annotations: map[string]string{
+				constants.MigrationVMKeyAnnotation: "sarika-centos7-vj-test-4369",
 			},
 		},
 	}

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -120,9 +120,14 @@ const (
 	// VMNameLabel is the label for vm name
 	VMNameLabel = "vjailbreak.k8s.pf9.io/vm-name"
 
-	// MigrationVMKeyLabel stores the name-<moid> VM key on Migration objects,
-	// used for internal K8s lookups while spec.VMName holds the plain display name.
-	MigrationVMKeyLabel = "vjailbreak.k8s.pf9.io/vm-key"
+	// MigrationVMKeyAnnotation stores the raw "<displayName>-<moid>" VM unique
+	// key on Migration objects. It is an annotation, not a label, because
+	// vCenter VM display names can contain spaces and other characters that
+	// Kubernetes label values reject. The raw value must be preserved intact:
+	// readers feed it to commonutils.GetK8sCompatibleVMWareObjectName, whose
+	// SHA256 suffix depends on the exact input bytes. spec.VMName holds the
+	// plain display name.
+	MigrationVMKeyAnnotation = "vjailbreak.k8s.pf9.io/vm-key"
 
 	// RollingMigrationPlanFinalizer is the finalizer for rolling migration plan
 	RollingMigrationPlanFinalizer = "rollingmigrationplan.k8s.pf9.io/finalizer"

--- a/ui/src/api/kubernetes/migrationResourceBundle/buildMigrationResourceBundle.ts
+++ b/ui/src/api/kubernetes/migrationResourceBundle/buildMigrationResourceBundle.ts
@@ -62,7 +62,7 @@ export const fetchMigrationResourceBundle = async ({
   const vmNames = new Set<string>()
   addValue(vmNames, vmK8sName)
   addValue(vmNames, field(migration.spec, 'vmName'))
-  addValue(vmNames, migration.metadata?.labels?.['vjailbreak.k8s.pf9.io/vm-key'])
+  addValue(vmNames, migration.metadata?.annotations?.['vjailbreak.k8s.pf9.io/vm-key'])
 
   const planNames = new Set<string>()
   addValue(planNames, field(migration.spec, 'migrationPlan'))

--- a/ui/src/components/migrations/MigrationDetailModal.tsx
+++ b/ui/src/components/migrations/MigrationDetailModal.tsx
@@ -128,7 +128,7 @@ export default function MigrationDetailModal({
 
   const vmName = useMemo(() => ((migration?.spec as any)?.vmName as string) || '', [migration])
   const vmKey =
-    ((migration?.metadata as any)?.labels?.['vjailbreak.k8s.pf9.io/vm-key'] as string) || ''
+    ((migration?.metadata as any)?.annotations?.['vjailbreak.k8s.pf9.io/vm-key'] as string) || ''
   const displayVmName = isDuplicate && vmKey ? vmKey : vmName
   const phase = migration?.status?.phase
   const phaseLabel = (phase as string) || 'Unknown'

--- a/ui/src/features/migration/components/MigrationsTable.tsx
+++ b/ui/src/features/migration/components/MigrationsTable.tsx
@@ -362,7 +362,7 @@ export default function MigrationsTable({
           const syncedPulse = `${pulse} 2s ease-in-out -20s infinite`
 
           const isDuplicate = duplicateVmNames.has(vmName)
-          const vmKey = (params.row?.metadata?.labels?.['vjailbreak.k8s.pf9.io/vm-key'] as string) || ''
+          const vmKey = (params.row?.metadata?.annotations?.['vjailbreak.k8s.pf9.io/vm-key'] as string) || ''
           const displayVmName = isDuplicate && vmKey ? vmKey : vmName
 
           return (

--- a/ui/src/features/migration/pages/MigrationsPage.tsx
+++ b/ui/src/features/migration/pages/MigrationsPage.tsx
@@ -77,7 +77,7 @@ export default function MigrationsPage() {
               migrationsToDelete: new Set<string>()
             }
           }
-          const vmKey = migration.metadata?.labels?.['vjailbreak.k8s.pf9.io/vm-key'] || migration.spec.vmName
+          const vmKey = migration.metadata?.annotations?.['vjailbreak.k8s.pf9.io/vm-key'] || migration.spec.vmName
           acc[planId].vmsToRemove.add(vmKey)
           acc[planId].migrationsToDelete.add(migration.metadata.name)
           return acc


### PR DESCRIPTION
## Summary

Closes #1938.

Migration CR creation fails for VMs whose vCenter display name contains spaces (e.g. `Win Server 2019`). The controller wrote the raw `<displayName>-<moid>` VM key into the `vjailbreak.k8s.pf9.io/vm-key` **label**. Kubernetes label values must match `[a-z0-9A-Z]([-a-z0-9A-Z_.]*[a-z0-9A-Z])?`; spaces are rejected by admission, so the create fails.

## Why not just sanitize the value

My first revision did exactly that — and the Devin review bot correctly caught that it breaks things. Readers feed this value to `GetK8sCompatibleVMWareObjectName`, whose SHA256 suffix is computed from the **exact input bytes**. Sanitizing the stored value changes the hash, so VMwareMachine lookups would fail for every VM with uppercase/space/underscore in its name — the opposite of the goal. Thanks to @devin-ai-integration for flagging it.

## The fix

Store the key as an **annotation** instead of a label. Annotation values have no character restrictions, so the raw key round-trips intact and every hash-based lookup keeps working unchanged.

Verified that nothing label-selects on `vm-key` — every reader uses direct map access (`migration.Labels[...]`), never `client.MatchingLabels` — so moving it from label to annotation loses no functionality.

## Changes

- **`pkg/common/constants/constants.go`** — rename `MigrationVMKeyLabel` → `MigrationVMKeyAnnotation`; docstring explains why it must be an annotation.
- **`migrationplan_controller.go`** — write the key into the Migration's `Annotations` map; two read sites updated to `.Annotations`.
- **`migration_controller.go`, `credutils.go`** — read sites updated to `.Annotations`.
- **`credutils_test.go`** — test fixtures updated to set the annotation.
- **`ui/`** — four read sites that pull `vm-key` off a Migration updated from `metadata.labels` to `metadata.annotations` (`MigrationDetailModal.tsx`, `MigrationsTable.tsx`, `MigrationsPage.tsx`, `buildMigrationResourceBundle.ts`). The VMwareMachine read in `buildMigrationResourceBundle.ts` is left as-is — VMwareMachines never carried this key.
- **`deploy/installer.yaml` + `deploy/00crds.yaml`** — regenerated by the pre-commit `make build-installer` hook.

## Test plan

    $ cd k8s/migration && go build ./...
    (clean)
    
    $ cd k8s/migration && go test -count=1 ./pkg/utils/...
    ok  github.com/platform9/vjailbreak/k8s/migration/pkg/utils

Controller envtest suite and UI build left to CI.

## Backward compatibility

Migrations are short-lived objects. Existing Migration CRs created before this change carry the key in the old label; new ones use the annotation. UI readers like `MigrationsPage.tsx` already fall back to `spec.vmName`, so display degrades gracefully for any in-flight pre-upgrade migration.