### PR TITLE
feat(migration): optional power-off of target VM after migration (#1867)

### DIFF
--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -1007,6 +1007,12 @@ spec:
                   performHealthChecks:
                     default: false
                     type: boolean
+                  powerOffTargetVm:
+                    default: false
+                    description: |-
+                      PowerOffTargetVM, when true, leaves the migrated VM powered off in the
+                      target cloud instead of starting it after creation.
+                    type: boolean
                   type:
                     enum:
                     - hot
@@ -1202,6 +1208,12 @@ spec:
               podRef:
                 description: PodRef is the name of the pod
                 type: string
+              powerOffTargetVm:
+                description: |-
+                  PowerOffTargetVM specifies whether to leave the migrated VM powered off
+                  in the target cloud instead of starting it. Useful when post-migration
+                  tasks must run before the VM's first boot. Defaults to false.
+                type: boolean
               vmName:
                 description: VMName is the name of the VM getting migrated from VMWare
                   to Openstack
@@ -1379,8 +1391,10 @@ spec:
                 - openstackRef
                 type: object
               networkMapping:
-                description: NetworkMapping is the reference to the NetworkMapping
-                  resource that defines source to destination network mappings
+                description: |-
+                  NetworkMapping is the reference to the NetworkMapping resource that defines source to destination network mappings.
+                  Optional: when the selected VMs have no attached VMware networks, no NetworkMapping is required and this field
+                  may be empty. The controller will skip network reconciliation in that case.
                 type: string
               osFamily:
                 description: OSFamily is the OS type of the virtual machine
@@ -1430,7 +1444,6 @@ spec:
                 type: string
             required:
             - destination
-            - networkMapping
             - source
             type: object
         type: object
@@ -2382,6 +2395,12 @@ spec:
                     type: string
                   performHealthChecks:
                     default: false
+                    type: boolean
+                  powerOffTargetVm:
+                    default: false
+                    description: |-
+                      PowerOffTargetVM, when true, leaves the migrated VM powered off in the
+                      target cloud instead of starting it after creation.
                     type: boolean
                   type:
                     enum:

--- a/deploy/installer.yaml
+++ b/deploy/installer.yaml
@@ -1007,6 +1007,12 @@ spec:
                   performHealthChecks:
                     default: false
                     type: boolean
+                  powerOffTargetVm:
+                    default: false
+                    description: |-
+                      PowerOffTargetVM, when true, leaves the migrated VM powered off in the
+                      target cloud instead of starting it after creation.
+                    type: boolean
                   type:
                     enum:
                     - hot
@@ -1202,6 +1208,12 @@ spec:
               podRef:
                 description: PodRef is the name of the pod
                 type: string
+              powerOffTargetVm:
+                description: |-
+                  PowerOffTargetVM specifies whether to leave the migrated VM powered off
+                  in the target cloud instead of starting it. Useful when post-migration
+                  tasks must run before the VM's first boot. Defaults to false.
+                type: boolean
               vmName:
                 description: VMName is the name of the VM getting migrated from VMWare
                   to Openstack
@@ -1379,8 +1391,10 @@ spec:
                 - openstackRef
                 type: object
               networkMapping:
-                description: NetworkMapping is the reference to the NetworkMapping
-                  resource that defines source to destination network mappings
+                description: |-
+                  NetworkMapping is the reference to the NetworkMapping resource that defines source to destination network mappings.
+                  Optional: when the selected VMs have no attached VMware networks, no NetworkMapping is required and this field
+                  may be empty. The controller will skip network reconciliation in that case.
                 type: string
               osFamily:
                 description: OSFamily is the OS type of the virtual machine
@@ -1430,7 +1444,6 @@ spec:
                 type: string
             required:
             - destination
-            - networkMapping
             - source
             type: object
         type: object
@@ -2382,6 +2395,12 @@ spec:
                     type: string
                   performHealthChecks:
                     default: false
+                    type: boolean
+                  powerOffTargetVm:
+                    default: false
+                    description: |-
+                      PowerOffTargetVM, when true, leaves the migrated VM powered off in the
+                      target cloud instead of starting it after creation.
                     type: boolean
                   type:
                     enum:

--- a/k8s/migration/api/v1alpha1/migration_types.go
+++ b/k8s/migration/api/v1alpha1/migration_types.go
@@ -94,6 +94,12 @@ type MigrationSpec struct {
 	// +optional
 	DisconnectSourceNetwork bool `json:"disconnectSourceNetwork,omitempty"`
 
+	// PowerOffTargetVM specifies whether to leave the migrated VM powered off
+	// in the target cloud instead of starting it. Useful when post-migration
+	// tasks must run before the VM's first boot. Defaults to false.
+	// +optional
+	PowerOffTargetVM bool `json:"powerOffTargetVm,omitempty"`
+
 	// NetworkOverrides is the JSON-serialized per-NIC overrides for IP and MAC preservation
 	// +optional
 	NetworkOverrides string `json:"networkOverrides,omitempty"`

--- a/k8s/migration/api/v1alpha1/migrationplan_types.go
+++ b/k8s/migration/api/v1alpha1/migrationplan_types.go
@@ -45,6 +45,10 @@ type MigrationPlanStrategy struct {
 	DisconnectSourceNetwork bool `json:"disconnectSourceNetwork,omitempty"`
 	// +kubebuilder:default:=false
 	ArrayOffload bool `json:"arrayOffload,omitempty"`
+	// PowerOffTargetVM, when true, leaves the migrated VM powered off in the
+	// target cloud instead of starting it after creation.
+	// +kubebuilder:default:=false
+	PowerOffTargetVM bool `json:"powerOffTargetVm,omitempty"`
 }
 
 // AdvancedOptions defines advanced configuration options for the migration process

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationplans.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationplans.yaml
@@ -130,6 +130,12 @@ spec:
                   performHealthChecks:
                     default: false
                     type: boolean
+                  powerOffTargetVm:
+                    default: false
+                    description: |-
+                      PowerOffTargetVM, when true, leaves the migrated VM powered off in the
+                      target cloud instead of starting it after creation.
+                    type: boolean
                   type:
                     enum:
                     - hot

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrations.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrations.yaml
@@ -91,6 +91,12 @@ spec:
               podRef:
                 description: PodRef is the name of the pod
                 type: string
+              powerOffTargetVm:
+                description: |-
+                  PowerOffTargetVM specifies whether to leave the migrated VM powered off
+                  in the target cloud instead of starting it. Useful when post-migration
+                  tasks must run before the VM's first boot. Defaults to false.
+                type: boolean
               vmName:
                 description: VMName is the name of the VM getting migrated from VMWare
                   to Openstack

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_rollingmigrationplans.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_rollingmigrationplans.yaml
@@ -211,6 +211,12 @@ spec:
                   performHealthChecks:
                     default: false
                     type: boolean
+                  powerOffTargetVm:
+                    default: false
+                    description: |-
+                      PowerOffTargetVM, when true, leaves the migrated VM powered off in the
+                      target cloud instead of starting it after creation.
+                    type: boolean
                   type:
                     enum:
                     - hot

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -969,6 +969,7 @@ func (r *MigrationPlanReconciler) CreateMigration(ctx context.Context,
 				// PodRef will be set in the migration controller
 				InitiateCutover:         migrationplan.Spec.MigrationStrategy.AdminInitiatedCutOver,
 				DisconnectSourceNetwork: migrationplan.Spec.MigrationStrategy.DisconnectSourceNetwork,
+				PowerOffTargetVM:        migrationplan.Spec.MigrationStrategy.PowerOffTargetVM,
 				NetworkOverrides:        networkOverrides,
 				MigrationType:           migrationplan.Spec.MigrationStrategy.Type,
 			},
@@ -1519,6 +1520,7 @@ func (r *MigrationPlanReconciler) buildBaseConfigMapData(
 		"REMOVE_VMWARE_TOOLS":               strconv.FormatBool(migrationplan.Spec.AdvancedOptions.RemoveVMwareTools),
 		"ACKNOWLEDGE_NETWORK_CONFLICT_RISK": strconv.FormatBool(migrationplan.Spec.AdvancedOptions.AcknowledgeNetworkConflictRisk),
 		"DISCONNECT_SOURCE_NETWORK":         strconv.FormatBool(migrationobj.Spec.DisconnectSourceNetwork),
+		"POWER_OFF_TARGET_VM":               strconv.FormatBool(migrationobj.Spec.PowerOffTargetVM),
 	}
 }
 

--- a/v2v-helper/main.go
+++ b/v2v-helper/main.go
@@ -140,6 +140,7 @@ func main() {
 		Thumbprint:              thumbprint,
 		Convert:                 migrationparams.OpenstackConvert,
 		DisconnectSourceNetwork: migrationparams.DisconnectSourceNetwork,
+		PowerOffTargetVM:        migrationparams.PowerOffTargetVM,
 		Openstackclients:        openstackclients,
 		Vcclient:                vcclient,
 		VMops:                   vmops,
@@ -221,6 +222,7 @@ TYPE=%s
 TARGET_FLAVOR_ID=%s
 TARGET_AVAILABILITY_ZONE=%s
 DISCONNECT_SOURCE_NETWORK=%s
+POWER_OFF_TARGET_VM=%v
 SECURITY_GROUPS=%s
 SERVER_GROUP=%s
 RDM_DISKS=%s
@@ -239,6 +241,7 @@ ACKNOWLEDGE_NETWORK_CONFLICT_RISK=%s`,
 		migrationparams.TARGET_FLAVOR_ID,
 		migrationparams.TargetAvailabilityZone,
 		migrationparams.DisconnectSourceNetwork,
+		migrationparams.PowerOffTargetVM,
 		migrationparams.SecurityGroups,
 		migrationparams.ServerGroup,
 		migrationparams.RDMDisks,

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -50,6 +50,7 @@ type Migrate struct {
 	Thumbprint              string
 	Convert                 bool
 	DisconnectSourceNetwork bool
+	PowerOffTargetVM        bool
 	Openstackclients        openstack.OpenstackOperations
 	Vcclient                vcenter.VCenterOperations
 	VMops                   vm.VMOperations
@@ -1636,6 +1637,15 @@ func (migobj *Migrate) CreateTargetInstance(ctx context.Context, vminfo vm.VMInf
 	}
 
 	migobj.logMessage(fmt.Sprintf("VM created successfully: ID: %s", newVM.ID))
+
+	if migobj.PowerOffTargetVM {
+		migobj.logMessage("PowerOffTargetVM is set: powering off the target VM and skipping health checks")
+		if err := openstackops.StopServer(ctx, newVM.ID, *vjailbreakSettings); err != nil {
+			return errors.Wrap(err, "failed to power off target VM")
+		}
+		migobj.logMessage("Target VM powered off successfully")
+		return nil
+	}
 
 	if migobj.PerformHealthChecks {
 		err = migobj.HealthCheck(vminfo, ipaddresses)

--- a/v2v-helper/migrate/migrate_test.go
+++ b/v2v-helper/migrate/migrate_test.go
@@ -553,6 +553,59 @@ func TestCreateTargetInstance(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestCreateTargetInstance_PowerOffTargetVM(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ctx := context.Background()
+
+	mockOpenStackOps := openstack.NewMockOpenstackOperations(ctrl)
+	mockOpenStackOps.EXPECT().GetClosestFlavour(gomock.Any(), gomock.Any(), gomock.Any()).Return(&flavors.Flavor{
+		VCPUs: 2,
+		RAM:   2048,
+	}, nil).AnyTimes()
+	mockOpenStackOps.EXPECT().GetNetwork(gomock.Any(), gomock.Any()).Return(&networks.Network{}, nil).AnyTimes()
+	mockOpenStackOps.EXPECT().CreatePort(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ports.Port{
+		MACAddress: "mac-address",
+	}, nil).AnyTimes()
+	mockOpenStackOps.EXPECT().CreateVM(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&servers.Server{}, nil).AnyTimes()
+	mockOpenStackOps.EXPECT().WaitUntilVMActive(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+	mockOpenStackOps.EXPECT().GetFlavor(gomock.Any(), "flavor-id").Return(&flavors.Flavor{
+		VCPUs: 2,
+		RAM:   2048,
+	}, nil).AnyTimes()
+	mockOpenStackOps.EXPECT().GetSecurityGroupIDs(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil).AnyTimes()
+	// With PowerOffTargetVM set, CreateTargetInstance must call StopServer exactly once.
+	mockOpenStackOps.EXPECT().StopServer(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	inputvminfo := vm.VMInfo{
+		Name:   "test-vm",
+		OSType: "linux",
+		Mac: []string{
+			"mac-address-1",
+			"mac-address-2",
+		},
+	}
+
+	fakeCtrlClient := ctrlfake.NewClientBuilder().WithObjects(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.VjailbreakSettingsConfigMapName,
+			Namespace: constants.NamespaceMigrationSystem,
+		},
+		Data: map[string]string{},
+	}).Build()
+
+	migobj := Migrate{
+		Openstackclients: mockOpenStackOps,
+		Networknames:     []string{"network-name-1", "network-name-2"},
+		InPod:            false,
+		TargetFlavorId:   "flavor-id",
+		K8sClient:        fakeCtrlClient,
+		PowerOffTargetVM: true,
+	}
+	err := migobj.CreateTargetInstance(ctx, inputvminfo, []string{"network-id-1", "network-id-2"}, []string{"port-id-1", "port-id-2"}, []string{"ip-address-1", "ip-address-2"}, -1)
+	assert.NoError(t, err)
+}
+
 func TestCreateTargetInstance_AdvancedMapping_Ports(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/v2v-helper/openstack/openstackops.go
+++ b/v2v-helper/openstack/openstackops.go
@@ -54,6 +54,7 @@ type OpenstackOperations interface {
 	FindDevice(volumeID string) (string, error)
 	ManageExistingVolume(name string, ref map[string]interface{}, host string, volumeType string) (*volumes.Volume, error)
 	WaitUntilVMActive(ctx context.Context, vmID string) (bool, error)
+	StopServer(ctx context.Context, serverID string, vjailbreakSettings k8sutils.VjailbreakSettings) error
 	GetIsSimpleNetwork(ctx context.Context, networkID string) (bool, error)
 	// GetCinderVolumeServices returns Cinder volume services (Host, Status, State)
 	// Returns a slice of structs with these fields - defined in implementation package to avoid import cycles

--- a/v2v-helper/openstack/openstackops_mock.go
+++ b/v2v-helper/openstack/openstackops_mock.go
@@ -436,3 +436,17 @@ func (mr *MockOpenstackOperationsMockRecorder) WaitUntilVMActive(ctx, vmID inter
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVMActive", reflect.TypeOf((*MockOpenstackOperations)(nil).WaitUntilVMActive), ctx, vmID)
 }
+
+// StopServer mocks base method.
+func (m *MockOpenstackOperations) StopServer(ctx context.Context, serverID string, vjailbreakSettings k8sutils.VjailbreakSettings) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StopServer", ctx, serverID, vjailbreakSettings)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StopServer indicates an expected call of StopServer.
+func (mr *MockOpenstackOperationsMockRecorder) StopServer(ctx, serverID, vjailbreakSettings interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopServer", reflect.TypeOf((*MockOpenstackOperations)(nil).StopServer), ctx, serverID, vjailbreakSettings)
+}

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -974,6 +974,32 @@ func (osclient *OpenStackClients) WaitUntilVMActive(ctx context.Context, vmID st
 	return true, nil
 }
 
+// StopServer issues a power-off (stop) request for an OpenStack server and
+// waits until it reaches the SHUTOFF state. Used when the migration is
+// configured to leave the target VM powered off (see MigrationStrategy
+// .powerOffTargetVm).
+func (osclient *OpenStackClients) StopServer(ctx context.Context, serverID string, vjailbreakSettings k8sutils.VjailbreakSettings) error {
+	PrintLog(fmt.Sprintf("OPENSTACK API: Stopping server %s", serverID))
+	if err := servers.Stop(ctx, osclient.ComputeClient, serverID).ExtractErr(); err != nil {
+		return fmt.Errorf("failed to issue stop for server %s: %s", serverID, err)
+	}
+	for i := 0; i < vjailbreakSettings.VMActiveWaitRetryLimit; i++ {
+		result, err := servers.Get(ctx, osclient.ComputeClient, serverID).Extract()
+		if err != nil {
+			return fmt.Errorf("failed to get server status while waiting for shutoff: %s", err)
+		}
+		if result.Status == "SHUTOFF" {
+			PrintLog(fmt.Sprintf("Server %s is now powered off", serverID))
+			return nil
+		}
+		if result.Status == "ERROR" {
+			return fmt.Errorf("server %s went into ERROR state while stopping", serverID)
+		}
+		time.Sleep(time.Duration(vjailbreakSettings.VMActiveWaitIntervalSeconds) * time.Second)
+	}
+	return fmt.Errorf("server %s did not reach SHUTOFF after %d retries", serverID, vjailbreakSettings.VMActiveWaitRetryLimit)
+}
+
 // ManageExistingVolume manages an existing volume on the storage backend into Cinder
 // Uses the manageable_volumes endpoint which is the standard Cinder manage API
 func (osclient *OpenStackClients) ManageExistingVolume(name string, ref map[string]interface{}, host string, volumeType string) (*volumes.Volume, error) {

--- a/v2v-helper/pkg/utils/vcenterutils.go
+++ b/v2v-helper/pkg/utils/vcenterutils.go
@@ -37,6 +37,7 @@ type MigrationParams struct {
 	TargetAvailabilityZone         string
 	VMwareMachineName              string
 	DisconnectSourceNetwork        bool
+	PowerOffTargetVM               bool
 	SecurityGroups                 string
 	ServerGroup                    string
 	RDMDisks                       string
@@ -101,6 +102,7 @@ func GetMigrationParams(ctx context.Context, client client.Client) (*MigrationPa
 		TargetAvailabilityZone:         string(configMap.Data["TARGET_AVAILABILITY_ZONE"]),
 		VMwareMachineName:              string(configMap.Data["VMWARE_MACHINE_OBJECT_NAME"]),
 		DisconnectSourceNetwork:        string(configMap.Data["DISCONNECT_SOURCE_NETWORK"]) == constants.TrueString,
+		PowerOffTargetVM:               string(configMap.Data["POWER_OFF_TARGET_VM"]) == constants.TrueString,
 		SecurityGroups:                 string(configMap.Data["SECURITY_GROUPS"]),
 		ServerGroup:                    string(configMap.Data["SERVER_GROUP"]),
 		RDMDisks:                       string(configMap.Data["RDM_DISK_NAMES"]),


### PR DESCRIPTION
## Summary

Implements #1867.

By default the migrated VM boots powered-on in the target cloud — Nova starts it on creation. Operators who need to run post-migration tasks before first boot (the issue's example: assigning security groups via script) had no way to keep it off.

This adds a `powerOffTargetVm` option. When set, the target VM is stopped immediately after it's created and verified ACTIVE, and post-migration health checks are skipped (they require a running VM).

## Design

The flag mirrors the existing `disconnectSourceNetwork` plumbing end-to-end — an established pattern:

- **`migrationplan_types.go`** — `PowerOffTargetVM` added to `MigrationStrategy`.
- **`migration_types.go`** — `PowerOffTargetVM` added to `MigrationSpec`.
- **`config/crd/bases/*`** — regenerated via `make manifests`.
- **`migrationplan_controller.go`** — copies the strategy flag onto each Migration's spec, and writes `POWER_OFF_TARGET_VM` into the v2v-helper configmap.
- **`vcenterutils.go`** — reads `POWER_OFF_TARGET_VM` into `MigrationParams`.
- **`main.go`** — populates `Migrate.PowerOffTargetVM` and logs it.
- **`migrate.go`** — new `PowerOffTargetVM` field; in `CreateTargetInstance`, after the VM is ACTIVE, stops it and skips health checks when the flag is set.

## New OpenStack operation

`OpenstackOperations` gains `StopServer`, which issues `servers.Stop` and polls until the server reaches `SHUTOFF` (reusing the existing `VMActiveWait` retry settings). Implementation in `openstackopsutils.go`, mock in `openstackops_mock.go`.

## Tests

`TestCreateTargetInstance_PowerOffTargetVM` asserts `StopServer` is called exactly once when `PowerOffTargetVM` is set.

Verified locally:
- `go build ./...` (k8s/migration) — OK
- `go test ./pkg/utils/...` (k8s/migration) — OK
- `CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build ./...` (v2v-helper) — OK

The v2v-helper `migrate` package test suite can't be built locally because of a pre-existing `CreateVM` mock mismatch on `main` (addressed by #1945). `TestCreateTargetInstance_PowerOffTargetVM` will run in CI.

## Scope

Backend only. A UI checkbox ("Keep Target VM Powered Off", as the issue suggests) will follow in a separate PR. The capability is usable now via the MigrationPlan CRD / CLI:

    spec:
      migrationStrategy:
        powerOffTargetVm: true
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/1950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->