### PR TITLE
[1803] fix: Added retry for transient API errors

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,7 +8,7 @@ cd "${REPO_ROOT}"
 if [ -f graphify-out/graph.json ]; then
   echo "[pre-commit] updating knowledge graph (graphify)"
   GRAPHIFY_PYTHON=""
-  GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+  GRAPHIFY_BIN=$(command -v graphify 2>/dev/null) || true
   if [ -n "$GRAPHIFY_BIN" ]; then
     _SHEBANG=$(head -1 "$GRAPHIFY_BIN" | sed 's/^#![[:space:]]*//')
     case "$_SHEBANG" in

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -353,6 +353,10 @@ const (
 	// Number of intervals to wait for the volume to become available
 	MaxIntervalCount = 60
 
+	// Retry attempts for delete operations (port, volume) during cleanup.
+	// Kept small — cleanup should not block indefinitely, but must survive transient API errors.
+	DeleteOperationRetryCount = 5
+
 	InspectOSCommand      = "inspect-os"
 	LSBootCommand         = "ls /boot"
 	XMLFileName           = "libxml.xml"

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -353,7 +353,8 @@ const (
 	// Number of intervals to wait for the volume to become available
 	MaxIntervalCount = 60
 
-	// Retry attempts and interval for delete/create operations to survive transient API errors.
+	// Retry attempts for delete operations (port, volume) during cleanup.
+	// Kept small — cleanup should not block indefinitely, but must survive transient API errors.
 	DeleteOperationRetryCount           = 5
 	DeleteOperationRetryIntervalSeconds = 5
 

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -353,9 +353,9 @@ const (
 	// Number of intervals to wait for the volume to become available
 	MaxIntervalCount = 60
 
-	// Retry attempts for delete operations (port, volume) during cleanup.
-	// Kept small — cleanup should not block indefinitely, but must survive transient API errors.
-	DeleteOperationRetryCount = 5
+	// Retry attempts and interval for delete/create operations to survive transient API errors.
+	DeleteOperationRetryCount           = 5
+	DeleteOperationRetryIntervalSeconds = 5
 
 	InspectOSCommand      = "inspect-os"
 	LSBootCommand         = "ls /boot"

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -269,6 +269,10 @@ func (migobj *Migrate) DetachVolume(ctx context.Context, disk vm.VMDisk) error {
 func (migobj *Migrate) DetachAllVolumes(ctx context.Context, vminfo vm.VMInfo) error {
 	openstackops := migobj.Openstackclients
 	for _, vmdisk := range vminfo.VMDisks {
+		if vmdisk.OpenstackVol == nil {
+			migobj.logMessage(fmt.Sprintf("Skipping detach for disk %s: no OpenStack volume was created", vmdisk.Name))
+			continue
+		}
 		migobj.logMessage(fmt.Sprintf("Detaching volume %s from VM", vmdisk.Name))
 		if err := openstackops.DetachVolumeFromVM(ctx, vmdisk.OpenstackVol.ID); err != nil && !strings.Contains(err.Error(), "is not attached to volume") {
 			return errors.Wrap(err, "failed to detach volume from VM")
@@ -287,6 +291,10 @@ func (migobj *Migrate) DetachAllVolumes(ctx context.Context, vminfo vm.VMInfo) e
 func (migobj *Migrate) DeleteAllVolumes(ctx context.Context, vminfo vm.VMInfo) error {
 	openstackops := migobj.Openstackclients
 	for _, vmdisk := range vminfo.VMDisks {
+		if vmdisk.OpenstackVol == nil {
+			migobj.logMessage(fmt.Sprintf("Skipping delete for disk %s: no OpenStack volume was created", vmdisk.Name))
+			continue
+		}
 		err := openstackops.DeleteVolume(ctx, vmdisk.OpenstackVol.ID)
 		if err != nil {
 			return errors.Wrap(err, "failed to delete volume")
@@ -1881,6 +1889,9 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 	if migobj.StorageCopyMethod == constants.StorageCopyMethod {
 		// Initialize storage provider if using StorageAcceleratedCopy migration
 		if err := migobj.InitializeStorageProvider(ctx); err != nil {
+			if cleanuperror := migobj.cleanup(ctx, vminfo, fmt.Sprintf("failed to initialize storage provider: %s", err), portids, vcenterSettings); cleanuperror != nil {
+				return errors.Wrapf(err, "failed to cleanup after storage provider init failure: %s", cleanuperror)
+			}
 			return errors.Wrap(err, "failed to initialize storage provider")
 		}
 		defer func() {
@@ -1889,15 +1900,24 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 			}
 		}()
 		if err := migobj.ValidateStorageAcceleratedCopyPrerequisites(ctx); err != nil {
+			if cleanuperror := migobj.cleanup(ctx, vminfo, fmt.Sprintf("StorageAcceleratedCopy prerequisites validation failed: %s", err), portids, vcenterSettings); cleanuperror != nil {
+				return errors.Wrapf(err, "failed to cleanup after prerequisites validation failure: %s", cleanuperror)
+			}
 			return errors.Wrap(err, "StorageAcceleratedCopy prerequisites validation failed")
 		}
 
 		// Perform the copy here.
 		if _, err := migobj.StorageAcceleratedCopyCopyDisks(ctx, vminfo); err != nil {
+			if cleanuperror := migobj.cleanup(ctx, vminfo, fmt.Sprintf("failed to perform StorageAcceleratedCopy copy: %s", err), portids, vcenterSettings); cleanuperror != nil {
+				return errors.Wrapf(err, "failed to cleanup after StorageAcceleratedCopy failure: %s", cleanuperror)
+			}
 			return errors.Wrap(err, "failed to perform StorageAcceleratedCopy copy")
 		}
 		// Apply image tags to the volumes we cinder managed.
 		if err := migobj.applyImageMetadataForXCOPYVolumes(ctx, vminfo); err != nil {
+			if cleanuperror := migobj.cleanup(ctx, vminfo, fmt.Sprintf("failed to apply image metadata to XCOPY volumes: %s", err), portids, vcenterSettings); cleanuperror != nil {
+				return errors.Wrapf(err, "failed to cleanup after image metadata failure: %s", cleanuperror)
+			}
 			return errors.Wrap(err, "failed to apply image metadata to XCOPY volumes")
 		}
 
@@ -1906,6 +1926,9 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 		// Create and Add Volumes to Host
 		vminfo, err = migobj.CreateVolumes(ctx, vminfo)
 		if err != nil {
+			if cleanuperror := migobj.cleanup(ctx, vminfo, fmt.Sprintf("failed to create volumes: %s", err), portids, vcenterSettings); cleanuperror != nil {
+				return errors.Wrapf(err, "failed to cleanup after volume creation failure: %s", cleanuperror)
+			}
 			return errors.Wrap(err, "failed to add volumes to host")
 		}
 		// Enable CBT

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1934,7 +1934,7 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 		// Enable CBT
 		err = migobj.EnableCBTWrapper()
 		if err != nil {
-			migobj.cleanup(ctx, vminfo, fmt.Sprintf("CBT Failure: %s", err), portids, nil)
+			migobj.cleanup(ctx, vminfo, fmt.Sprintf("CBT Failure: %s", err), portids, vcenterSettings)
 			return errors.Wrap(err, "CBT Failure")
 		}
 
@@ -1946,7 +1946,7 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 		// Live Replicate Disks
 		vminfo, err = migobj.LiveReplicateDisks(ctx, vminfo)
 		if err != nil {
-			if cleanuperror := migobj.cleanup(ctx, vminfo, fmt.Sprintf("failed to live replicate disks: %s", err), portids, nil); cleanuperror != nil {
+			if cleanuperror := migobj.cleanup(ctx, vminfo, fmt.Sprintf("failed to live replicate disks: %s", err), portids, vcenterSettings); cleanuperror != nil {
 				// combine both errors
 				return errors.Wrapf(err, "failed to cleanup disks: %s", cleanuperror)
 			}

--- a/v2v-helper/migrate/migrate_test.go
+++ b/v2v-helper/migrate/migrate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/platform9/vjailbreak/pkg/common/constants"
 	"github.com/platform9/vjailbreak/v2v-helper/nbd"
 	"github.com/platform9/vjailbreak/v2v-helper/openstack"
+	"github.com/platform9/vjailbreak/v2v-helper/pkg/k8sutils"
 	"github.com/platform9/vjailbreak/v2v-helper/vm"
 
 	"github.com/golang/mock/gomock"
@@ -517,7 +518,7 @@ func TestCreateTargetInstance(t *testing.T) {
 	mockOpenStackOps.EXPECT().CreatePort(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ports.Port{
 		MACAddress: "mac-address",
 	}, nil).AnyTimes()
-	mockOpenStackOps.EXPECT().CreateVM(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&servers.Server{}, nil).AnyTimes()
+	mockOpenStackOps.EXPECT().CreateVM(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&servers.Server{}, nil).AnyTimes()
 	mockOpenStackOps.EXPECT().WaitUntilVMActive(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	mockOpenStackOps.EXPECT().GetFlavor(gomock.Any(), "flavor-id").Return(&flavors.Flavor{
 		VCPUs: 2,
@@ -571,7 +572,7 @@ func TestCreateTargetInstance_AdvancedMapping_Ports(t *testing.T) {
 		ID:        "port-2-id",
 		NetworkID: "network-2",
 	}, nil).AnyTimes()
-	mockOpenStackOps.EXPECT().CreateVM(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&servers.Server{}, nil).AnyTimes()
+	mockOpenStackOps.EXPECT().CreateVM(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&servers.Server{}, nil).AnyTimes()
 	mockOpenStackOps.EXPECT().WaitUntilVMActive(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	mockOpenStackOps.EXPECT().GetFlavor(gomock.Any(), "flavor-id").Return(&flavors.Flavor{
 		VCPUs: 2,
@@ -619,7 +620,7 @@ func TestCreateTargetInstance_AdvancedMapping_InsufficientPorts(t *testing.T) {
 		RAM:   2048,
 	}, nil).AnyTimes()
 	mockOpenStackOps.EXPECT().GetSecurityGroupIDs(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil).AnyTimes()
-	mockOpenStackOps.EXPECT().CreateVM(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&servers.Server{}, nil).AnyTimes()
+	mockOpenStackOps.EXPECT().CreateVM(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&servers.Server{}, nil).AnyTimes()
 	mockOpenStackOps.EXPECT().WaitUntilVMActive(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
 	inputvminfo := vm.VMInfo{
 		Name:   "test-vm",
@@ -650,5 +651,82 @@ func TestCreateTargetInstance_AdvancedMapping_InsufficientPorts(t *testing.T) {
 	err := migobj.CreateTargetInstance(ctx, inputvminfo, []string{"network-id-1", "network-id-2"}, []string{"port-id-1", "port-id-2"}, []string{"ip-address-1", "ip-address-2"}, -1)
 	// The test passes port IDs directly, so the validation in the port creation code path is not triggered
 	// This test now just verifies that CreateTargetInstance can handle mismatched Networkports config
+	assert.NoError(t, err)
+}
+
+func TestDetachAllVolumes_SkipsNilOpenstackVol(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ctx := context.Background()
+
+	mockOpenStackOps := openstack.NewMockOpenstackOperations(ctrl)
+	// Only disk1 has a volume — expect exactly one detach+wait, not two.
+	mockOpenStackOps.EXPECT().DetachVolumeFromVM(gomock.Any(), "id1").Return(nil).Times(1)
+	mockOpenStackOps.EXPECT().WaitForVolume(gomock.Any(), "id1").Return(nil).Times(1)
+
+	vminfo := vm.VMInfo{
+		VMDisks: []vm.VMDisk{
+			{Name: "disk1", OpenstackVol: &volumes.Volume{ID: "id1"}},
+			{Name: "disk2", OpenstackVol: nil},
+		},
+	}
+	migobj := Migrate{Openstackclients: mockOpenStackOps, InPod: false}
+	err := migobj.DetachAllVolumes(ctx, vminfo)
+	assert.NoError(t, err)
+}
+
+func TestDeleteAllVolumes_SkipsNilOpenstackVol(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ctx := context.Background()
+
+	mockOpenStackOps := openstack.NewMockOpenstackOperations(ctrl)
+	// Only disk1 has a volume — expect exactly one delete call.
+	mockOpenStackOps.EXPECT().DeleteVolume(gomock.Any(), "id1").Return(nil).Times(1)
+
+	vminfo := vm.VMInfo{
+		VMDisks: []vm.VMDisk{
+			{Name: "disk1", OpenstackVol: &volumes.Volume{ID: "id1"}},
+			{Name: "disk2", OpenstackVol: nil},
+		},
+	}
+	migobj := Migrate{Openstackclients: mockOpenStackOps, InPod: false}
+	err := migobj.DeleteAllVolumes(ctx, vminfo)
+	assert.NoError(t, err)
+}
+
+// TestCleanup_PartialVolumes verifies that when CreateVolumes fails partway through,
+// cleanup correctly handles the mix of created (non-nil) and uncreated (nil) volumes,
+// deletes only the created volume, and deletes ports when the setting is enabled.
+func TestCleanup_PartialVolumes_DeletesCreatedVolumeAndPorts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	ctx := context.Background()
+
+	mockOpenStackOps := openstack.NewMockOpenstackOperations(ctrl)
+	mockVMOps := vm.NewMockVMOperations(ctrl)
+
+	// disk1 was created; disk2 was never created (nil OpenstackVol).
+	mockOpenStackOps.EXPECT().DetachVolumeFromVM(gomock.Any(), "id1").Return(nil).Times(1)
+	mockOpenStackOps.EXPECT().WaitForVolume(gomock.Any(), "id1").Return(nil).Times(1)
+	mockOpenStackOps.EXPECT().DeleteVolume(gomock.Any(), "id1").Return(nil).Times(1)
+	mockOpenStackOps.EXPECT().DeletePort(gomock.Any(), "port-1").Return(nil).Times(1)
+	mockVMOps.EXPECT().CleanUpSnapshots(true).Return(nil).Times(1)
+
+	vminfo := vm.VMInfo{
+		VMDisks: []vm.VMDisk{
+			{Name: "disk1", OpenstackVol: &volumes.Volume{ID: "id1"}},
+			{Name: "disk2", OpenstackVol: nil},
+		},
+	}
+	settings := &k8sutils.VjailbreakSettings{
+		CleanupPortsAfterMigrationFailure: true,
+	}
+	migobj := Migrate{
+		Openstackclients: mockOpenStackOps,
+		VMops:            mockVMOps,
+		InPod:            false,
+	}
+	err := migobj.cleanup(ctx, vminfo, "test partial volume failure", []string{"port-1"}, settings)
 	assert.NoError(t, err)
 }

--- a/v2v-helper/openstack/openstackops_mock.go
+++ b/v2v-helper/openstack/openstackops_mock.go
@@ -43,6 +43,20 @@ func (m *MockOpenstackOperations) EXPECT() *MockOpenstackOperationsMockRecorder 
 	return m.recorder
 }
 
+// ApplyBootVolumeImageMetadata mocks base method.
+func (m *MockOpenstackOperations) ApplyBootVolumeImageMetadata(ctx context.Context, volume *volumes.Volume, metadata map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyBootVolumeImageMetadata", ctx, volume, metadata)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyBootVolumeImageMetadata indicates an expected call of ApplyBootVolumeImageMetadata.
+func (mr *MockOpenstackOperationsMockRecorder) ApplyBootVolumeImageMetadata(ctx, volume, metadata interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyBootVolumeImageMetadata", reflect.TypeOf((*MockOpenstackOperations)(nil).ApplyBootVolumeImageMetadata), ctx, volume, metadata)
+}
+
 // AttachVolumeToVM mocks base method.
 func (m *MockOpenstackOperations) AttachVolumeToVM(ctx context.Context, volumeID string) error {
 	m.ctrl.T.Helper()
@@ -73,18 +87,18 @@ func (mr *MockOpenstackOperationsMockRecorder) CreatePort(ctx, networkid, mac, i
 }
 
 // CreateVM mocks base method.
-func (m *MockOpenstackOperations) CreateVM(ctx context.Context, flavor *flavors.Flavor, networkIDs, portIDs []string, vminfo vm.VMInfo, availabilityZone string, securityGroups []string, serverGroupID string, vjailbreakSettings k8sutils.VjailbreakSettings, useFlavorless bool) (*servers.Server, error) {
+func (m *MockOpenstackOperations) CreateVM(ctx context.Context, flavor *flavors.Flavor, networkIDs, portIDs []string, vminfo vm.VMInfo, availabilityZone string, securityGroups []string, serverGroupID string, vjailbreakSettings k8sutils.VjailbreakSettings, useFlavorless bool, espDiskIndex int) (*servers.Server, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateVM", ctx, flavor, networkIDs, portIDs, vminfo, availabilityZone, securityGroups, serverGroupID, vjailbreakSettings, useFlavorless)
+	ret := m.ctrl.Call(m, "CreateVM", ctx, flavor, networkIDs, portIDs, vminfo, availabilityZone, securityGroups, serverGroupID, vjailbreakSettings, useFlavorless, espDiskIndex)
 	ret0, _ := ret[0].(*servers.Server)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateVM indicates an expected call of CreateVM.
-func (mr *MockOpenstackOperationsMockRecorder) CreateVM(ctx, flavor, networkIDs, portIDs, vminfo, availabilityZone, securityGroups, serverGroupID, vjailbreakSettings, useFlavorless interface{}) *gomock.Call {
+func (mr *MockOpenstackOperationsMockRecorder) CreateVM(ctx, flavor, networkIDs, portIDs, vminfo, availabilityZone, securityGroups, serverGroupID, vjailbreakSettings, useFlavorless, espDiskIndex interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVM", reflect.TypeOf((*MockOpenstackOperations)(nil).CreateVM), ctx, flavor, networkIDs, portIDs, vminfo, availabilityZone, securityGroups, serverGroupID, vjailbreakSettings, useFlavorless)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVM", reflect.TypeOf((*MockOpenstackOperations)(nil).CreateVM), ctx, flavor, networkIDs, portIDs, vminfo, availabilityZone, securityGroups, serverGroupID, vjailbreakSettings, useFlavorless, espDiskIndex)
 }
 
 // CreateVolume mocks base method.
@@ -349,20 +363,6 @@ func (m *MockOpenstackOperations) SetVolumeImageMetadata(ctx context.Context, vo
 func (mr *MockOpenstackOperationsMockRecorder) SetVolumeImageMetadata(ctx, volume, setRDMLabel interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVolumeImageMetadata", reflect.TypeOf((*MockOpenstackOperations)(nil).SetVolumeImageMetadata), ctx, volume, setRDMLabel)
-}
-
-// ApplyBootVolumeImageMetadata mocks base method.
-func (m *MockOpenstackOperations) ApplyBootVolumeImageMetadata(ctx context.Context, volume *volumes.Volume, metadata map[string]string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplyBootVolumeImageMetadata", ctx, volume, metadata)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ApplyBootVolumeImageMetadata indicates an expected call of ApplyBootVolumeImageMetadata.
-func (mr *MockOpenstackOperationsMockRecorder) ApplyBootVolumeImageMetadata(ctx, volume, metadata interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyBootVolumeImageMetadata", reflect.TypeOf((*MockOpenstackOperations)(nil).ApplyBootVolumeImageMetadata), ctx, volume, metadata)
 }
 
 // SetVolumeUEFI mocks base method.

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -186,9 +186,18 @@ func (osclient *OpenStackClients) CreateVolume(ctx context.Context, name string,
 	// Add 1GB to the size to account for the extra space
 	opts.Size += 1
 
-	volume, err := volumes.Create(ctx, blockStorageClient, opts, nil).Extract()
+	var volume *volumes.Volume
+	var err error
+	for i := 0; i < constants.DeleteOperationRetryCount; i++ {
+		volume, err = volumes.Create(ctx, blockStorageClient, opts, nil).Extract()
+		if err == nil {
+			break
+		}
+		PrintLog(fmt.Sprintf("Transient error creating volume %s (attempt %d/%d): %s", name, i+1, constants.DeleteOperationRetryCount, err))
+		time.Sleep(constants.DeleteOperationRetryIntervalSeconds * time.Second)
+	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to create volume: %s", err)
+		return nil, fmt.Errorf("failed to create volume after %d attempts: %s", constants.DeleteOperationRetryCount, err)
 	}
 
 	err = osclient.WaitForVolume(ctx, volume.ID)
@@ -400,11 +409,16 @@ func (osclient *OpenStackClients) EnableQGA(ctx context.Context, volume *volumes
 			"hw_pointer_model":    "usbtablet",
 		},
 	}
-	err := volumes.SetImageMetadata(ctx, osclient.BlockStorageClient, volume.ID, options).ExtractErr()
-	if err != nil {
-		return fmt.Errorf("failed to detach volume from VM: %s", err)
+	var err error
+	for i := 0; i < constants.DeleteOperationRetryCount; i++ {
+		err = volumes.SetImageMetadata(ctx, osclient.BlockStorageClient, volume.ID, options).ExtractErr()
+		if err == nil {
+			return nil
+		}
+		PrintLog(fmt.Sprintf("Transient error setting QGA metadata for volume %s (attempt %d/%d): %s", volume.ID, i+1, constants.DeleteOperationRetryCount, err))
+		time.Sleep(constants.DeleteOperationRetryIntervalSeconds * time.Second)
 	}
-	return nil
+	return fmt.Errorf("failed to set QGA metadata for volume %s after %d attempts: %s", volume.ID, constants.DeleteOperationRetryCount, err)
 }
 
 func (osclient *OpenStackClients) SetVolumeUEFI(ctx context.Context, volume *volumes.Volume) error {
@@ -414,11 +428,16 @@ func (osclient *OpenStackClients) SetVolumeUEFI(ctx context.Context, volume *vol
 			"hw_firmware_type": "uefi",
 		},
 	}
-	err := volumes.SetImageMetadata(ctx, osclient.BlockStorageClient, volume.ID, options).ExtractErr()
-	if err != nil {
-		return fmt.Errorf("failed to set volume image metadata hw_firmware_type to uefi: %s", err)
+	var err error
+	for i := 0; i < constants.DeleteOperationRetryCount; i++ {
+		err = volumes.SetImageMetadata(ctx, osclient.BlockStorageClient, volume.ID, options).ExtractErr()
+		if err == nil {
+			return nil
+		}
+		PrintLog(fmt.Sprintf("Transient error setting UEFI metadata for volume %s (attempt %d/%d): %s", volume.ID, i+1, constants.DeleteOperationRetryCount, err))
+		time.Sleep(constants.DeleteOperationRetryIntervalSeconds * time.Second)
 	}
-	return nil
+	return fmt.Errorf("failed to set UEFI metadata for volume %s after %d attempts: %s", volume.ID, constants.DeleteOperationRetryCount, err)
 }
 
 func (osclient *OpenStackClients) SetVolumeImageMetadata(ctx context.Context, volume *volumes.Volume, setRDMLabel bool) error {
@@ -431,11 +450,16 @@ func (osclient *OpenStackClients) SetVolumeImageMetadata(ctx context.Context, vo
 	if setRDMLabel {
 		options.Metadata["hw_scsi_model"] = "virtio-scsi"
 	}
-	err := volumes.SetImageMetadata(ctx, osclient.BlockStorageClient, volume.ID, options).ExtractErr()
-	if err != nil {
-		return fmt.Errorf("failed to set volume image metadata for windows: %s", err)
+	var err error
+	for i := 0; i < constants.DeleteOperationRetryCount; i++ {
+		err = volumes.SetImageMetadata(ctx, osclient.BlockStorageClient, volume.ID, options).ExtractErr()
+		if err == nil {
+			return nil
+		}
+		PrintLog(fmt.Sprintf("Transient error setting image metadata for volume %s (attempt %d/%d): %s", volume.ID, i+1, constants.DeleteOperationRetryCount, err))
+		time.Sleep(constants.DeleteOperationRetryIntervalSeconds * time.Second)
 	}
-	return nil
+	return fmt.Errorf("failed to set image metadata for volume %s after %d attempts: %s", volume.ID, constants.DeleteOperationRetryCount, err)
 }
 
 // ApplyBootVolumeImageMetadata merges profile-supplied properties onto the boot volume's existing
@@ -446,10 +470,16 @@ func (osclient *OpenStackClients) ApplyBootVolumeImageMetadata(ctx context.Conte
 	}
 	PrintLog(fmt.Sprintf("OPENSTACK API: Merging %d profile image metadata key(s) onto boot volume %s", len(metadata), volume.ID))
 	options := volumes.ImageMetadataOpts{Metadata: metadata}
-	if err := volumes.SetImageMetadata(ctx, osclient.BlockStorageClient, volume.ID, options).ExtractErr(); err != nil {
-		return fmt.Errorf("failed to apply profile image metadata to boot volume: %s", err)
+	var err error
+	for i := 0; i < constants.DeleteOperationRetryCount; i++ {
+		err = volumes.SetImageMetadata(ctx, osclient.BlockStorageClient, volume.ID, options).ExtractErr()
+		if err == nil {
+			return nil
+		}
+		PrintLog(fmt.Sprintf("Transient error applying profile metadata to boot volume %s (attempt %d/%d): %s", volume.ID, i+1, constants.DeleteOperationRetryCount, err))
+		time.Sleep(constants.DeleteOperationRetryIntervalSeconds * time.Second)
 	}
-	return nil
+	return fmt.Errorf("failed to apply profile metadata to boot volume %s after %d attempts: %s", volume.ID, constants.DeleteOperationRetryCount, err)
 }
 
 func (osclient *OpenStackClients) SetVolumeBootable(ctx context.Context, volume *volumes.Volume) error {
@@ -457,11 +487,16 @@ func (osclient *OpenStackClients) SetVolumeBootable(ctx context.Context, volume 
 	options := volumes.BootableOpts{
 		Bootable: true,
 	}
-	err := volumes.SetBootable(ctx, osclient.BlockStorageClient, volume.ID, options).ExtractErr()
-	if err != nil {
-		return fmt.Errorf("failed to set volume as bootable: %s", err)
+	var err error
+	for i := 0; i < constants.DeleteOperationRetryCount; i++ {
+		err = volumes.SetBootable(ctx, osclient.BlockStorageClient, volume.ID, options).ExtractErr()
+		if err == nil {
+			return nil
+		}
+		PrintLog(fmt.Sprintf("Transient error setting volume %s as bootable (attempt %d/%d): %s", volume.ID, i+1, constants.DeleteOperationRetryCount, err))
+		time.Sleep(constants.DeleteOperationRetryIntervalSeconds * time.Second)
 	}
-	return nil
+	return fmt.Errorf("failed to set volume %s as bootable after %d attempts: %s", volume.ID, constants.DeleteOperationRetryCount, err)
 }
 
 func (osclient *OpenStackClients) GetClosestFlavour(ctx context.Context, cpu int32, memory int32) (*flavors.Flavor, error) {
@@ -787,16 +822,27 @@ func (osclient *OpenStackClients) CreatePort(ctx context.Context, networkid *net
 }
 
 func (osclient *OpenStackClients) createPortLowLevel(ctx context.Context, createOpts ports.CreateOpts) (*ports.Port, error) {
-	// When no security groups are selected, disable port security
-	if createOpts.SecurityGroups == nil || len(*createOpts.SecurityGroups) == 0 {
-		disabled := false
-		extOpts := portsecurity.PortCreateOptsExt{
-			CreateOptsBuilder:   createOpts,
-			PortSecurityEnabled: &disabled,
+	var port *ports.Port
+	var err error
+	for i := 0; i < constants.DeleteOperationRetryCount; i++ {
+		// When no security groups are selected, disable port security
+		if createOpts.SecurityGroups == nil || len(*createOpts.SecurityGroups) == 0 {
+			disabled := false
+			extOpts := portsecurity.PortCreateOptsExt{
+				CreateOptsBuilder:   createOpts,
+				PortSecurityEnabled: &disabled,
+			}
+			port, err = ports.Create(ctx, osclient.NetworkingClient, extOpts).Extract()
+		} else {
+			port, err = ports.Create(ctx, osclient.NetworkingClient, createOpts).Extract()
 		}
-		return ports.Create(ctx, osclient.NetworkingClient, extOpts).Extract()
+		if err == nil {
+			return port, nil
+		}
+		PrintLog(fmt.Sprintf("Transient error creating port (attempt %d/%d): %s", i+1, constants.DeleteOperationRetryCount, err))
+		time.Sleep(constants.DeleteOperationRetryIntervalSeconds * time.Second)
 	}
-	return ports.Create(ctx, osclient.NetworkingClient, createOpts).Extract()
+	return nil, fmt.Errorf("failed to create port after %d attempts: %s", constants.DeleteOperationRetryCount, err)
 }
 
 func (osclient *OpenStackClients) CreateVM(ctx context.Context, flavor *flavors.Flavor, networkIDs, portIDs []string, vminfo vm.VMInfo, availabilityZone string, securityGroups []string, serverGroupID string, vjailbreakSettings k8sutils.VjailbreakSettings, useFlavorless bool, espDiskIndex int) (*servers.Server, error) {

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -225,11 +225,16 @@ func (osclient *OpenStackClients) CreateVolume(ctx context.Context, name string,
 
 func (osclient *OpenStackClients) DeleteVolume(ctx context.Context, volumeID string) error {
 	PrintLog(fmt.Sprintf("OPENSTACK API: Deleting volume with ID %s, authurl %s, tenant %s", volumeID, osclient.AuthURL, osclient.Tenant))
-	err := volumes.Delete(ctx, osclient.BlockStorageClient, volumeID, volumes.DeleteOpts{}).ExtractErr()
-	if err != nil {
-		return fmt.Errorf("failed to delete volume: %s", err)
+	var err error
+	for i := 0; i < constants.DeleteOperationRetryCount; i++ {
+		err = volumes.Delete(ctx, osclient.BlockStorageClient, volumeID, volumes.DeleteOpts{}).ExtractErr()
+		if err == nil {
+			return nil
+		}
+		PrintLog(fmt.Sprintf("Transient error deleting volume %s (attempt %d/%d): %s", volumeID, i+1, constants.DeleteOperationRetryCount, err))
+		time.Sleep(5 * time.Second)
 	}
-	return nil
+	return fmt.Errorf("failed to delete volume after %d attempts: %s", constants.DeleteOperationRetryCount, err)
 }
 
 func (osclient *OpenStackClients) WaitForVolume(ctx context.Context, volumeID string) error {
@@ -242,7 +247,9 @@ func (osclient *OpenStackClients) WaitForVolume(ctx context.Context, volumeID st
 	for i := 0; i < vjailbreakSettings.VolumeAvailableWaitRetryLimit; i++ {
 		volume, err := volumes.Get(ctx, osclient.BlockStorageClient, volumeID).Extract()
 		if err != nil {
-			return fmt.Errorf("failed to get volume: %s", err)
+			PrintLog(fmt.Sprintf("Transient error polling volume %s (attempt %d/%d): %s", volumeID, i+1, vjailbreakSettings.VolumeAvailableWaitRetryLimit, err))
+			time.Sleep(time.Duration(vjailbreakSettings.VolumeAvailableWaitIntervalSeconds) * time.Second)
+			continue
 		}
 		if volume.Status == "error" {
 			return fmt.Errorf("volume %s is in error state", volumeID)
@@ -255,7 +262,9 @@ func (osclient *OpenStackClients) WaitForVolume(ctx context.Context, volumeID st
 		// Check if the volume is available from nova side as well
 		server, err := servers.Get(ctx, osclient.ComputeClient, instanceID).Extract()
 		if err != nil {
-			return fmt.Errorf("failed to get server: %s", err)
+			PrintLog(fmt.Sprintf("Transient error polling server %s (attempt %d/%d): %s", instanceID, i+1, vjailbreakSettings.VolumeAvailableWaitRetryLimit, err))
+			time.Sleep(time.Duration(vjailbreakSettings.VolumeAvailableWaitIntervalSeconds) * time.Second)
+			continue
 		}
 
 		// get the attachments from the server
@@ -523,12 +532,17 @@ func (osclient *OpenStackClients) GetPort(ctx context.Context, portID string) (*
 
 func (osclient *OpenStackClients) DeletePort(ctx context.Context, portID string) error {
 	PrintLog(fmt.Sprintf("OPENSTACK API: Deleting port %s, authurl %s, tenant %s", portID, osclient.AuthURL, osclient.Tenant))
-	err := ports.Delete(ctx, osclient.NetworkingClient, portID).ExtractErr()
-	if err != nil {
-		return fmt.Errorf("failed to delete port %s: %s", portID, err)
+	var err error
+	for i := 0; i < constants.DeleteOperationRetryCount; i++ {
+		err = ports.Delete(ctx, osclient.NetworkingClient, portID).ExtractErr()
+		if err == nil {
+			PrintLog(fmt.Sprintf("Successfully deleted port %s", portID))
+			return nil
+		}
+		PrintLog(fmt.Sprintf("Transient error deleting port %s (attempt %d/%d): %s", portID, i+1, constants.DeleteOperationRetryCount, err))
+		time.Sleep(5 * time.Second)
 	}
-	PrintLog(fmt.Sprintf("Successfully deleted port %s", portID))
-	return nil
+	return fmt.Errorf("failed to delete port %s after %d attempts: %s", portID, constants.DeleteOperationRetryCount, err)
 }
 
 func (osclient *OpenStackClients) GetSubnet(ctx context.Context, subnetList []string, ip string) (*subnets.Subnet, error) {

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -232,7 +232,7 @@ func (osclient *OpenStackClients) DeleteVolume(ctx context.Context, volumeID str
 			return nil
 		}
 		PrintLog(fmt.Sprintf("Transient error deleting volume %s (attempt %d/%d): %s", volumeID, i+1, constants.DeleteOperationRetryCount, err))
-		time.Sleep(5 * time.Second)
+		time.Sleep(constants.DeleteOperationRetryIntervalSeconds * time.Second)
 	}
 	return fmt.Errorf("failed to delete volume after %d attempts: %s", constants.DeleteOperationRetryCount, err)
 }
@@ -540,7 +540,7 @@ func (osclient *OpenStackClients) DeletePort(ctx context.Context, portID string)
 			return nil
 		}
 		PrintLog(fmt.Sprintf("Transient error deleting port %s (attempt %d/%d): %s", portID, i+1, constants.DeleteOperationRetryCount, err))
-		time.Sleep(5 * time.Second)
+		time.Sleep(constants.DeleteOperationRetryIntervalSeconds * time.Second)
 	}
 	return fmt.Errorf("failed to delete port %s after %d attempts: %s", portID, constants.DeleteOperationRetryCount, err)
 }
@@ -954,9 +954,18 @@ func (osclient *OpenStackClients) CreateVM(ctx context.Context, flavor *flavors.
 		}
 	}
 
-	server, err := servers.Create(ctx, osclient.ComputeClient, serverCreateOpts, schedulerHints).Extract()
+	var server *servers.Server
+	var err error
+	for i := 0; i < constants.DeleteOperationRetryCount; i++ {
+		server, err = servers.Create(ctx, osclient.ComputeClient, serverCreateOpts, schedulerHints).Extract()
+		if err == nil {
+			break
+		}
+		PrintLog(fmt.Sprintf("Transient error creating server %s (attempt %d/%d): %s", vminfo.Name, i+1, constants.DeleteOperationRetryCount, err))
+		time.Sleep(constants.DeleteOperationRetryIntervalSeconds * time.Second)
+	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to create server: %s", err)
+		return nil, fmt.Errorf("failed to create server after %d attempts: %s", constants.DeleteOperationRetryCount, err)
 	}
 
 	// Wait for server to become active


### PR DESCRIPTION
## What this PR does / why we need it

Three classes of bugs addressed:

1. Missing cleanup after failure: ports created by ReservePortsForVM were orphaned when subsequent steps failed (CreateVolumes, StorageAcceleratedCopy path: InitializeStorageProvider, ValidatePrerequisites, CopyDisks, applyImageMetadata). Each failure path now calls cleanup() with portids and vcenterSettings so ports are deleted when CleanupPortsAfterMigrationFailure is enabled.

2. Transient API errors not retried in WaitForVolume: volumes.Get and servers.Get errors returned immediately, aborting the polling loop. The reported failure was a context deadline exceeded on servers.Get that exited all retries. Both calls now log and continue to the next iteration.

3. Nil OpenstackVol panic in cleanup: when CreateVolumes failed mid-loop, later disks had nil OpenstackVol. DetachAllVolumes and DeleteAllVolumes now skip nil entries so cleanup does not panic on partial volume creation.

Also: DeletePort and DeleteVolume now retry up to DeleteOperationRetryCount (5) times so transient errors during cleanup do not leave resources orphaned. Constant defined in pkg/common/constants alongside existing retry constants.


## Which issue(s) this PR fixes

fixes #1803 
fixes #1926

## Testing done
<img width="1440" height="806" alt="image" src="https://github.com/user-attachments/assets/418e35a5-db26-4ee9-832c-6021bf10dcad" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/1958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->