### PR TITLE
[1990] Fix boot device index parse failure due to mixed guestfish stderr/stdout

### DIFF
--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -732,11 +732,17 @@ func RunCommandInGuestAllVolumes(disks []vm.VMDisk, command string, write bool, 
 	os.Setenv("LIBGUESTFS_BACKEND", "direct")
 	cmd := prepareGuestfishCommand(disks, command, write, args...)
 	log.Printf("Executing %s", cmd.String())
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("failed to run command (%s): %v: %s", command, err, strings.TrimSpace(string(out)))
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	err := cmd.Run()
+	if stderrBuf.Len() > 0 {
+		log.Printf("guestfish stderr (%s): %s", command, strings.TrimSpace(stderrBuf.String()))
 	}
-	return strings.ToLower(string(out)), nil
+	if err != nil {
+		return "", fmt.Errorf("failed to run command (%s): %v: %s", command, err, strings.TrimSpace(stderrBuf.String()))
+	}
+	return strings.ToLower(stdoutBuf.String()), nil
 }
 
 // GetDeviceNumberFromPartition returns the device index for a given partition name


### PR DESCRIPTION
## Problem

`RunCommandInGuestAllVolumes` used `cmd.CombinedOutput()`, which merges stderr and stdout into a single byte buffer. When guestfish launches with `-i` (auto-inspect), it attempts to mount all filesystems. For VMs with LVM volumes or complex partition layouts (e.g. LVM-backed `/var`, bind-mounted `/var/log`, `/var/tmp`), some mounts fail. libguestfs writes these to **stderr**; guestfish still exits 0 and writes the actual command result to **stdout**.

With `CombinedOutput()`, the returned string looks like:

```
libguestfs: error: mount_ro: mount exited with status 32: ...
guestfish: some filesystems could not be mounted (ignored)
0
```

`strconv.Atoi(strings.TrimSpace(...))` fails with `invalid syntax` — the error lines precede the actual value `0`. Migrations abort during disk conversion even though the underlying data is valid.

Same `device-index` call made from three locations — all fixed by this single root change:
- `migrate.go` (confirmed failure site from pod logs)
- `virtv2v/virtv2vops.go` — `GetDeviceNumberFromPartition`
- `virtv2v/esp_detection.go` — `GetESPDiskIndex`

## Fix

Separate `cmd.Stdout` and `cmd.Stderr` into explicit `bytes.Buffer` captures in `RunCommandInGuestAllVolumes`:
- **stdout only** returned to callers — clean, parseable
- **stderr** forwarded to pod logs via `log.Printf` — observability preserved
- On failure, error message still includes full stderr for debugging

Mirrors the pattern already used correctly in `GetBootablePartition` (`virtv2vops.go:1128–1130`).

## Test Plan

- [ ] Migrate VM with LVM volumes — previously failed at boot device index step, should now succeed
- [ ] Confirm libguestfs stderr mount warnings appear in v2v-helper pod logs
- [ ] Migrate VM with simple partition layout — verify no regression

Closes #1990
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/1993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->