### PR TITLE
Rename Firstboot-Scheduler.ps1 to 0-Firstboot-Scheduler.ps1

### DIFF
--- a/scripts/firstboot/store/Firstboot-Scheduler.ps1
+++ b/scripts/firstboot/store/Firstboot-Scheduler.ps1
@@ -8,7 +8,7 @@ $ScriptRoot = "C:\firstboot"
 $LogFile = Join-Path $ScriptRoot "Firstboot-Scheduler.log"
 $TaskName = "FirstbootSchedulerPostReboot"
 $StateFilePath = Join-Path $ScriptRoot "Firstboot-Scheduler.state"
-$SchedulerScriptPath = Join-Path $ScriptRoot "Firstboot-Scheduler.ps1"
+$SchedulerScriptPath = Join-Path $ScriptRoot "0-Firstboot-Scheduler.ps1"
 $failedScriptNames = New-Object 'System.Collections.Generic.List[string]'
 function Write-Log {
     param([string]$Message, [string]$Level = "INFO")


### PR DESCRIPTION
Wrong filename which concludes that task scheduler on windows can't find the script on won't run the firstboot scheduler after a reboot. Fixing bug of issue #1992

## What this PR does / why we need it
Firstboot scheduler doesn't run after reboot because the scheduled task is created with the wrong filename 

## Which issue(s) this PR fixes
fixes #1992 

## Special notes for your reviewer


## Testing done
Testing done manually just by renaming the file in scheduled task action

<img width="1012" height="629" alt="image" src="https://github.com/user-attachments/assets/21598b36-529f-422f-b6f5-9a1b46cc9766" />
<img width="694" height="550" alt="image" src="https://github.com/user-attachments/assets/20f247f4-7a37-456b-8d82-9e9ed4ba006d" />
<img width="1292" height="840" alt="image" src="https://github.com/user-attachments/assets/4808882d-085b-4122-a8c9-11f1e9318bd6" />
<img width="1301" height="844" alt="image" src="https://github.com/user-attachments/assets/f39c9e12-b236-433f-b051-b8b35b5a245e" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/1994" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->