### PR TITLE
[2004] Fix SLED OS detection and broaden SSH key format support

### DIFF
--- a/ui/src/features/proxyvms/components/AddProxyVMDrawer.tsx
+++ b/ui/src/features/proxyvms/components/AddProxyVMDrawer.tsx
@@ -45,10 +45,10 @@ function toK8sName(input: string): string {
 const validateSshPrivateKey = (value: string): string | null => {
   const trimmed = value.trim()
   if (!trimmed) return 'SSH private key is required'
-  const hasBegin = /-----BEGIN OPENSSH PRIVATE KEY-----/.test(trimmed)
-  const hasEnd = /-----END OPENSSH PRIVATE KEY-----/.test(trimmed)
+  const hasBegin = /-----BEGIN [A-Z ]*PRIVATE KEY-----/.test(trimmed)
+  const hasEnd = /-----END [A-Z ]*PRIVATE KEY-----/.test(trimmed)
   if (!hasBegin || !hasEnd) {
-    return 'Invalid key format. Expected OpenSSH private key (-----BEGIN OPENSSH PRIVATE KEY-----)'
+    return 'Invalid key format. Expected a PEM private key (e.g. -----BEGIN OPENSSH PRIVATE KEY----- or -----BEGIN RSA PRIVATE KEY-----)'
   }
   return null
 }

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1158,7 +1158,7 @@ func (migobj *Migrate) validateLinuxOS(osRelease string) error {
 		"redhat", "red hat", "rhel", "centos", "scientific linux",
 		"oracle linux", "fedora", "sles", "sled", "opensuse",
 		"alt linux", "debian", "ubuntu", "rocky linux",
-		"suse linux enterprise server", "alma linux",
+		"suse linux enterprise server", "suse linux enterprise desktop", "alma linux",
 	}
 
 	for _, s := range supportedOS {


### PR DESCRIPTION
## What this PR does
- Add `"suse linux enterprise desktop"` to the supported OS list — SLED 11 was failing the compatibility check despite SUSE migration being fully supported
- Relax SSH private key validation in `AddProxyVMDrawer` to accept RSA, EC, PKCS#8 and DSA keys in addition to OpenSSH format

fixes: #2004

## Testing done

SLED 11 guest passing OS detection and proceeding through migration:

```
OS detected by guestfish: suse linux enterprise desktop 11 (x86_64)
operating system compatibility check passed
SUSE guest detected: using --replace-fstab (skipping fix_grub_config)
Running generate-mount-persistence.sh with --replace-fstab option
Successfully uploaded generate-mount-persistence.sh to guest
```