### PR TITLE
Fixed the missing --binding-profile '{"l2-port": true}' on ports created for VMs migrated onto L2-only networks in PCD

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,286 +1,264 @@
-# Graph Report - vjailbreak  (2026-06-09)
+# Graph Report - vjailbreak  (2026-06-11)
 
 ## Corpus Check
-- 733 files · ~1,732,143 words
+- 419 files · ~616,240 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5709 nodes · 9401 edges · 749 communities (286 shown, 463 thin omitted)
-- Extraction: 90% EXTRACTED · 10% INFERRED · 0% AMBIGUOUS · INFERRED: 943 edges (avg confidence: 0.8)
+- 5195 nodes · 13962 edges · 259 communities detected
+- Extraction: 48% EXTRACTED · 52% INFERRED · 0% AMBIGUOUS · INFERRED: 7205 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
-## Graph Freshness
-- Built from commit: `590cb543`
-- Run `git rev-parse HEAD` and compare to check if the graph is stale.
-- Run `graphify update .` after code changes (no API cost).
-
 ## Community Hubs (Navigation)
-- [[_COMMUNITY_vpwned Upgrade & Version|vpwned Upgrade & Version]]
-- [[_COMMUNITY_ESXi Migration Reconciler|ESXi Migration Reconciler]]
-- [[_COMMUNITY_MigrationPlan API Types|MigrationPlan API Types]]
-- [[_COMMUNITY_K8s Utilities (Creds, Keys)|K8s Utilities (Creds, Keys)]]
-- [[_COMMUNITY_Keystone Auth (PCD)|Keystone Auth (PCD)]]
-- [[_COMMUNITY_ArrayCreds Controller|ArrayCreds Controller]]
-- [[_COMMUNITY_Migration Credential Utils|Migration Credential Utils]]
-- [[_COMMUNITY_Migration Reconciler|Migration Reconciler]]
-- [[_COMMUNITY_virt-v2v OS Detection|virt-v2v OS Detection]]
-- [[_COMMUNITY_OpenStack Client|OpenStack Client]]
-- [[_COMMUNITY_v2v-helper Disk Migration|v2v-helper Disk Migration]]
-- [[_COMMUNITY_Config Samples & Templates|Config Samples & Templates]]
-- [[_COMMUNITY_PCD Auth & Keystone SDK|PCD Auth & Keystone SDK]]
-- [[_COMMUNITY_OpenStack Cinder Operations|OpenStack Cinder Operations]]
-- [[_COMMUNITY_vpwned Protobuf API|vpwned Protobuf API]]
-- [[_COMMUNITY_vpwned vCenter gRPC Target|vpwned vCenter gRPC Target]]
-- [[_COMMUNITY_BM Mock Provider|BM Mock Provider]]
-- [[_COMMUNITY_Rolling Migration Utils|Rolling Migration Utils]]
-- [[_COMMUNITY_vpwned Machine Info Protobuf|vpwned Machine Info Protobuf]]
-- [[_COMMUNITY_RBAC Roles & CRD Docs|RBAC Roles & CRD Docs]]
-- [[_COMMUNITY_ArrayCreds API Types|ArrayCreds API Types]]
-- [[_COMMUNITY_BMConfig CLI & Controller|BMConfig CLI & Controller]]
-- [[_COMMUNITY_ResMgr SDK (PCD)|ResMgr SDK (PCD)]]
-- [[_COMMUNITY_Monitoring Stack (Alertmanager)|Monitoring Stack (Alertmanager)]]
-- [[_COMMUNITY_VMwareMachine API Types|VMwareMachine API Types]]
-- [[_COMMUNITY_ESXi SSH Client|ESXi SSH Client]]
-- [[_COMMUNITY_OpenStack Mock Operations|OpenStack Mock Operations]]
-- [[_COMMUNITY_OpenstackCreds API Types|OpenstackCreds API Types]]
-- [[_COMMUNITY_OpenStack Mock Recorder|OpenStack Mock Recorder]]
-- [[_COMMUNITY_vpwned gRPC Gateway|vpwned gRPC Gateway]]
-- [[_COMMUNITY_virt-v2v Mock Operations|virt-v2v Mock Operations]]
-- [[_COMMUNITY_Monitoring Stack (Grafana)|Monitoring Stack (Grafana)]]
-- [[_COMMUNITY_vpwned Update Response Protobuf|vpwned Update Response Protobuf]]
-- [[_COMMUNITY_vpwned gRPC Server (Storage)|vpwned gRPC Server (Storage)]]
-- [[_COMMUNITY_Rolling Migration Plan Utils|Rolling Migration Plan Utils]]
-- [[_COMMUNITY_RollingMigrationPlan Reconciler|RollingMigrationPlan Reconciler]]
-- [[_COMMUNITY_NetApp Storage Provider|NetApp Storage Provider]]
-- [[_COMMUNITY_RollingMigrationPlan API Types|RollingMigrationPlan API Types]]
-- [[_COMMUNITY_NBD Disk Copy Protocol|NBD Disk Copy Protocol]]
-- [[_COMMUNITY_vpwned SDK Targets|vpwned SDK Targets]]
-- [[_COMMUNITY_Component 40|Component 40]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Component 42|Component 42]]
-- [[_COMMUNITY_RBAC Manifests|RBAC Manifests]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_Mock  Test Double|Mock / Test Double]]
-- [[_COMMUNITY_Utilities|Utilities]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_Mock  Test Double|Mock / Test Double]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Component 58|Component 58]]
-- [[_COMMUNITY_Utilities|Utilities]]
-- [[_COMMUNITY_Component 60|Component 60]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_Migration Worker|Migration Worker]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Component 72|Component 72]]
-- [[_COMMUNITY_Component 73|Component 73]]
-- [[_COMMUNITY_Component 74|Component 74]]
-- [[_COMMUNITY_RBAC Manifests|RBAC Manifests]]
-- [[_COMMUNITY_OpenStack Component|OpenStack Component]]
-- [[_COMMUNITY_VMware Component|VMware Component]]
-- [[_COMMUNITY_Component 78|Component 78]]
-- [[_COMMUNITY_VMware Component|VMware Component]]
-- [[_COMMUNITY_Component 80|Component 80]]
-- [[_COMMUNITY_Component 81|Component 81]]
-- [[_COMMUNITY_VMware Component|VMware Component]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Component 89|Component 89]]
-- [[_COMMUNITY_Component 90|Component 90]]
-- [[_COMMUNITY_Utilities|Utilities]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Keystone Auth|Keystone Auth]]
-- [[_COMMUNITY_Test Utilities|Test Utilities]]
-- [[_COMMUNITY_Test Utilities|Test Utilities]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Config & Samples|Config & Samples]]
-- [[_COMMUNITY_OpenStack Component|OpenStack Component]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_VMware Component|VMware Component]]
-- [[_COMMUNITY_Utilities|Utilities]]
-- [[_COMMUNITY_Component 110|Component 110]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_OpenStack Component|OpenStack Component]]
-- [[_COMMUNITY_Test Utilities|Test Utilities]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Test Utilities|Test Utilities]]
-- [[_COMMUNITY_Test Utilities|Test Utilities]]
-- [[_COMMUNITY_Utilities|Utilities]]
-- [[_COMMUNITY_Component 122|Component 122]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_VMware Component|VMware Component]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_PCD Integration|PCD Integration]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_RBAC Manifests|RBAC Manifests]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_VMware Component|VMware Component]]
-- [[_COMMUNITY_Component 135|Component 135]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_RBAC Manifests|RBAC Manifests]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Server Component|Server Component]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_OpenStack Component|OpenStack Component]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_OpenStack Component|OpenStack Component]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_OpenStack Component|OpenStack Component]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Test Utilities|Test Utilities]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Test Utilities|Test Utilities]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Server Component|Server Component]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_VMware Component|VMware Component]]
-- [[_COMMUNITY_Utilities|Utilities]]
-- [[_COMMUNITY_Component 209|Component 209]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_RBAC Manifests|RBAC Manifests]]
-- [[_COMMUNITY_Test Utilities|Test Utilities]]
-- [[_COMMUNITY_Component 213|Component 213]]
-- [[_COMMUNITY_Keystone Auth|Keystone Auth]]
-- [[_COMMUNITY_Keystone Auth|Keystone Auth]]
-- [[_COMMUNITY_Keystone Auth|Keystone Auth]]
-- [[_COMMUNITY_Config & Samples|Config & Samples]]
-- [[_COMMUNITY_Component 218|Component 218]]
-- [[_COMMUNITY_Protobuf Service|Protobuf Service]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Component 221|Component 221]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Component 223|Component 223]]
-- [[_COMMUNITY_Config & Samples|Config & Samples]]
-- [[_COMMUNITY_VMware Component|VMware Component]]
-- [[_COMMUNITY_Config & Samples|Config & Samples]]
-- [[_COMMUNITY_Component 227|Component 227]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Component 229|Component 229]]
-- [[_COMMUNITY_Component 230|Component 230]]
-- [[_COMMUNITY_VMware Component|VMware Component]]
-- [[_COMMUNITY_Utilities|Utilities]]
-- [[_COMMUNITY_Component 233|Component 233]]
-- [[_COMMUNITY_VMware Component|VMware Component]]
-- [[_COMMUNITY_RBAC Manifests|RBAC Manifests]]
-- [[_COMMUNITY_Config & Samples|Config & Samples]]
-- [[_COMMUNITY_Test Utilities|Test Utilities]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Component 239|Component 239]]
-- [[_COMMUNITY_Component 240|Component 240]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_PCD Integration|PCD Integration]]
-- [[_COMMUNITY_Component 243|Component 243]]
-- [[_COMMUNITY_Test Utilities|Test Utilities]]
-- [[_COMMUNITY_Component 245|Component 245]]
-- [[_COMMUNITY_Utilities|Utilities]]
-- [[_COMMUNITY_Component 247|Component 247]]
-- [[_COMMUNITY_Component 248|Component 248]]
-- [[_COMMUNITY_Component 249|Component 249]]
-- [[_COMMUNITY_Component 250|Component 250]]
-- [[_COMMUNITY_Component 251|Component 251]]
-- [[_COMMUNITY_Utilities|Utilities]]
-- [[_COMMUNITY_Component 253|Component 253]]
-- [[_COMMUNITY_Component 254|Component 254]]
-- [[_COMMUNITY_Component 255|Component 255]]
-- [[_COMMUNITY_Component 256|Component 256]]
-- [[_COMMUNITY_Component 257|Component 257]]
-- [[_COMMUNITY_Config & Samples|Config & Samples]]
-- [[_COMMUNITY_Test Utilities|Test Utilities]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_Controller Component|Controller Component]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_CRD API Types|CRD API Types]]
-- [[_COMMUNITY_Component 271|Component 271]]
-- [[_COMMUNITY_Component 272|Component 272]]
-- [[_COMMUNITY_Component 273|Component 273]]
-- [[_COMMUNITY_Component 274|Component 274]]
-- [[_COMMUNITY_Component 275|Component 275]]
-- [[_COMMUNITY_Component 276|Component 276]]
-- [[_COMMUNITY_Component 277|Component 277]]
-- [[_COMMUNITY_Component 278|Component 278]]
-- [[_COMMUNITY_Component 279|Component 279]]
-- [[_COMMUNITY_Component 280|Component 280]]
-- [[_COMMUNITY_Component 281|Component 281]]
-- [[_COMMUNITY_VMware Component|VMware Component]]
-- [[_COMMUNITY_Component 283|Component 283]]
-- [[_COMMUNITY_Community 284|Community 284]]
-- [[_COMMUNITY_Community 285|Community 285]]
-- [[_COMMUNITY_Community 286|Community 286]]
-- [[_COMMUNITY_Community 287|Community 287]]
-- [[_COMMUNITY_Community 288|Community 288]]
-- [[_COMMUNITY_Community 289|Community 289]]
-- [[_COMMUNITY_Community 290|Community 290]]
-- [[_COMMUNITY_Community 291|Community 291]]
-- [[_COMMUNITY_Community 292|Community 292]]
+- [[_COMMUNITY_Community 0|Community 0]]
+- [[_COMMUNITY_Community 1|Community 1]]
+- [[_COMMUNITY_Community 2|Community 2]]
+- [[_COMMUNITY_Community 3|Community 3]]
+- [[_COMMUNITY_Community 4|Community 4]]
+- [[_COMMUNITY_Community 5|Community 5]]
+- [[_COMMUNITY_Community 6|Community 6]]
+- [[_COMMUNITY_Community 7|Community 7]]
+- [[_COMMUNITY_Community 8|Community 8]]
+- [[_COMMUNITY_Community 9|Community 9]]
+- [[_COMMUNITY_Community 10|Community 10]]
+- [[_COMMUNITY_Community 11|Community 11]]
+- [[_COMMUNITY_Community 12|Community 12]]
+- [[_COMMUNITY_Community 13|Community 13]]
+- [[_COMMUNITY_Community 14|Community 14]]
+- [[_COMMUNITY_Community 15|Community 15]]
+- [[_COMMUNITY_Community 16|Community 16]]
+- [[_COMMUNITY_Community 17|Community 17]]
+- [[_COMMUNITY_Community 18|Community 18]]
+- [[_COMMUNITY_Community 19|Community 19]]
+- [[_COMMUNITY_Community 20|Community 20]]
+- [[_COMMUNITY_Community 21|Community 21]]
+- [[_COMMUNITY_Community 22|Community 22]]
+- [[_COMMUNITY_Community 23|Community 23]]
+- [[_COMMUNITY_Community 24|Community 24]]
+- [[_COMMUNITY_Community 25|Community 25]]
+- [[_COMMUNITY_Community 26|Community 26]]
+- [[_COMMUNITY_Community 27|Community 27]]
+- [[_COMMUNITY_Community 28|Community 28]]
+- [[_COMMUNITY_Community 29|Community 29]]
+- [[_COMMUNITY_Community 30|Community 30]]
+- [[_COMMUNITY_Community 31|Community 31]]
+- [[_COMMUNITY_Community 32|Community 32]]
+- [[_COMMUNITY_Community 33|Community 33]]
+- [[_COMMUNITY_Community 34|Community 34]]
+- [[_COMMUNITY_Community 35|Community 35]]
+- [[_COMMUNITY_Community 36|Community 36]]
+- [[_COMMUNITY_Community 37|Community 37]]
+- [[_COMMUNITY_Community 38|Community 38]]
+- [[_COMMUNITY_Community 39|Community 39]]
+- [[_COMMUNITY_Community 40|Community 40]]
+- [[_COMMUNITY_Community 41|Community 41]]
+- [[_COMMUNITY_Community 42|Community 42]]
+- [[_COMMUNITY_Community 43|Community 43]]
+- [[_COMMUNITY_Community 44|Community 44]]
+- [[_COMMUNITY_Community 45|Community 45]]
+- [[_COMMUNITY_Community 46|Community 46]]
+- [[_COMMUNITY_Community 47|Community 47]]
+- [[_COMMUNITY_Community 48|Community 48]]
+- [[_COMMUNITY_Community 49|Community 49]]
+- [[_COMMUNITY_Community 50|Community 50]]
+- [[_COMMUNITY_Community 51|Community 51]]
+- [[_COMMUNITY_Community 52|Community 52]]
+- [[_COMMUNITY_Community 53|Community 53]]
+- [[_COMMUNITY_Community 54|Community 54]]
+- [[_COMMUNITY_Community 55|Community 55]]
+- [[_COMMUNITY_Community 56|Community 56]]
+- [[_COMMUNITY_Community 57|Community 57]]
+- [[_COMMUNITY_Community 58|Community 58]]
+- [[_COMMUNITY_Community 59|Community 59]]
+- [[_COMMUNITY_Community 60|Community 60]]
+- [[_COMMUNITY_Community 61|Community 61]]
+- [[_COMMUNITY_Community 62|Community 62]]
+- [[_COMMUNITY_Community 63|Community 63]]
+- [[_COMMUNITY_Community 64|Community 64]]
+- [[_COMMUNITY_Community 65|Community 65]]
+- [[_COMMUNITY_Community 66|Community 66]]
+- [[_COMMUNITY_Community 67|Community 67]]
+- [[_COMMUNITY_Community 68|Community 68]]
+- [[_COMMUNITY_Community 69|Community 69]]
+- [[_COMMUNITY_Community 70|Community 70]]
+- [[_COMMUNITY_Community 71|Community 71]]
+- [[_COMMUNITY_Community 72|Community 72]]
+- [[_COMMUNITY_Community 73|Community 73]]
+- [[_COMMUNITY_Community 74|Community 74]]
+- [[_COMMUNITY_Community 75|Community 75]]
+- [[_COMMUNITY_Community 76|Community 76]]
+- [[_COMMUNITY_Community 77|Community 77]]
+- [[_COMMUNITY_Community 78|Community 78]]
+- [[_COMMUNITY_Community 79|Community 79]]
+- [[_COMMUNITY_Community 80|Community 80]]
+- [[_COMMUNITY_Community 81|Community 81]]
+- [[_COMMUNITY_Community 82|Community 82]]
+- [[_COMMUNITY_Community 83|Community 83]]
+- [[_COMMUNITY_Community 84|Community 84]]
+- [[_COMMUNITY_Community 85|Community 85]]
+- [[_COMMUNITY_Community 86|Community 86]]
+- [[_COMMUNITY_Community 87|Community 87]]
+- [[_COMMUNITY_Community 88|Community 88]]
+- [[_COMMUNITY_Community 89|Community 89]]
+- [[_COMMUNITY_Community 90|Community 90]]
+- [[_COMMUNITY_Community 91|Community 91]]
+- [[_COMMUNITY_Community 92|Community 92]]
+- [[_COMMUNITY_Community 93|Community 93]]
+- [[_COMMUNITY_Community 94|Community 94]]
+- [[_COMMUNITY_Community 95|Community 95]]
+- [[_COMMUNITY_Community 96|Community 96]]
+- [[_COMMUNITY_Community 97|Community 97]]
+- [[_COMMUNITY_Community 98|Community 98]]
+- [[_COMMUNITY_Community 99|Community 99]]
+- [[_COMMUNITY_Community 100|Community 100]]
+- [[_COMMUNITY_Community 101|Community 101]]
+- [[_COMMUNITY_Community 102|Community 102]]
+- [[_COMMUNITY_Community 103|Community 103]]
+- [[_COMMUNITY_Community 104|Community 104]]
+- [[_COMMUNITY_Community 105|Community 105]]
+- [[_COMMUNITY_Community 106|Community 106]]
+- [[_COMMUNITY_Community 107|Community 107]]
+- [[_COMMUNITY_Community 108|Community 108]]
+- [[_COMMUNITY_Community 109|Community 109]]
+- [[_COMMUNITY_Community 110|Community 110]]
+- [[_COMMUNITY_Community 111|Community 111]]
+- [[_COMMUNITY_Community 112|Community 112]]
+- [[_COMMUNITY_Community 113|Community 113]]
+- [[_COMMUNITY_Community 114|Community 114]]
+- [[_COMMUNITY_Community 115|Community 115]]
+- [[_COMMUNITY_Community 116|Community 116]]
+- [[_COMMUNITY_Community 117|Community 117]]
+- [[_COMMUNITY_Community 118|Community 118]]
+- [[_COMMUNITY_Community 119|Community 119]]
+- [[_COMMUNITY_Community 120|Community 120]]
+- [[_COMMUNITY_Community 121|Community 121]]
+- [[_COMMUNITY_Community 122|Community 122]]
+- [[_COMMUNITY_Community 123|Community 123]]
+- [[_COMMUNITY_Community 124|Community 124]]
+- [[_COMMUNITY_Community 125|Community 125]]
+- [[_COMMUNITY_Community 126|Community 126]]
+- [[_COMMUNITY_Community 128|Community 128]]
+- [[_COMMUNITY_Community 129|Community 129]]
+- [[_COMMUNITY_Community 130|Community 130]]
+- [[_COMMUNITY_Community 131|Community 131]]
+- [[_COMMUNITY_Community 132|Community 132]]
+- [[_COMMUNITY_Community 133|Community 133]]
+- [[_COMMUNITY_Community 134|Community 134]]
+- [[_COMMUNITY_Community 135|Community 135]]
+- [[_COMMUNITY_Community 137|Community 137]]
+- [[_COMMUNITY_Community 138|Community 138]]
+- [[_COMMUNITY_Community 139|Community 139]]
+- [[_COMMUNITY_Community 140|Community 140]]
+- [[_COMMUNITY_Community 141|Community 141]]
+- [[_COMMUNITY_Community 142|Community 142]]
+- [[_COMMUNITY_Community 143|Community 143]]
+- [[_COMMUNITY_Community 144|Community 144]]
+- [[_COMMUNITY_Community 145|Community 145]]
+- [[_COMMUNITY_Community 146|Community 146]]
+- [[_COMMUNITY_Community 149|Community 149]]
+- [[_COMMUNITY_Community 151|Community 151]]
+- [[_COMMUNITY_Community 155|Community 155]]
+- [[_COMMUNITY_Community 157|Community 157]]
+- [[_COMMUNITY_Community 158|Community 158]]
+- [[_COMMUNITY_Community 159|Community 159]]
+- [[_COMMUNITY_Community 160|Community 160]]
+- [[_COMMUNITY_Community 161|Community 161]]
+- [[_COMMUNITY_Community 162|Community 162]]
+- [[_COMMUNITY_Community 163|Community 163]]
+- [[_COMMUNITY_Community 164|Community 164]]
+- [[_COMMUNITY_Community 165|Community 165]]
+- [[_COMMUNITY_Community 166|Community 166]]
+- [[_COMMUNITY_Community 167|Community 167]]
+- [[_COMMUNITY_Community 168|Community 168]]
+- [[_COMMUNITY_Community 169|Community 169]]
+- [[_COMMUNITY_Community 170|Community 170]]
+- [[_COMMUNITY_Community 171|Community 171]]
+- [[_COMMUNITY_Community 172|Community 172]]
+- [[_COMMUNITY_Community 173|Community 173]]
+- [[_COMMUNITY_Community 174|Community 174]]
+- [[_COMMUNITY_Community 175|Community 175]]
+- [[_COMMUNITY_Community 176|Community 176]]
+- [[_COMMUNITY_Community 177|Community 177]]
+- [[_COMMUNITY_Community 178|Community 178]]
+- [[_COMMUNITY_Community 179|Community 179]]
+- [[_COMMUNITY_Community 180|Community 180]]
+- [[_COMMUNITY_Community 181|Community 181]]
+- [[_COMMUNITY_Community 182|Community 182]]
+- [[_COMMUNITY_Community 183|Community 183]]
+- [[_COMMUNITY_Community 184|Community 184]]
+- [[_COMMUNITY_Community 185|Community 185]]
+- [[_COMMUNITY_Community 186|Community 186]]
+- [[_COMMUNITY_Community 187|Community 187]]
+- [[_COMMUNITY_Community 188|Community 188]]
+- [[_COMMUNITY_Community 189|Community 189]]
+- [[_COMMUNITY_Community 190|Community 190]]
+- [[_COMMUNITY_Community 191|Community 191]]
+- [[_COMMUNITY_Community 192|Community 192]]
+- [[_COMMUNITY_Community 193|Community 193]]
+- [[_COMMUNITY_Community 194|Community 194]]
+- [[_COMMUNITY_Community 195|Community 195]]
+- [[_COMMUNITY_Community 196|Community 196]]
+- [[_COMMUNITY_Community 197|Community 197]]
+- [[_COMMUNITY_Community 198|Community 198]]
+- [[_COMMUNITY_Community 199|Community 199]]
+- [[_COMMUNITY_Community 200|Community 200]]
+- [[_COMMUNITY_Community 201|Community 201]]
+- [[_COMMUNITY_Community 202|Community 202]]
+- [[_COMMUNITY_Community 203|Community 203]]
+- [[_COMMUNITY_Community 204|Community 204]]
+- [[_COMMUNITY_Community 205|Community 205]]
+- [[_COMMUNITY_Community 206|Community 206]]
+- [[_COMMUNITY_Community 207|Community 207]]
+- [[_COMMUNITY_Community 208|Community 208]]
+- [[_COMMUNITY_Community 209|Community 209]]
+- [[_COMMUNITY_Community 210|Community 210]]
+- [[_COMMUNITY_Community 211|Community 211]]
+- [[_COMMUNITY_Community 212|Community 212]]
+- [[_COMMUNITY_Community 213|Community 213]]
+- [[_COMMUNITY_Community 214|Community 214]]
+- [[_COMMUNITY_Community 215|Community 215]]
+- [[_COMMUNITY_Community 216|Community 216]]
+- [[_COMMUNITY_Community 217|Community 217]]
+- [[_COMMUNITY_Community 218|Community 218]]
+- [[_COMMUNITY_Community 219|Community 219]]
+- [[_COMMUNITY_Community 220|Community 220]]
+- [[_COMMUNITY_Community 221|Community 221]]
+- [[_COMMUNITY_Community 222|Community 222]]
+- [[_COMMUNITY_Community 223|Community 223]]
+- [[_COMMUNITY_Community 224|Community 224]]
+- [[_COMMUNITY_Community 225|Community 225]]
+- [[_COMMUNITY_Community 226|Community 226]]
+- [[_COMMUNITY_Community 227|Community 227]]
+- [[_COMMUNITY_Community 228|Community 228]]
+- [[_COMMUNITY_Community 230|Community 230]]
+- [[_COMMUNITY_Community 231|Community 231]]
+- [[_COMMUNITY_Community 232|Community 232]]
+- [[_COMMUNITY_Community 233|Community 233]]
+- [[_COMMUNITY_Community 234|Community 234]]
+- [[_COMMUNITY_Community 235|Community 235]]
+- [[_COMMUNITY_Community 236|Community 236]]
+- [[_COMMUNITY_Community 237|Community 237]]
+- [[_COMMUNITY_Community 238|Community 238]]
+- [[_COMMUNITY_Community 239|Community 239]]
+- [[_COMMUNITY_Community 240|Community 240]]
+- [[_COMMUNITY_Community 241|Community 241]]
+- [[_COMMUNITY_Community 242|Community 242]]
+- [[_COMMUNITY_Community 243|Community 243]]
+- [[_COMMUNITY_Community 244|Community 244]]
+- [[_COMMUNITY_Community 245|Community 245]]
+- [[_COMMUNITY_Community 246|Community 246]]
+- [[_COMMUNITY_Community 247|Community 247]]
+- [[_COMMUNITY_Community 248|Community 248]]
+- [[_COMMUNITY_Community 249|Community 249]]
+- [[_COMMUNITY_Community 250|Community 250]]
+- [[_COMMUNITY_Community 251|Community 251]]
+- [[_COMMUNITY_Community 252|Community 252]]
+- [[_COMMUNITY_Community 253|Community 253]]
+- [[_COMMUNITY_Community 254|Community 254]]
+- [[_COMMUNITY_Community 255|Community 255]]
+- [[_COMMUNITY_Community 256|Community 256]]
+- [[_COMMUNITY_Community 257|Community 257]]
+- [[_COMMUNITY_Community 258|Community 258]]
 - [[_COMMUNITY_Community 293|Community 293]]
 - [[_COMMUNITY_Community 294|Community 294]]
 - [[_COMMUNITY_Community 295|Community 295]]
@@ -291,459 +269,22 @@
 - [[_COMMUNITY_Community 300|Community 300]]
 - [[_COMMUNITY_Community 301|Community 301]]
 - [[_COMMUNITY_Community 302|Community 302]]
-- [[_COMMUNITY_Community 303|Community 303]]
-- [[_COMMUNITY_Community 304|Community 304]]
-- [[_COMMUNITY_Community 305|Community 305]]
-- [[_COMMUNITY_Community 306|Community 306]]
-- [[_COMMUNITY_Community 307|Community 307]]
-- [[_COMMUNITY_Community 308|Community 308]]
-- [[_COMMUNITY_Community 309|Community 309]]
-- [[_COMMUNITY_Community 310|Community 310]]
-- [[_COMMUNITY_Community 311|Community 311]]
-- [[_COMMUNITY_Community 312|Community 312]]
-- [[_COMMUNITY_Community 313|Community 313]]
-- [[_COMMUNITY_Community 314|Community 314]]
-- [[_COMMUNITY_Community 315|Community 315]]
-- [[_COMMUNITY_Community 316|Community 316]]
-- [[_COMMUNITY_Community 317|Community 317]]
-- [[_COMMUNITY_Community 318|Community 318]]
-- [[_COMMUNITY_Community 319|Community 319]]
-- [[_COMMUNITY_Community 320|Community 320]]
-- [[_COMMUNITY_Community 321|Community 321]]
-- [[_COMMUNITY_Community 322|Community 322]]
-- [[_COMMUNITY_Community 323|Community 323]]
-- [[_COMMUNITY_Community 324|Community 324]]
-- [[_COMMUNITY_Community 325|Community 325]]
-- [[_COMMUNITY_Community 326|Community 326]]
-- [[_COMMUNITY_Community 327|Community 327]]
-- [[_COMMUNITY_Community 328|Community 328]]
-- [[_COMMUNITY_Community 329|Community 329]]
-- [[_COMMUNITY_Community 330|Community 330]]
-- [[_COMMUNITY_Community 331|Community 331]]
-- [[_COMMUNITY_Community 332|Community 332]]
-- [[_COMMUNITY_Community 333|Community 333]]
-- [[_COMMUNITY_Community 334|Community 334]]
-- [[_COMMUNITY_Community 335|Community 335]]
-- [[_COMMUNITY_Community 336|Community 336]]
-- [[_COMMUNITY_Community 337|Community 337]]
-- [[_COMMUNITY_Community 338|Community 338]]
-- [[_COMMUNITY_Community 339|Community 339]]
-- [[_COMMUNITY_Community 340|Community 340]]
-- [[_COMMUNITY_Community 341|Community 341]]
-- [[_COMMUNITY_Community 342|Community 342]]
-- [[_COMMUNITY_Community 343|Community 343]]
-- [[_COMMUNITY_Community 344|Community 344]]
-- [[_COMMUNITY_Community 345|Community 345]]
-- [[_COMMUNITY_Community 346|Community 346]]
-- [[_COMMUNITY_Community 347|Community 347]]
-- [[_COMMUNITY_Community 348|Community 348]]
-- [[_COMMUNITY_Community 349|Community 349]]
-- [[_COMMUNITY_Community 350|Community 350]]
-- [[_COMMUNITY_Community 351|Community 351]]
-- [[_COMMUNITY_Community 352|Community 352]]
-- [[_COMMUNITY_Community 353|Community 353]]
-- [[_COMMUNITY_Community 354|Community 354]]
-- [[_COMMUNITY_Community 355|Community 355]]
-- [[_COMMUNITY_Community 356|Community 356]]
-- [[_COMMUNITY_Community 357|Community 357]]
-- [[_COMMUNITY_Community 358|Community 358]]
-- [[_COMMUNITY_Community 359|Community 359]]
-- [[_COMMUNITY_Community 360|Community 360]]
-- [[_COMMUNITY_Community 361|Community 361]]
-- [[_COMMUNITY_Community 362|Community 362]]
-- [[_COMMUNITY_Community 363|Community 363]]
-- [[_COMMUNITY_Community 364|Community 364]]
-- [[_COMMUNITY_Community 365|Community 365]]
-- [[_COMMUNITY_Community 366|Community 366]]
-- [[_COMMUNITY_Community 367|Community 367]]
-- [[_COMMUNITY_Community 368|Community 368]]
-- [[_COMMUNITY_Community 369|Community 369]]
-- [[_COMMUNITY_Community 370|Community 370]]
-- [[_COMMUNITY_Community 371|Community 371]]
-- [[_COMMUNITY_Community 372|Community 372]]
-- [[_COMMUNITY_Community 373|Community 373]]
-- [[_COMMUNITY_Community 374|Community 374]]
-- [[_COMMUNITY_Community 375|Community 375]]
-- [[_COMMUNITY_Community 376|Community 376]]
-- [[_COMMUNITY_Community 377|Community 377]]
-- [[_COMMUNITY_Community 378|Community 378]]
-- [[_COMMUNITY_Community 379|Community 379]]
-- [[_COMMUNITY_Community 380|Community 380]]
-- [[_COMMUNITY_Community 381|Community 381]]
-- [[_COMMUNITY_Community 382|Community 382]]
-- [[_COMMUNITY_Community 383|Community 383]]
-- [[_COMMUNITY_Community 384|Community 384]]
-- [[_COMMUNITY_Community 385|Community 385]]
-- [[_COMMUNITY_Community 386|Community 386]]
-- [[_COMMUNITY_Community 387|Community 387]]
-- [[_COMMUNITY_Community 388|Community 388]]
-- [[_COMMUNITY_Community 389|Community 389]]
-- [[_COMMUNITY_Community 390|Community 390]]
-- [[_COMMUNITY_Community 391|Community 391]]
-- [[_COMMUNITY_Community 392|Community 392]]
-- [[_COMMUNITY_Community 393|Community 393]]
-- [[_COMMUNITY_Community 394|Community 394]]
-- [[_COMMUNITY_Community 395|Community 395]]
-- [[_COMMUNITY_Community 396|Community 396]]
-- [[_COMMUNITY_Community 397|Community 397]]
-- [[_COMMUNITY_Community 398|Community 398]]
-- [[_COMMUNITY_Community 399|Community 399]]
-- [[_COMMUNITY_Community 400|Community 400]]
-- [[_COMMUNITY_Community 401|Community 401]]
-- [[_COMMUNITY_Community 402|Community 402]]
-- [[_COMMUNITY_Community 403|Community 403]]
-- [[_COMMUNITY_Community 404|Community 404]]
-- [[_COMMUNITY_Community 405|Community 405]]
-- [[_COMMUNITY_Community 406|Community 406]]
-- [[_COMMUNITY_Community 407|Community 407]]
-- [[_COMMUNITY_Community 408|Community 408]]
-- [[_COMMUNITY_Community 409|Community 409]]
-- [[_COMMUNITY_Community 410|Community 410]]
-- [[_COMMUNITY_Community 411|Community 411]]
-- [[_COMMUNITY_Community 412|Community 412]]
-- [[_COMMUNITY_Community 413|Community 413]]
-- [[_COMMUNITY_Community 414|Community 414]]
-- [[_COMMUNITY_Community 415|Community 415]]
-- [[_COMMUNITY_Community 416|Community 416]]
-- [[_COMMUNITY_Community 417|Community 417]]
-- [[_COMMUNITY_Community 418|Community 418]]
-- [[_COMMUNITY_Community 419|Community 419]]
-- [[_COMMUNITY_Community 420|Community 420]]
-- [[_COMMUNITY_Community 421|Community 421]]
-- [[_COMMUNITY_Community 422|Community 422]]
-- [[_COMMUNITY_Community 423|Community 423]]
-- [[_COMMUNITY_Community 424|Community 424]]
-- [[_COMMUNITY_Community 425|Community 425]]
-- [[_COMMUNITY_Community 426|Community 426]]
-- [[_COMMUNITY_Community 427|Community 427]]
-- [[_COMMUNITY_Community 428|Community 428]]
-- [[_COMMUNITY_Community 429|Community 429]]
-- [[_COMMUNITY_Community 430|Community 430]]
-- [[_COMMUNITY_Community 431|Community 431]]
-- [[_COMMUNITY_Community 432|Community 432]]
-- [[_COMMUNITY_Community 433|Community 433]]
-- [[_COMMUNITY_Community 434|Community 434]]
-- [[_COMMUNITY_Community 435|Community 435]]
-- [[_COMMUNITY_Community 436|Community 436]]
-- [[_COMMUNITY_Community 437|Community 437]]
-- [[_COMMUNITY_Community 438|Community 438]]
-- [[_COMMUNITY_Community 439|Community 439]]
-- [[_COMMUNITY_Community 440|Community 440]]
-- [[_COMMUNITY_Community 441|Community 441]]
-- [[_COMMUNITY_Community 442|Community 442]]
-- [[_COMMUNITY_Community 443|Community 443]]
-- [[_COMMUNITY_Community 444|Community 444]]
-- [[_COMMUNITY_Community 445|Community 445]]
-- [[_COMMUNITY_Community 446|Community 446]]
-- [[_COMMUNITY_Community 447|Community 447]]
-- [[_COMMUNITY_Community 448|Community 448]]
-- [[_COMMUNITY_Community 449|Community 449]]
-- [[_COMMUNITY_Community 450|Community 450]]
-- [[_COMMUNITY_Community 451|Community 451]]
-- [[_COMMUNITY_Community 452|Community 452]]
-- [[_COMMUNITY_Community 453|Community 453]]
-- [[_COMMUNITY_Community 454|Community 454]]
-- [[_COMMUNITY_Community 455|Community 455]]
-- [[_COMMUNITY_Community 456|Community 456]]
-- [[_COMMUNITY_Community 457|Community 457]]
-- [[_COMMUNITY_Community 458|Community 458]]
-- [[_COMMUNITY_Community 459|Community 459]]
-- [[_COMMUNITY_Community 460|Community 460]]
-- [[_COMMUNITY_Community 461|Community 461]]
-- [[_COMMUNITY_Community 462|Community 462]]
-- [[_COMMUNITY_Community 463|Community 463]]
-- [[_COMMUNITY_Community 464|Community 464]]
-- [[_COMMUNITY_Community 465|Community 465]]
-- [[_COMMUNITY_Community 466|Community 466]]
-- [[_COMMUNITY_Community 467|Community 467]]
-- [[_COMMUNITY_Community 468|Community 468]]
-- [[_COMMUNITY_Community 469|Community 469]]
-- [[_COMMUNITY_Community 470|Community 470]]
-- [[_COMMUNITY_Community 471|Community 471]]
-- [[_COMMUNITY_Community 472|Community 472]]
-- [[_COMMUNITY_Community 473|Community 473]]
-- [[_COMMUNITY_Community 474|Community 474]]
-- [[_COMMUNITY_Community 475|Community 475]]
-- [[_COMMUNITY_Community 476|Community 476]]
-- [[_COMMUNITY_Community 477|Community 477]]
-- [[_COMMUNITY_Community 478|Community 478]]
-- [[_COMMUNITY_Community 479|Community 479]]
-- [[_COMMUNITY_Community 480|Community 480]]
-- [[_COMMUNITY_Community 481|Community 481]]
-- [[_COMMUNITY_Community 482|Community 482]]
-- [[_COMMUNITY_Community 483|Community 483]]
-- [[_COMMUNITY_Community 484|Community 484]]
-- [[_COMMUNITY_Community 485|Community 485]]
-- [[_COMMUNITY_Community 486|Community 486]]
-- [[_COMMUNITY_Community 487|Community 487]]
-- [[_COMMUNITY_Community 488|Community 488]]
-- [[_COMMUNITY_Community 489|Community 489]]
-- [[_COMMUNITY_Community 490|Community 490]]
-- [[_COMMUNITY_Community 491|Community 491]]
-- [[_COMMUNITY_Community 492|Community 492]]
-- [[_COMMUNITY_Community 493|Community 493]]
-- [[_COMMUNITY_Community 494|Community 494]]
-- [[_COMMUNITY_Community 495|Community 495]]
-- [[_COMMUNITY_Community 496|Community 496]]
-- [[_COMMUNITY_Community 497|Community 497]]
-- [[_COMMUNITY_Community 498|Community 498]]
-- [[_COMMUNITY_Community 499|Community 499]]
-- [[_COMMUNITY_Community 500|Community 500]]
-- [[_COMMUNITY_Community 501|Community 501]]
-- [[_COMMUNITY_Community 502|Community 502]]
-- [[_COMMUNITY_Community 503|Community 503]]
-- [[_COMMUNITY_Community 504|Community 504]]
-- [[_COMMUNITY_Community 505|Community 505]]
-- [[_COMMUNITY_Community 506|Community 506]]
-- [[_COMMUNITY_Community 507|Community 507]]
-- [[_COMMUNITY_Community 508|Community 508]]
-- [[_COMMUNITY_Community 509|Community 509]]
-- [[_COMMUNITY_Community 510|Community 510]]
-- [[_COMMUNITY_Community 511|Community 511]]
-- [[_COMMUNITY_Community 512|Community 512]]
-- [[_COMMUNITY_Community 513|Community 513]]
-- [[_COMMUNITY_Community 514|Community 514]]
-- [[_COMMUNITY_Community 515|Community 515]]
-- [[_COMMUNITY_Community 516|Community 516]]
-- [[_COMMUNITY_Community 517|Community 517]]
-- [[_COMMUNITY_Community 518|Community 518]]
-- [[_COMMUNITY_Community 519|Community 519]]
-- [[_COMMUNITY_Community 520|Community 520]]
-- [[_COMMUNITY_Community 521|Community 521]]
-- [[_COMMUNITY_Community 522|Community 522]]
-- [[_COMMUNITY_Community 523|Community 523]]
-- [[_COMMUNITY_Community 524|Community 524]]
-- [[_COMMUNITY_Community 525|Community 525]]
-- [[_COMMUNITY_Community 526|Community 526]]
-- [[_COMMUNITY_Community 527|Community 527]]
-- [[_COMMUNITY_Community 528|Community 528]]
-- [[_COMMUNITY_Community 529|Community 529]]
-- [[_COMMUNITY_Community 530|Community 530]]
-- [[_COMMUNITY_Community 531|Community 531]]
-- [[_COMMUNITY_Community 532|Community 532]]
-- [[_COMMUNITY_Community 533|Community 533]]
-- [[_COMMUNITY_Community 534|Community 534]]
-- [[_COMMUNITY_Community 535|Community 535]]
-- [[_COMMUNITY_Community 536|Community 536]]
-- [[_COMMUNITY_Community 537|Community 537]]
-- [[_COMMUNITY_Community 538|Community 538]]
-- [[_COMMUNITY_Community 539|Community 539]]
-- [[_COMMUNITY_Community 540|Community 540]]
-- [[_COMMUNITY_Community 541|Community 541]]
-- [[_COMMUNITY_Community 542|Community 542]]
-- [[_COMMUNITY_Community 543|Community 543]]
-- [[_COMMUNITY_Community 544|Community 544]]
-- [[_COMMUNITY_Community 545|Community 545]]
-- [[_COMMUNITY_Community 546|Community 546]]
-- [[_COMMUNITY_Community 547|Community 547]]
-- [[_COMMUNITY_Community 548|Community 548]]
-- [[_COMMUNITY_Community 549|Community 549]]
-- [[_COMMUNITY_Community 550|Community 550]]
-- [[_COMMUNITY_Community 551|Community 551]]
-- [[_COMMUNITY_Community 552|Community 552]]
-- [[_COMMUNITY_Community 553|Community 553]]
-- [[_COMMUNITY_Community 554|Community 554]]
-- [[_COMMUNITY_Community 555|Community 555]]
-- [[_COMMUNITY_Community 556|Community 556]]
-- [[_COMMUNITY_Community 557|Community 557]]
-- [[_COMMUNITY_Community 558|Community 558]]
-- [[_COMMUNITY_Community 559|Community 559]]
-- [[_COMMUNITY_Community 560|Community 560]]
-- [[_COMMUNITY_Community 561|Community 561]]
-- [[_COMMUNITY_Community 562|Community 562]]
-- [[_COMMUNITY_Community 563|Community 563]]
-- [[_COMMUNITY_Community 564|Community 564]]
-- [[_COMMUNITY_Community 565|Community 565]]
-- [[_COMMUNITY_Community 566|Community 566]]
-- [[_COMMUNITY_Community 567|Community 567]]
-- [[_COMMUNITY_Community 568|Community 568]]
-- [[_COMMUNITY_Community 569|Community 569]]
-- [[_COMMUNITY_Community 570|Community 570]]
-- [[_COMMUNITY_Community 571|Community 571]]
-- [[_COMMUNITY_Community 572|Community 572]]
-- [[_COMMUNITY_Community 573|Community 573]]
-- [[_COMMUNITY_Community 574|Community 574]]
-- [[_COMMUNITY_Community 575|Community 575]]
-- [[_COMMUNITY_Community 576|Community 576]]
-- [[_COMMUNITY_Community 577|Community 577]]
-- [[_COMMUNITY_Community 578|Community 578]]
-- [[_COMMUNITY_Community 579|Community 579]]
-- [[_COMMUNITY_Community 580|Community 580]]
-- [[_COMMUNITY_Community 581|Community 581]]
-- [[_COMMUNITY_Community 582|Community 582]]
-- [[_COMMUNITY_Community 583|Community 583]]
-- [[_COMMUNITY_Community 584|Community 584]]
-- [[_COMMUNITY_Community 585|Community 585]]
-- [[_COMMUNITY_Community 586|Community 586]]
-- [[_COMMUNITY_Community 587|Community 587]]
-- [[_COMMUNITY_Community 588|Community 588]]
-- [[_COMMUNITY_Community 589|Community 589]]
-- [[_COMMUNITY_Community 590|Community 590]]
-- [[_COMMUNITY_Community 591|Community 591]]
-- [[_COMMUNITY_Community 592|Community 592]]
-- [[_COMMUNITY_Community 593|Community 593]]
-- [[_COMMUNITY_Community 594|Community 594]]
-- [[_COMMUNITY_Community 595|Community 595]]
-- [[_COMMUNITY_Community 596|Community 596]]
-- [[_COMMUNITY_Community 597|Community 597]]
-- [[_COMMUNITY_Community 598|Community 598]]
-- [[_COMMUNITY_Community 599|Community 599]]
-- [[_COMMUNITY_Community 600|Community 600]]
-- [[_COMMUNITY_Community 601|Community 601]]
-- [[_COMMUNITY_Community 602|Community 602]]
-- [[_COMMUNITY_Community 603|Community 603]]
-- [[_COMMUNITY_Community 604|Community 604]]
-- [[_COMMUNITY_Community 605|Community 605]]
-- [[_COMMUNITY_Community 606|Community 606]]
-- [[_COMMUNITY_Community 607|Community 607]]
-- [[_COMMUNITY_Community 608|Community 608]]
-- [[_COMMUNITY_Community 609|Community 609]]
-- [[_COMMUNITY_Community 610|Community 610]]
-- [[_COMMUNITY_Community 611|Community 611]]
-- [[_COMMUNITY_Community 612|Community 612]]
-- [[_COMMUNITY_Community 613|Community 613]]
-- [[_COMMUNITY_Community 614|Community 614]]
-- [[_COMMUNITY_Community 615|Community 615]]
-- [[_COMMUNITY_Community 616|Community 616]]
-- [[_COMMUNITY_Community 617|Community 617]]
-- [[_COMMUNITY_Community 618|Community 618]]
-- [[_COMMUNITY_Community 619|Community 619]]
-- [[_COMMUNITY_Community 620|Community 620]]
-- [[_COMMUNITY_Community 621|Community 621]]
-- [[_COMMUNITY_Community 622|Community 622]]
-- [[_COMMUNITY_Community 623|Community 623]]
-- [[_COMMUNITY_Community 624|Community 624]]
-- [[_COMMUNITY_Community 625|Community 625]]
-- [[_COMMUNITY_Community 626|Community 626]]
-- [[_COMMUNITY_Community 627|Community 627]]
-- [[_COMMUNITY_Community 628|Community 628]]
-- [[_COMMUNITY_Community 629|Community 629]]
-- [[_COMMUNITY_Community 630|Community 630]]
-- [[_COMMUNITY_Community 631|Community 631]]
-- [[_COMMUNITY_Community 632|Community 632]]
-- [[_COMMUNITY_Community 633|Community 633]]
-- [[_COMMUNITY_Community 634|Community 634]]
-- [[_COMMUNITY_Community 635|Community 635]]
-- [[_COMMUNITY_Community 636|Community 636]]
-- [[_COMMUNITY_Community 637|Community 637]]
-- [[_COMMUNITY_Community 638|Community 638]]
-- [[_COMMUNITY_Community 639|Community 639]]
-- [[_COMMUNITY_Community 640|Community 640]]
-- [[_COMMUNITY_Community 641|Community 641]]
-- [[_COMMUNITY_Community 642|Community 642]]
-- [[_COMMUNITY_Community 643|Community 643]]
-- [[_COMMUNITY_Community 644|Community 644]]
-- [[_COMMUNITY_Community 645|Community 645]]
-- [[_COMMUNITY_Community 646|Community 646]]
-- [[_COMMUNITY_Community 647|Community 647]]
-- [[_COMMUNITY_Community 648|Community 648]]
-- [[_COMMUNITY_Community 649|Community 649]]
-- [[_COMMUNITY_Community 650|Community 650]]
-- [[_COMMUNITY_Community 651|Community 651]]
-- [[_COMMUNITY_Community 652|Community 652]]
-- [[_COMMUNITY_Community 653|Community 653]]
-- [[_COMMUNITY_Community 654|Community 654]]
-- [[_COMMUNITY_Community 655|Community 655]]
-- [[_COMMUNITY_Community 656|Community 656]]
-- [[_COMMUNITY_Community 657|Community 657]]
-- [[_COMMUNITY_Community 658|Community 658]]
-- [[_COMMUNITY_Community 659|Community 659]]
-- [[_COMMUNITY_Community 660|Community 660]]
-- [[_COMMUNITY_Community 661|Community 661]]
-- [[_COMMUNITY_Community 662|Community 662]]
-- [[_COMMUNITY_Community 663|Community 663]]
-- [[_COMMUNITY_Community 664|Community 664]]
-- [[_COMMUNITY_Community 665|Community 665]]
-- [[_COMMUNITY_Community 666|Community 666]]
-- [[_COMMUNITY_Community 667|Community 667]]
-- [[_COMMUNITY_Community 668|Community 668]]
-- [[_COMMUNITY_Community 669|Community 669]]
-- [[_COMMUNITY_Community 670|Community 670]]
-- [[_COMMUNITY_Community 671|Community 671]]
-- [[_COMMUNITY_Community 672|Community 672]]
-- [[_COMMUNITY_Community 673|Community 673]]
-- [[_COMMUNITY_Community 674|Community 674]]
-- [[_COMMUNITY_Community 675|Community 675]]
-- [[_COMMUNITY_Community 676|Community 676]]
-- [[_COMMUNITY_Community 677|Community 677]]
-- [[_COMMUNITY_Community 678|Community 678]]
-- [[_COMMUNITY_Community 679|Community 679]]
-- [[_COMMUNITY_Community 680|Community 680]]
-- [[_COMMUNITY_Community 681|Community 681]]
-- [[_COMMUNITY_Community 682|Community 682]]
-- [[_COMMUNITY_Community 683|Community 683]]
-- [[_COMMUNITY_Community 684|Community 684]]
-- [[_COMMUNITY_Community 685|Community 685]]
-- [[_COMMUNITY_Community 686|Community 686]]
-- [[_COMMUNITY_Community 687|Community 687]]
-- [[_COMMUNITY_Community 688|Community 688]]
-- [[_COMMUNITY_Community 689|Community 689]]
-- [[_COMMUNITY_Community 690|Community 690]]
-- [[_COMMUNITY_Community 691|Community 691]]
-- [[_COMMUNITY_Community 692|Community 692]]
-- [[_COMMUNITY_Community 693|Community 693]]
-- [[_COMMUNITY_Community 694|Community 694]]
-- [[_COMMUNITY_Community 695|Community 695]]
-- [[_COMMUNITY_Community 696|Community 696]]
-- [[_COMMUNITY_Community 697|Community 697]]
-- [[_COMMUNITY_Community 698|Community 698]]
-- [[_COMMUNITY_Community 699|Community 699]]
-- [[_COMMUNITY_Community 700|Community 700]]
-- [[_COMMUNITY_Community 701|Community 701]]
-- [[_COMMUNITY_Community 702|Community 702]]
-- [[_COMMUNITY_Community 703|Community 703]]
-- [[_COMMUNITY_Community 704|Community 704]]
-- [[_COMMUNITY_Community 705|Community 705]]
-- [[_COMMUNITY_Community 706|Community 706]]
-- [[_COMMUNITY_Community 707|Community 707]]
-- [[_COMMUNITY_Community 708|Community 708]]
-- [[_COMMUNITY_Community 709|Community 709]]
-- [[_COMMUNITY_Community 710|Community 710]]
-- [[_COMMUNITY_Community 711|Community 711]]
-- [[_COMMUNITY_Community 712|Community 712]]
-- [[_COMMUNITY_Community 713|Community 713]]
-- [[_COMMUNITY_Community 714|Community 714]]
-- [[_COMMUNITY_Community 715|Community 715]]
-- [[_COMMUNITY_Community 716|Community 716]]
-- [[_COMMUNITY_Community 717|Community 717]]
-- [[_COMMUNITY_Community 718|Community 718]]
-- [[_COMMUNITY_Community 719|Community 719]]
-- [[_COMMUNITY_Community 720|Community 720]]
-- [[_COMMUNITY_Community 721|Community 721]]
-- [[_COMMUNITY_Community 722|Community 722]]
-- [[_COMMUNITY_Community 723|Community 723]]
-- [[_COMMUNITY_Community 724|Community 724]]
-- [[_COMMUNITY_Community 725|Community 725]]
-- [[_COMMUNITY_Community 726|Community 726]]
-- [[_COMMUNITY_Community 727|Community 727]]
-- [[_COMMUNITY_Community 728|Community 728]]
-- [[_COMMUNITY_Community 729|Community 729]]
-- [[_COMMUNITY_Community 732|Community 732]]
-- [[_COMMUNITY_Community 733|Community 733]]
-- [[_COMMUNITY_Community 734|Community 734]]
-- [[_COMMUNITY_Community 735|Community 735]]
-- [[_COMMUNITY_Community 736|Community 736]]
-- [[_COMMUNITY_Community 737|Community 737]]
-- [[_COMMUNITY_Community 738|Community 738]]
-- [[_COMMUNITY_Community 739|Community 739]]
-- [[_COMMUNITY_Community 740|Community 740]]
-- [[_COMMUNITY_Community 741|Community 741]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `Contains()` - 115 edges
-2. `Context` - 78 edges
-3. `PrintLog()` - 71 edges
-4. `Marshaler` - 58 edges
-5. `Request` - 58 edges
-6. `Message` - 58 edges
-7. `ServerMetadata` - 58 edges
-8. `Migrate` - 55 edges
-9. `Migrate` - 54 edges
-10. `Context` - 49 edges
+1. `New()` - 220 edges
+2. `Info` - 150 edges
+3. `PopulateQueryParameters()` - 146 edges
+4. `readAll()` - 141 edges
+5. `Run()` - 135 edges
+6. `contains()` - 127 edges
+7. `Registry` - 95 edges
+8. `NewRegistry()` - 91 edges
+9. `main()` - 87 edges
+10. `applyTemplate()` - 75 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `initCfg()` --calls--> `Info`  [INFERRED]
-  pkg/vpwned/cli/serve.go → k8s/migration/pkg/sdk/pcd/types.go
+- `vJailbreak README` --references--> `Migration Form Step 2 Screenshot`  [EXTRACTED]
+  README.md → assets/migrationform2.png
 - `vJailbreak README` --references--> `Migration Progress List Screenshot`  [EXTRACTED]
   README.md → assets/migrationprogress1.png
 - `vJailbreak README` --references--> `Migration Progress Detail Tooltip Screenshot`  [EXTRACTED]
@@ -764,1027 +305,1304 @@
 - **RBAC Roles Governing Migration Resources** — vmwarecreds_viewer_role, storagemapping_viewer_role, migrationplan_editor_role, migrationtemplate_editor_role, vmwaremachine_editor_role, vmwarehost_editor_role, rdmdisk_viewer_role [EXTRACTED 1.00]
 - **ESXi SSH Authentication via Credentials and Secret** — esxisshcreds_sample, esxi_ssh_key_secret, vmwarecreds_pnapbmc1 [INFERRED 0.85]
 
-## Communities (749 total, 463 thin omitted)
+## Communities
 
-### Community 0 - "vpwned Upgrade & Version"
-Cohesion: 0.09
-Nodes (46): runUpgradeJob(), Client, Clientset, Config, Context, Duration, Interface, Mutex (+38 more)
+### Community 0 - "Community 0"
+Cohesion: 0.01
+Nodes (474): newABitOfEverythingServer(), local_request_ABitOfEverythingService_CheckExternalNestedPathEnum_0(), local_request_ABitOfEverythingService_CheckExternalPathEnum_0(), local_request_ABitOfEverythingService_CheckGetQueryParams_0(), local_request_ABitOfEverythingService_CheckNestedEnumGetQueryParams_0(), local_request_ABitOfEverythingService_CheckPostQueryParams_0(), local_request_ABitOfEverythingService_CheckStatus_0(), local_request_ABitOfEverythingService_CreateBody_0() (+466 more)
 
-### Community 1 - "ESXi Migration Reconciler"
-Cohesion: 0.06
-Nodes (53): computeSourceVMKey(), createVCenterClientAndDC(), extractVCenterCredentials(), getDatastoresForVolumeMapping(), GetVMwareMachineForVM(), MergeLabels(), resolveVirtioDriverURL(), TestGetDatastoresForVolumeMapping_FallsBackToLegacyDatastores() (+45 more)
+### Community 1 - "Community 1"
+Cohesion: 0.01
+Nodes (335): buildProviderOptionsFromSpec(), getDatastoreInfo(), validateNetAppTargetSelection(), NewArrayCredsScope(), appendScriptToRunCmd(), ConvertESXiToPCDHost(), generatePCDOnboardingCloudInit(), GetBMConfig() (+327 more)
 
-### Community 2 - "MigrationPlan API Types"
-Cohesion: 0.08
-Nodes (48): VMDisk, Cmd, Context, GuestNetwork, IpEntry, VMDisk, DetectESPDiskIndex(), FirstBootWindows (+40 more)
+### Community 2 - "Community 2"
+Cohesion: 0.02
+Nodes (215): ABitOfEverythingApiService, ABitOfEverythingServiceEcho3Opts, APIClient, cacheControl, CamelCaseServiceNameApiService, EchoRpcApiService, GenericSwaggerError, service (+207 more)
 
-### Community 3 - "K8s Utilities (Creds, Keys)"
-Cohesion: 0.12
-Nodes (17): init(), OpenstackVolume, init(), ArrayInfo, BackendTarget, BackendTargetDiscoverer, BackendTargetGroup, CapacityInfo (+9 more)
+### Community 3 - "Community 3"
+Cohesion: 0.02
+Nodes (260): local_request_ABitOfEverythingService_Create_0(), request_ABitOfEverythingService_Create_0(), JSONCamelCase(), Bool(), Float32(), Int32(), Uint32(), TestCycle() (+252 more)
 
-### Community 4 - "Keystone Auth (PCD)"
-Cohesion: 0.07
-Nodes (45): ConditionStatus, getVMKeyFromMigration(), MigrationReconciler, Client, Context, EventList, Manager, Migration (+37 more)
+### Community 4 - "Community 4"
+Cohesion: 0.02
+Nodes (165): GetInclusterClient(), NewCloneTracker(), VjailbreakSettings, Duration(), Uint64(), UInt64Value(), DetectESPDiskIndex(), CloneStatus (+157 more)
 
-### Community 5 - "ArrayCreds Controller"
+### Community 5 - "Community 5"
+Cohesion: 0.01
+Nodes (220): local_request_ABitOfEverythingService_GetRepeatedQuery_0(), request_ABitOfEverythingService_GetRepeatedQuery_0(), contains(), convertDatastorePathToFilesystemPath(), NewClientWithTimeout(), parseEsxcliXMLOutput(), parseTaskResponse(), NewClusterMigrationScope() (+212 more)
+
+### Community 6 - "Community 6"
+Cohesion: 0.02
+Nodes (150): decodeBinHeader(), HTTPPathPattern(), HTTPPattern(), isMalformedHTTPHeader(), isPermanentHTTPHeader(), isValidGRPCMetadataKey(), isValidGRPCMetadataTextValue(), RPCMethod() (+142 more)
+
+### Community 7 - "Community 7"
+Cohesion: 0.02
+Nodes (97): TestCompile(), NetworkMappingReconciler, StorageMappingReconciler, ValidateAndGetProviderClient(), Compiler, deepWildcard, InvalidTemplateError, literal (+89 more)
+
+### Community 8 - "Community 8"
+Cohesion: 0.04
+Nodes (34): ContainsIgnoreCase(), detectSANProtocol(), init(), initiatorMatches(), isONTAPConflict(), isWWPNLike(), NetAppStorageProvider, normaliseToONTAPInitiators() (+26 more)
+
+### Community 9 - "Community 9"
+Cohesion: 0.04
+Nodes (41): Bytes(), BytesValue(), extensionsToMap(), allOfEntry, enumMap, extension, keyVal, messageMap (+33 more)
+
+### Community 10 - "Community 10"
 Cohesion: 0.05
-Nodes (39): 1.1 Document Purpose, 1.2 Product Scope, 1.3 Definitions, Acronyms and Abbreviations, 1.4 References, 1.5 Document Overview, 1. Introduction, 2.1 Product Perspective, 2.2 Product Functions (+31 more)
+Nodes (26): Camel(), CamelIdentifier(), isASCIIDigit(), isASCIILower(), TestCamelIdentifier(), Binding, Body, Field (+18 more)
 
-### Community 6 - "Migration Credential Utils"
-Cohesion: 0.13
-Nodes (18): CancelFunc, Migrate, extractFileName(), MigrationTimes, NBDOperations, NICOverride, OpenstackOperations, Reporter (+10 more)
-
-### Community 7 - "Migration Reconciler"
-Cohesion: 0.06
-Nodes (38): BMConfig Sample CR, BMConfig Sample CR (MAAS Provider), Go File Boilerplate (Apache 2.0 License Header), Cloud-Init Template for PCD Node Setup, ClusterMigration Sample CR, ClusterMigration Sample CR, ESXi Host Migration Sequence in ClusterMigration, ESXIMigration Sample CR (+30 more)
-
-### Community 8 - "virt-v2v OS Detection"
-Cohesion: 0.06
-Nodes (68): CachedAuthenticator, Host, AuthInfo, Client, Context, Credentials, Duration, ObjectMeta (+60 more)
-
-### Community 9 - "OpenStack Client"
-Cohesion: 0.16
-Nodes (7): DiskInfo, Client, StorageDeviceInfo, DatastoreInfo, Duration, Client, VMInfo
-
-### Community 10 - "v2v-helper Disk Migration"
-Cohesion: 0.08
-Nodes (37): vJailbreak Agents Guide, appliance/ Vagrant k3s Cluster, Business Source License 1.1, vJailbreak Contributing Guide, ArrayCreds CRD, BMConfig CRD, ClusterMigration CRD, ESXIMigration CRD (+29 more)
-
-### Community 11 - "Config Samples & Templates"
-Cohesion: 0.06
-Nodes (33): code:text (specs/002-agent-dns-config/), code:go (if vjNode.Annotations[reprovisionAnnotation] == reprovisionR), code:typescript (AGENT_HOST_ENTRIES: string  // JSON string, default ""), code:typescript (interface HostEntriesTabProps {), code:typescript (const isValidIP = (ip: string) => /^(\d{1,3}\.){3}\d{1,3}$|^), code:typescript (export const reprovisionNode = async (nodeName: string): Pro), code:bash (# Go (pkg/common module — pure function tests)), code:text (pkg/common/) (+25 more)
-
-### Community 12 - "PCD Auth & Keystone SDK"
-Cohesion: 0.10
-Nodes (32): createDummyPCDCluster(), fetchAndUpdateFlavors(), generateArrayCredsName(), handlePCDSync(), handleValidatedCreds(), populateVMwareMachineFlavors(), runPCDSyncAsync(), setupMasterNode() (+24 more)
-
-### Community 13 - "OpenStack Cinder Operations"
-Cohesion: 0.14
-Nodes (21): CreateOpts, ServerGroupInfo, Subnet, CinderVolumeService, OpenStackClients, GetCurrentInstanceUUID(), getInstanceUUIDFromNode(), PrintLog() (+13 more)
-
-### Community 14 - "vpwned Protobuf API"
-Cohesion: 0.09
-Nodes (35): BM Config Editor Role, Cluster Migration Viewer Role, Controller Manager Service Account, BMConfigs CRD, ClusterMigrations CRD, ESXiMigrations CRD, Migrations CRD, NetworkMappings CRD (+27 more)
-
-### Community 15 - "vpwned vCenter gRPC Target"
+### Community 11 - "Community 11"
 Cohesion: 0.05
-Nodes (48): AuthRequestAuthIdentity, AuthRequestAuthIdentityPassword, AuthRequestAuthIdentityPasswordUser, AuthRequestAuthScope, AuthRequestAuthScopeProject, AuthRequestAuthScopeProjectDomain, AuthResponseToken, AuthResponseTokenProject (+40 more)
+Nodes (29): config, BoolP(), Float32P(), Float64P(), Int32P(), Int64P(), StringP(), Uint32P() (+21 more)
 
-### Community 16 - "BM Mock Provider"
+### Community 12 - "Community 12"
 Cohesion: 0.05
-Nodes (42): BaseVirtualMachineBootOptionsBootableDevice, CordonHostRequest, CordonHostResponse, GetVMRequest, GetVMResponse, ListHostsRequest, ListVMsRequest, ListVMsResponse (+34 more)
+Nodes (20): NewBasicTokenGenerator(), NewCachedAuthenticator(), NewStaticTokenAuthenticator(), getKeystoneAuthenticator(), Authenticator, AuthOptions, BasicAuthenticator, CachedAuthenticator (+12 more)
 
-### Community 17 - "Rolling Migration Utils"
-Cohesion: 0.09
-Nodes (23): BMListMachinesRequest, BMListMachinesResponse, BMProvisionerAccessInfo, GetResourceInfoRequest, GetResourceInfoResponse, ListBootSourceResponse, BMAccessInfo, Context (+15 more)
-
-### Community 18 - "vpwned Machine Info Protobuf"
-Cohesion: 0.08
-Nodes (31): Alertmanager CRD (monitoring.coreos.com), alertmanager-main PodDisruptionBudget, Alertmanager Main Service, AlertmanagerConfig CRD (monitoring.coreos.com/v1alpha1), blackbox-exporter ServiceAccount, grafana-api-ingress Ingress, grafana-folders ConfigMap, Grafana ServiceMonitor (+23 more)
-
-### Community 19 - "RBAC Roles & CRD Docs"
-Cohesion: 0.12
-Nodes (26): GPUInfo, GuestNicInfo, HostStorageDeviceInfo, GuestNetwork, HostSystem, ManagedObjectReference, Mutex, NIC (+18 more)
-
-### Community 20 - "ArrayCreds API Types"
-Cohesion: 0.07
-Nodes (28): Acknowledgements, Agent Scaling, code:bash (# Install ORAS (see https://oras.land/docs/installation)), code:bash (# Upload the image to your OpenStack environment), code:bash (# Example /etc/hosts entry), code:bash (# After modifying resolv.conf), Community and Support, Contributing (+20 more)
-
-### Community 21 - "BMConfig CLI & Controller"
-Cohesion: 0.07
-Nodes (26): code:bash (# Step 1: write tests first (parallel — different files)), Dependencies & Execution Order, Format: `[ID] [P?] [Story] Description`, Implementation for User Story 1, Implementation for User Story 2, Implementation for User Story 3, Implementation Strategy, Incremental Delivery (+18 more)
-
-### Community 22 - "ResMgr SDK (PCD)"
-Cohesion: 0.08
-Nodes (27): Alertmanager (alertmanager-main), Alertmanager NetworkPolicy (alertmanager-main), Alertmanager ServiceAccount (alertmanager-main), Grafana Config Secret, Grafana Dashboard Definitions, Grafana Dashboard Sources ConfigMap, Grafana Dashboard Datasources Secret, Grafana Deployment (+19 more)
-
-### Community 23 - "Monitoring Stack (Alertmanager)"
-Cohesion: 0.17
-Nodes (35): Client, Context, Flavor, Migration, OpenstackCreds, RollingMigrationPlan, VjailbreakNode, Node (+27 more)
-
-### Community 24 - "VMwareMachine API Types"
-Cohesion: 0.16
-Nodes (39): BMConfig, BMCProvider, Client, Context, ESXIMigrationScope, LocalObjectReference, Migration, MigrationPlan (+31 more)
-
-### Community 25 - "ESXi SSH Client"
-Cohesion: 0.16
-Nodes (14): RollingMigrationPlanReconciler, Client, Context, Logger, Manager, Request, Result, RollingMigrationPlanScope (+6 more)
-
-### Community 26 - "OpenStack Mock Operations"
-Cohesion: 0.08
-Nodes (120): BMProviderClient, BMProviderServer, initCfg(), serve(), ClientConn, DialOption, Handler, Message (+112 more)
-
-### Community 27 - "OpenstackCreds API Types"
-Cohesion: 0.15
-Nodes (7): NetAppStorageProvider, OntapClusterInfo, BackendTargetGroup, BaseStorageProvider, Context, StorageAccessInfo, VolumeInfo
-
-### Community 28 - "OpenStack Mock Recorder"
-Cohesion: 0.19
-Nodes (9): DatastoreInfo, Contains(), DiskChangeInfo, ManagedObjectReference, VCenterClient, VirtualMachine, IsTransientVCenterError(), VirtualMachineSnapshotTree (+1 more)
-
-### Community 29 - "vpwned gRPC Gateway"
-Cohesion: 0.17
-Nodes (20): DiskChangeExtent, Libnbd, BlockStatusData, handlePool, NBDOperations, coalesceExtents(), copyBlockParallel(), copyRange() (+12 more)
-
-### Community 30 - "virt-v2v Mock Operations"
-Cohesion: 0.09
-Nodes (30): InjectEnvVariablesRequest, InjectEnvVariablesResponse, OpenstackAccessInfo, Client, Context, OpenstackInfo, ProviderClient, Request (+22 more)
-
-### Community 31 - "Monitoring Stack (Grafana)"
-Cohesion: 0.07
-Nodes (79): description, schema, description, schema, operationId, parameters, responses, summary (+71 more)
-
-### Community 32 - "vpwned Update Response Protobuf"
-Cohesion: 0.25
-Nodes (20): Finder, Client, Context, HostSystem, VMwareClusterInfo, VMwareCredsScope, VMwareHost, GetFinderForVMwareCreds() (+12 more)
-
-### Community 33 - "vpwned gRPC Server (Storage)"
-Cohesion: 0.07
-Nodes (37): BaseOptionValue, isDiskEnableUUIDSet(), parseComponentCheckOutput(), ProxyVMReconciler, Folder, Client, Context, Manager (+29 more)
-
-### Community 34 - "Rolling Migration Plan Utils"
-Cohesion: 0.10
-Nodes (22): Alertmanager CR (main), Alertmanager PrometheusRule (alertmanager-main-rules), Alertmanager ServiceMonitor (alertmanager-main), BlackboxExporter Deployment, BlackboxExporter ServiceMonitor, Kubernetes ControlPlane ServiceMonitor (kube-apiserver), KubeStateMetrics ClusterRoleBinding, KubeStateMetrics Deployment (+14 more)
-
-### Community 35 - "RollingMigrationPlan Reconciler"
-Cohesion: 0.10
-Nodes (22): ArrayCredsMapping CRD, BMConfig Viewer ClusterRole, Controller Manager Cluster Admin Binding, ClusterMigration Editor ClusterRole, Default Kustomization, Leader Election RoleBinding, Manager Kustomization, Manager Metrics Patch (+14 more)
-
-### Community 36 - "NetApp Storage Provider"
-Cohesion: 0.11
-Nodes (49): VMwareCreds, Client, ClusterMigration, ClusterMigrationInfo, ClusterMigrationScope, ConfigMap, Context, ESXIMigration (+41 more)
-
-### Community 37 - "RollingMigrationPlan API Types"
-Cohesion: 0.21
-Nodes (19): ColonSeparated(), EqualWWNs(), FormattedWWPNFromFCUID(), ParseFCUID(), StripWWNFormatting(), TestColonSeparated(), TestColonSeparatedRoundTrip(), TestEqualWWNs() (+11 more)
-
-### Community 38 - "NBD Disk Copy Protocol"
-Cohesion: 0.11
-Nodes (18): code:bash (# One-time setup), code:bash (# Controller logs), Common Pitfalls, CRD Changes, Debugging, Development Rules, External Documentation, Generated Files (+10 more)
-
-### Community 39 - "vpwned SDK Targets"
-Cohesion: 0.13
-Nodes (21): MigrationParams, MigrationParams, DoRetryWithExponentialBackoff(), GetFirstbootConfigMapName(), GetInclusterClient(), GetMigrationConfigMapName(), GetMigrationObjectName(), GetNetworkPersistance() (+13 more)
-
-### Community 40 - "Component 40"
-Cohesion: 0.11
-Nodes (18): code:sh (make docker-build docker-push IMG=<some-registry>/migration:), code:sh (make install), code:sh (make deploy IMG=<some-registry>/migration:tag), code:sh (kubectl apply -k config/samples/), code:sh (kubectl delete -k config/samples/), code:sh (make uninstall), code:sh (make undeploy), code:sh (make build-installer IMG=<some-registry>/migration:tag) (+10 more)
-
-### Community 41 - "Controller Component"
-Cohesion: 0.21
-Nodes (12): ClusterMigrationPhase, countSuccessfulESXIMigrations(), handleVMMigrations(), ClusterMigrationReconciler, Client, ClusterMigrationScope, Context, Manager (+4 more)
-
-### Community 42 - "Component 42"
-Cohesion: 0.14
-Nodes (24): getMostRecentValidationFailedCondition(), handleError(), updateStatusCondition(), ValidateRDMDiskFields(), RDMDiskReconciler, Client, Condition, Context (+16 more)
-
-### Community 43 - "RBAC Manifests"
-Cohesion: 0.12
-Nodes (15): Cloud-init Output (generated), code:go (type HostEntry struct {), code:json ([), code:block3 ((absent) --[user sets]--> "requested"), code:typescript (AGENT_HOST_ENTRIES: string  // JSON string, same storage for), code:typescript (interface HostEntry {), code:yaml (#cloud-config), ConfigMap Storage (+7 more)
-
-### Community 44 - "Controller Component"
-Cohesion: 0.25
-Nodes (10): ESXIMigrationReconciler, BMConfig, Client, Context, ESXIMigrationScope, Manager, Request, Result (+2 more)
-
-### Community 45 - "CRD API Types"
-Cohesion: 0.08
-Nodes (24): Authenticator, Extensions, InterfaceAddress, InterfaceDetails, InterfaceInfo, Client, Info, Host (+16 more)
-
-### Community 46 - "Mock / Test Double"
-Cohesion: 0.10
-Nodes (20): EsxcliField, EsxcliRoot, EsxcliStructure, EsxcliStructureList, convertDatastorePathToFilesystemPath(), parseEsxcliXMLOutput(), parseTaskResponse(), EsxcliField (+12 more)
-
-### Community 47 - "Utilities"
-Cohesion: 0.08
-Nodes (20): UnimplementedBaseProvider, BMAccessInfo, BMCProvider, BootsourceSelections, Context, DeployMachineRequest, DeployMachineResponse, IpmiType (+12 more)
-
-### Community 48 - "CRD API Types"
-Cohesion: 0.17
-Nodes (13): detectSANProtocol(), isONTAPConflict(), normaliseToONTAPInitiators(), OntapFlexVol, OntapFlexVolResponse, OntapIgroup, OntapIgroupResponse, OntapLUN (+5 more)
-
-### Community 49 - "CRD API Types"
-Cohesion: 0.13
-Nodes (8): BaseStorageProvider, Client, Context, MappingContext, StorageAccessInfo, Volume, VolumeInfo, PureStorageProvider
-
-### Community 50 - "CRD API Types"
-Cohesion: 0.17
-Nodes (16): analytics-keys Secret (Amplitude/Bugsnag), configmap-editor-role Role, vJailbreak UI Deployment (image_builder/deploy/01ui.yaml), migration-system Kubernetes Namespace, NetworkMapping Custom Resource, OpenstackCreds Custom Resource, version-checker-binding RoleBinding, vjailbreak-version-checker CronJob (+8 more)
-
-### Community 51 - "CRD API Types"
-Cohesion: 0.20
-Nodes (8): Reporter, generateRandomString(), IsRunningInPod(), NewReporter(), ReporterOps, Clientset, Context, Pod
-
-### Community 52 - "CRD API Types"
-Cohesion: 0.29
-Nodes (7): HostConfig, Cluster, Context, Request, Host, Impl, Impl
-
-### Community 53 - "CRD API Types"
-Cohesion: 0.22
-Nodes (7): CreateProjectResponseProject, Context, Logger, CreateProjectResponse, HTTPClient, Project, PrettyPrint()
-
-### Community 54 - "CRD API Types"
-Cohesion: 0.28
-Nodes (14): Remove-ControlPanelEntry(), Remove-DriverStore(), Remove-VMwareDevices(), Remove-VMwareDrivers(), Remove-VMwareFolderAggressive(), Remove-VMwareFolders(), Remove-VMwarePnPDevicesAggressive(), Remove-VMwareRegistry() (+6 more)
-
-### Community 55 - "Mock / Test Double"
-Cohesion: 0.05
-Nodes (34): NewMaasClient(), MaasClient, MaasProvider, MaasAccessInfo, MaasClient, Machine, BootsourceSelections, Client (+26 more)
-
-### Community 56 - "Protobuf Service"
-Cohesion: 0.13
-Nodes (14): Code of Conduct, Code Review Process, code:bash (git clone https://github.com/platform9/vjailbreak.git), code:bash (go mod download), code:bash (make build), code:bash (make test), Contributing to vJailbreak, Development Setup (+6 more)
-
-### Community 57 - "Controller Component"
-Cohesion: 0.13
-Nodes (16): Disk, GuestNetwork, ListMeta, NIC, ObjectMeta, TypeMeta, Disk, GPUInfo (+8 more)
-
-### Community 58 - "Component 58"
-Cohesion: 0.24
-Nodes (9): VMwareCredsReconciler, Client, Context, Manager, Request, Result, Scheme, VMwareCredsScope (+1 more)
-
-### Community 59 - "Utilities"
-Cohesion: 0.07
-Nodes (37): ArrayCredsMapping, NewCloneTracker(), CloneStatus, CloneTracker, ProgressLogger, atoi(), GetArrayCreds(), GetArrayCredsMapping() (+29 more)
-
-### Community 60 - "Component 60"
-Cohesion: 0.14
-Nodes (10): init(), init(), IronicProvider, init(), MaasAccessInfo, UnimplementedBaseProvider, BMAccessInfo, BMCProvider (+2 more)
-
-### Community 61 - "CRD API Types"
-Cohesion: 0.09
-Nodes (25): AuthOptions, OpenstackOperations, authOptionsFromEnv(), NewOpenStackClients(), validateOpenStack(), Client, Config, Duration (+17 more)
-
-### Community 62 - "CRD API Types"
-Cohesion: 0.13
-Nodes (8): Client, Context, Reader, StorageAccessInfo, Volume, VolumeInfo, BaseStorageProvider, VendorConfig
-
-### Community 63 - "CRD API Types"
-Cohesion: 0.14
-Nodes (12): Baseline tooling, code:bash (make setup-hooks), code:bash (yarn), code:bash (make lint), code:bash (make test), code:bash (go test ./...), Commit guidance, Common commands (+4 more)
-
-### Community 64 - "CRD API Types"
-Cohesion: 0.30
-Nodes (12): T, HostEntry, buildHostsLines(), BuildUserData(), isValidHostname(), ParseHostEntries(), SerializeHostEntries(), TestBuildUserData() (+4 more)
-
-### Community 65 - "CRD API Types"
-Cohesion: 0.14
-Nodes (12): Assumptions, Edge Cases, Feature Specification: Agent Node Custom Host Entries, Functional Requirements, Key Entities, Measurable Outcomes, Requirements *(mandatory)*, Success Criteria *(mandatory)* (+4 more)
-
-### Community 66 - "Migration Worker"
-Cohesion: 0.20
-Nodes (12): parseESXiVersion(), ESXiSSHCredsReconciler, hostValidationResult, ESXiSSHCreds, ESXiSSHCredsInfo, Client, Context, Manager (+4 more)
-
-### Community 67 - "Controller Component"
-Cohesion: 0.17
-Nodes (15): Flavor, ListMeta, ObjectMeta, ObjectReference, TypeMeta, HostConfig, OpenstackCreds, OpenStackCredsInfo (+7 more)
-
-### Community 68 - "CRD API Types"
-Cohesion: 0.09
-Nodes (41): AvailableUpdatesResponse, CleanupRequest, CleanupResponse, Client, Config, Context, Time, UpgradeProgress (+33 more)
-
-### Community 69 - "CRD API Types"
+### Community 13 - "Community 13"
 Cohesion: 0.05
 Nodes (42): API Server Tests (`pkg/vpwned/`), Arrange-Act-Assert Pattern, Avoid, Benchmarks (Go), Cleanup, Common Testing Pitfalls, Component-Specific Requirements, Continuous Integration (+34 more)
 
-### Community 70 - "CRD API Types"
-Cohesion: 0.14
-Nodes (17): BackendTargetGroup, ListMeta, NetAppConfig, ObjectMeta, ObjectReference, TypeMeta, OpenstackMapping, ArrayCreds (+9 more)
-
-### Community 71 - "Controller Component"
-Cohesion: 0.14
-Nodes (11): AuthResponse, CreateUserRequest, CreateUserResponse, AuthInfo, Context, Credentials, Project, Role (+3 more)
-
-### Community 72 - "Component 72"
-Cohesion: 0.21
-Nodes (16): TestCleanup_PartialVolumes_DeletesCreatedVolumeAndPorts(), TestCreateTargetInstance(), TestCreateTargetInstance_AdvancedMapping_InsufficientPorts(), TestCreateTargetInstance_AdvancedMapping_Ports(), TestCreateVolumes(), TestDeleteAllVolumes(), TestDeleteAllVolumes_SkipsNilOpenstackVol(), TestDetachAllVolumes() (+8 more)
-
-### Community 73 - "Component 73"
-Cohesion: 0.10
-Nodes (17): Devices, Driver, Source, Target, VMInfo, Disk, Name, T (+9 more)
-
-### Community 74 - "Component 74"
-Cohesion: 0.05
-Nodes (43): description, type, description, type, description, type, description, format (+35 more)
-
-### Community 75 - "RBAC Manifests"
-Cohesion: 0.18
-Nodes (15): ListMeta, MigrationPlanSpecPerVM, ObjectMeta, PodPhase, Time, TypeMeta, AdvancedOptions, MigrationPlan (+7 more)
-
-### Community 76 - "OpenStack Component"
-Cohesion: 0.12
-Nodes (47): ArrayCredsInfo, Client, Context, Flavor, Map, OpenStackClients, OpenstackCreds, OpenstackInfo (+39 more)
-
-### Community 77 - "VMware Component"
-Cohesion: 0.24
-Nodes (15): PostValidationResources, authErrorMessage(), ensureLogger(), FetchResourcesPostValidation(), getCredentialsFromSecret(), Validate(), verifyCredentialsMatchCurrentEnvironment(), ValidationResult (+7 more)
-
-### Community 78 - "Component 78"
-Cohesion: 0.22
-Nodes (10): ServiceClient, OpenStackClients, OpenStackMetadata, CloudInitParams, Network, OpenStackMetadata, RollingMigartionValidationConfig, vmError (+2 more)
-
-### Community 79 - "VMware Component"
+### Community 14 - "Community 14"
 Cohesion: 0.05
 Nodes (41): API Authentication, API Client Usage, API Design Principles, API Documentation, API Handler Pattern, API Server Development Rules, API Testing, Authentication & Authorization (+33 more)
 
-### Community 80 - "Component 80"
-Cohesion: 0.31
-Nodes (11): FilterFlavorsByAvailabilityZone(), GetClosestFlavour(), getPassthroughGPUCount(), getVGPUCount(), isGPUFlavor(), TestFilterFlavorsByAvailabilityZone(), TestGetClosestFlavourWithGPU(), TestGetPassthroughGPUCount() (+3 more)
+### Community 15 - "Community 15"
+Cohesion: 0.12
+Nodes (16): getProgressConfigMapName(), NewUpgradeExecutor(), DeploymentConfig, runUpgradeJob(), ReleaseInfo, UpgradeExecutor, CheckImagesExist(), GetAllTags() (+8 more)
 
-### Community 81 - "Component 81"
-Cohesion: 0.33
-Nodes (10): reprovisionTestScheme(), TestReconcileReprovision_NoAnnotation(), TestReconcileReprovision_RequestedIdleNode(), TestReconcileReprovision_RequestedWithActiveMigrations(), TestReprovisionAllowed_NilMigrations(), TestReprovisionAllowed_NoMigrations(), TestReprovisionAllowed_WithActiveMigrations(), reprovisionAllowed() (+2 more)
-
-### Community 82 - "VMware Component"
-Cohesion: 0.24
-Nodes (10): VjailbreakNodeReconciler, Client, Context, Manager, Request, Result, Scheme, VjailbreakNode (+2 more)
-
-### Community 83 - "Protobuf Service"
-Cohesion: 0.36
-Nodes (6): GetManager(), main(), SetupControllers(), Config, Manager, Server
-
-### Community 84 - "Protobuf Service"
-Cohesion: 0.18
-Nodes (9): code:go (func reprovisionAllowed(activeMigrations []string) bool), Decision 1: Host Entries Storage Location, Decision 2: No New Files in `k8s/migration` — Use `pkg/common/utils/`, Decision 3: Cloud-init Injection — `BuildUserData` in `pkg/common/utils/hosts.go`, Decision 4: Interface-First + TDD (Constitution Principle IV), Decision 5: `pkg/common/constants` — Add One Constant, Decision 6: Reprovision Mechanism, Decision 7: Module Boundary for Vendor Copies (+1 more)
-
-### Community 85 - "Protobuf Service"
-Cohesion: 0.19
-Nodes (14): ListMeta, LocalObjectReference, MigrationPlanSpecPerVM, ObjectMeta, SecretReference, TypeMeta, ClusterMapping, ClusterMigrationInfo (+6 more)
-
-### Community 86 - "Protobuf Service"
-Cohesion: 0.67
-Nodes (4): VMwareClusterInfo, VMwareHost, FindVMwareHostsNotInVcenter(), HostExistsInVcenter()
-
-### Community 87 - "Protobuf Service"
-Cohesion: 0.22
-Nodes (12): Client, Request, Response, T, NewTestClient(), TestGetEndpointForRegion(), TestGetServiceID(), RoundTripFunc (+4 more)
-
-### Community 88 - "Controller Component"
-Cohesion: 0.33
-Nodes (9): Cmd, GetProjectDir(), InstallCertManager(), InstallPrometheusOperator(), LoadImageToKindClusterWithName(), Run(), UninstallCertManager(), UninstallPrometheusOperator() (+1 more)
-
-### Community 89 - "Component 89"
-Cohesion: 0.33
-Nodes (15): Client, Context, Model, Server, T, VCenterClient, cleanupSimulator(), simulateVCenter() (+7 more)
-
-### Community 90 - "Component 90"
-Cohesion: 0.06
-Nodes (42): description, $ref, id, properties, type, description, items, type (+34 more)
-
-### Community 91 - "Utilities"
-Cohesion: 0.15
-Nodes (16): GuestNetwork, NIC, RDMDisk, VirtualDisk, VirtualMachinePowerState, VMDisk, Volume, ChangeID (+8 more)
-
-### Community 92 - "Protobuf Service"
+### Community 16 - "Community 16"
 Cohesion: 0.05
-Nodes (41): description, id, location, pattern, properties, required, type, description (+33 more)
+Nodes (39): 1.1 Document Purpose, 1.2 Product Scope, 1.3 Definitions, Acronyms and Abbreviations, 1.4 References, 1.5 Document Overview, 1. Introduction, 2.1 Product Perspective, 2.2 Product Functions (+31 more)
 
-### Community 93 - "Protobuf Service"
-Cohesion: 0.38
-Nodes (9): Ensure-64BitPowerShell(), Get-Script(), Init-Table(), Pop-Script(), Push-Script(), Remove-MyTask(), Schedule-MyTask(), Script-Runner() (+1 more)
-
-### Community 94 - "Controller Component"
-Cohesion: 0.24
-Nodes (10): MigrationPlan Editor ClusterRole, MigrationPlan Instance (vm-migration-sample), MigrationTemplate Editor ClusterRole, MigrationTemplate Instance (migration-template-sample), NetworkMapping Instance (nwmap1), OpenstackCreds Instance (sapmo1), StorageMapping Instance (stmap1), StorageMapping Viewer ClusterRole (+2 more)
-
-### Community 95 - "CRD API Types"
-Cohesion: 0.37
-Nodes (12): HostEntry, ConfigMap, Scheme, T, GetAgentHostEntries(), configMapWithHostEntries(), TestGetAgentHostEntries_ConfigMapMissing(), TestGetAgentHostEntries_KeyAbsent() (+4 more)
-
-### Community 96 - "Controller Component"
-Cohesion: 0.18
-Nodes (25): Migration, VMInfo, VMwareCreds, VMwareMachine, Scheme, T, NamespacedName, createNewVMwareMachine() (+17 more)
-
-### Community 97 - "Controller Component"
-Cohesion: 0.24
-Nodes (10): ListMeta, ObjectMeta, PodCondition, TypeMeta, Migration, MigrationConditionType, MigrationList, MigrationSpec (+2 more)
-
-### Community 98 - "Keystone Auth"
+### Community 17 - "Community 17"
 Cohesion: 0.05
 Nodes (37): Accessibility, API Calls, API Integration, Backend Communication, Best Practices, Browser DevTools, Build and Deployment, Code Style (+29 more)
 
-### Community 99 - "Test Utilities"
-Cohesion: 0.22
-Nodes (9): CoreDNS ServiceMonitor, Node Exporter ClusterRole, Node Exporter ClusterRoleBinding, Node Exporter DaemonSet, Node Exporter NetworkPolicy, Node Exporter PrometheusRule (node-exporter-rules), Node Exporter Service, Node Exporter ServiceAccount (+1 more)
-
-### Community 100 - "Test Utilities"
-Cohesion: 0.26
-Nodes (10): ListMeta, ObjectMeta, SecretReference, TypeMeta, BMConfig, BMConfigList, BMConfigSpec, BMConfigStatus (+2 more)
-
-### Community 101 - "Protobuf Service"
+### Community 18 - "Community 18"
 Cohesion: 0.06
-Nodes (37): methods, description, httpMethod, id, parameterOrder, path, response, scopes (+29 more)
+Nodes (38): BMConfig Sample CR, BMConfig Sample CR (MAAS Provider), Go File Boilerplate (Apache 2.0 License Header), Cloud-Init Template for PCD Node Setup, ClusterMigration Sample CR, ClusterMigration Sample CR, ESXi Host Migration Sequence in ClusterMigration, ESXIMigration Sample CR (+30 more)
 
-### Community 102 - "Protobuf Service"
-Cohesion: 0.18
-Nodes (29): HandlerFunc, Request, ResponseWriter, Server, T, ReactionFunc, Regexp, ReverseProxy (+21 more)
+### Community 19 - "Community 19"
+Cohesion: 0.06
+Nodes (33): code:text (specs/002-agent-dns-config/), code:go (if vjNode.Annotations[reprovisionAnnotation] == reprovisionR), code:typescript (AGENT_HOST_ENTRIES: string  // JSON string, default ""), code:typescript (interface HostEntriesTabProps {), code:typescript (const isValidIP = (ip: string) => /^(\d{1,3}\.){3}\d{1,3}$|^), code:typescript (export const reprovisionNode = async (nodeName: string): Pro), code:bash (# Go (pkg/common module — pure function tests)), code:text (pkg/common/) (+25 more)
 
-### Community 103 - "Protobuf Service"
-Cohesion: 0.07
-Nodes (30): default, description, enum, type, description, properties, type, properties (+22 more)
+### Community 20 - "Community 20"
+Cohesion: 0.09
+Nodes (35): BM Config Editor Role, Cluster Migration Viewer Role, Controller Manager Service Account, BMConfigs CRD, ClusterMigrations CRD, ESXiMigrations CRD, Migrations CRD, NetworkMappings CRD (+27 more)
 
-### Community 104 - "Config & Samples"
-Cohesion: 0.25
-Nodes (7): Client, Logger, VjailbreakNode, VjailbreakNodeScope, VjailbreakNodeScope, NewVjailbreakNodeScope(), VjailbreakNodeScopeParams
-
-### Community 105 - "OpenStack Component"
-Cohesion: 0.25
-Nodes (9): DatastoreArrayCredsMapping, ListMeta, ObjectMeta, TypeMeta, ArrayCredsMapping, ArrayCredsMappingList, ArrayCredsMappingSpec, ArrayCredsMappingStatus (+1 more)
-
-### Community 106 - "Controller Component"
-Cohesion: 0.27
-Nodes (9): ListMeta, ObjectMeta, ObjectReference, TypeMeta, VjailbreakNode, VjailbreakNodeList, VjailbreakNodePhase, VjailbreakNodeSpec (+1 more)
-
-### Community 107 - "Controller Component"
-Cohesion: 0.27
-Nodes (9): ListMeta, LocalObjectReference, ObjectMeta, TypeMeta, MigrationTemplate, MigrationTemplateDestination, MigrationTemplateList, MigrationTemplateSource (+1 more)
-
-### Community 108 - "VMware Component"
-Cohesion: 0.25
-Nodes (9): ListMeta, ObjectMeta, TypeMeta, Storage, Storage, StorageMapping, StorageMappingList, StorageMappingSpec (+1 more)
-
-### Community 109 - "Utilities"
-Cohesion: 0.31
-Nodes (8): ListMeta, ObjectMeta, TypeMeta, PCDHost, PCDHostInterface, PCDHostList, PCDHostSpec, PCDHostStatus
-
-### Community 110 - "Component 110"
-Cohesion: 0.31
-Nodes (8): ListMeta, ObjectMeta, TypeMeta, VMwareCluster, VMwareClusterList, VMwareClusterPhase, VMwareClusterSpec, VMwareClusterStatus
-
-### Community 111 - "Protobuf Service"
-Cohesion: 0.25
-Nodes (9): ListMeta, Network, ObjectMeta, TypeMeta, Network, NetworkMapping, NetworkMappingList, NetworkMappingSpec (+1 more)
-
-### Community 112 - "Protobuf Service"
-Cohesion: 0.27
-Nodes (9): ListMeta, LocalObjectReference, ObjectMeta, TypeMeta, ESXIMigration, ESXIMigrationList, ESXIMigrationPhase, ESXIMigrationSpec (+1 more)
-
-### Community 113 - "Protobuf Service"
-Cohesion: 0.23
-Nodes (10): Condition, ListMeta, ObjectMeta, TypeMeta, OpenstackVolumeRef, OpenstackVolumeRef, RDMDisk, RDMDiskList (+2 more)
-
-### Community 114 - "Protobuf Service"
-Cohesion: 0.25
-Nodes (9): ListMeta, ObjectMeta, ObjectReference, TypeMeta, VMwareCreds, VMwareCredsInfo, VMwareCredsList, VMwareCredsSpec (+1 more)
-
-### Community 115 - "Protobuf Service"
-Cohesion: 0.27
-Nodes (9): ListMeta, LocalObjectReference, ObjectMeta, TypeMeta, ClusterMigration, ClusterMigrationList, ClusterMigrationPhase, ClusterMigrationSpec (+1 more)
-
-### Community 116 - "OpenStack Component"
-Cohesion: 0.23
-Nodes (10): ListMeta, ObjectMeta, ObjectReference, Time, TypeMeta, ESXiSSHCreds, ESXiSSHCredsInfo, ESXiSSHCredsList (+2 more)
-
-### Community 117 - "Test Utilities"
+### Community 21 - "Community 21"
 Cohesion: 0.08
-Nodes (28): ClientBuilder, Client, ClusterMigration, ClusterMigrationScope, Logger, RollingMigrationPlan, Client, Logger (+20 more)
+Nodes (31): Alertmanager CRD (monitoring.coreos.com), alertmanager-main PodDisruptionBudget, Alertmanager Main Service, AlertmanagerConfig CRD (monitoring.coreos.com/v1alpha1), blackbox-exporter ServiceAccount, grafana-api-ingress Ingress, grafana-folders ConfigMap, Grafana ServiceMonitor (+23 more)
 
-### Community 118 - "Controller Component"
-Cohesion: 0.24
-Nodes (8): Client, ESXIMigration, ESXIMigrationScope, Logger, RollingMigrationPlan, ESXIMigrationScope, NewESXIMigrationScope(), ESXIMigrationScopeParams
+### Community 22 - "Community 22"
+Cohesion: 0.07
+Nodes (28): Acknowledgements, Agent Scaling, code:bash (# Install ORAS (see https://oras.land/docs/installation)), code:bash (# Upload the image to your OpenStack environment), code:bash (# Example /etc/hosts entry), code:bash (# After modifying resolv.conf), Community and Support, Contributing (+20 more)
 
-### Community 119 - "Test Utilities"
-Cohesion: 0.27
-Nodes (14): Client, Context, Map, VMInfo, VMwareCreds, VMwareCredsInfo, NormalizeVCenterURL(), PostValidationResources (+6 more)
+### Community 23 - "Community 23"
+Cohesion: 0.07
+Nodes (26): code:bash (# Step 1: write tests first (parallel — different files)), Dependencies & Execution Order, Format: `[ID] [P?] [Story] Description`, Implementation for User Story 1, Implementation for User Story 2, Implementation for User Story 3, Implementation Strategy, Incremental Delivery (+18 more)
 
-### Community 120 - "Test Utilities"
+### Community 24 - "Community 24"
 Cohesion: 0.07
 Nodes (26): Cold-Only Enforcement (New — FR-017), Complexity Tracking, Constitution Check, Contracts, Data Model, Documentation (this feature), hotadd_copy.go — `HotAddCopyDisks()`, Implementation Details (+18 more)
 
-### Community 121 - "Utilities"
+### Community 25 - "Community 25"
 Cohesion: 0.07
 Nodes (26): Common Issues, Common Patterns, Critical Context: Guestfish Appliance Environment, Debug Logging, Debugging, Deduplication, Documentation, Environment Detection (+18 more)
 
-### Community 122 - "Component 122"
+### Community 26 - "Community 26"
 Cohesion: 0.07
 Nodes (26): Dependencies & Execution Order, Format: `[ID] [P?] [Story] Description`, Implementation for User Story 1, Implementation for User Story 2, Implementation for User Story 3, Implementation Strategy, Incremental Delivery, MVP First (User Story 1 Only) (+18 more)
 
-### Community 123 - "Protobuf Service"
-Cohesion: 0.18
-Nodes (9): Content Quality, Feature Readiness, Notes, Requirement Completeness, Specification Quality Checklist: Agent Node Custom Host Entries, Content Quality, Feature Readiness, Notes (+1 more)
+### Community 27 - "Community 27"
+Cohesion: 0.08
+Nodes (27): Alertmanager (alertmanager-main), Alertmanager NetworkPolicy (alertmanager-main), Alertmanager ServiceAccount (alertmanager-main), Grafana Config Secret, Grafana Dashboard Definitions, Grafana Dashboard Sources ConfigMap, Grafana Dashboard Datasources Secret, Grafana Deployment (+19 more)
 
-### Community 124 - "VMware Component"
-Cohesion: 0.29
-Nodes (8): ListMeta, ObjectMeta, Time, TypeMeta, VMwareHost, VMwareHostList, VMwareHostSpec, VMwareHostStatus
-
-### Community 125 - "Protobuf Service"
-Cohesion: 0.33
-Nodes (7): ListMeta, ObjectMeta, TypeMeta, PCDCluster, PCDClusterList, PCDClusterSpec, PCDClusterStatus
-
-### Community 126 - "Protobuf Service"
-Cohesion: 0.40
-Nodes (5): DatastoreInfo, DiskInfo, ESXiCredentials, StorageDeviceInfo, VMInfo
-
-### Community 127 - "PCD Integration"
-Cohesion: 0.48
-Nodes (6): ProviderClient, InstanceMetadata, GetCurrentInstanceMetadata(), GetMasterInstanceUUID(), GetMasterInstanceUUIDFromDMI(), VerifyCredentialsMatchCurrentEnvironment()
-
-### Community 128 - "Protobuf Service"
+### Community 28 - "Community 28"
 Cohesion: 0.08
 Nodes (25): Before Adding Support for New OS, Build Process, Building v2v-helper, CGO and Platform Requirements, Common Issues, Debugging, Disk Conversion Process, Disk Streaming (+17 more)
 
-### Community 129 - "Protobuf Service"
-Cohesion: 0.33
-Nodes (6): Blackbox Exporter ClusterRole, Blackbox Exporter ClusterRoleBinding, Blackbox Exporter Configuration ConfigMap, Blackbox Exporter NetworkPolicy, Blackbox Exporter Service, Blackbox Exporter ServiceAccount
-
-### Community 130 - "Protobuf Service"
-Cohesion: 0.36
-Nodes (6): ListMeta, ObjectMeta, TypeMeta, VolumeImageProfile, VolumeImageProfileList, VolumeImageProfileSpec
-
-### Community 131 - "Controller Component"
-Cohesion: 0.33
-Nodes (5): AuthInfo, Client, ServiceManagerAPI, GetServiceID(), ServicesInfo
-
-### Community 132 - "RBAC Manifests"
-Cohesion: 0.33
-Nodes (5): AuthInfo, Client, EndpointManagerAPI, GetEndpointForRegion(), EndpointsInfo
-
-### Community 133 - "Controller Component"
-Cohesion: 0.33
-Nodes (4): AuthInfo, Context, NewFakeAuthenticator(), FakeAuthenticator
-
-### Community 134 - "VMware Component"
-Cohesion: 0.53
-Nodes (4): config, Execute(), parseLogLevel(), Level
-
-### Community 135 - "Component 135"
+### Community 29 - "Community 29"
 Cohesion: 0.08
 Nodes (25): 1. Initialize Analysis Context, 2. Load Artifacts (Progressive Disclosure), 3. Build Semantic Models, 4. Detection Passes (Token-Efficient Analysis), 5. Severity Assignment, 6. Produce Compact Analysis Report, 7. Provide Next Actions, 8. Offer Remediation (+17 more)
 
-### Community 136 - "Protobuf Service"
-Cohesion: 0.40
-Nodes (5): Controller Manager Deployment (migration-controller-manager), vJailbreak UI Deployment, Vpwned SDK Deployment (migration-vpwned-sdk), migration-system Kubernetes Namespace, VDDK Libraries (VMware Virtual Disk Dev Kit)
-
-### Community 137 - "Protobuf Service"
-Cohesion: 0.22
-Nodes (6): StorageMappingReconciler, BaseReconciler, Context, Manager, Request, Result
-
-### Community 138 - "Protobuf Service"
-Cohesion: 0.22
-Nodes (6): NetworkMappingReconciler, BaseReconciler, Context, Manager, Request, Result
-
-### Community 139 - "Protobuf Service"
-Cohesion: 0.36
-Nodes (8): GetAccessibleSecurityGroups(), ListSecurityGroupInfos(), resolveProjectID(), Context, ProviderClient, ServiceClient, SecGroup, SecurityGroupInfo
-
-### Community 141 - "Protobuf Service"
-Cohesion: 0.47
-Nodes (5): Atoi(), GetVjailbreakSettings(), VjailbreakSettings, Client, Context
-
-### Community 142 - "Protobuf Service"
-Cohesion: 0.50
-Nodes (3): Appliance VM, code:bash (vagrant up), Quickstart
-
-### Community 143 - "Protobuf Service"
-Cohesion: 0.50
-Nodes (4): Addons Kustomization, CRD Kustomize Config, Migration Controller README, vpwned-sdk Addon Deployment and Service
-
-### Community 144 - "Protobuf Service"
-Cohesion: 0.83
-Nodes (4): vpwned-sdk Kubernetes Deployment, vpwned-ingress Nginx Ingress (path: /dev-api/sdk/), vpwned-service Kubernetes ClusterIP Service, vpwned Kubernetes Namespace
-
-### Community 145 - "Protobuf Service"
-Cohesion: 0.25
-Nodes (6): BaseReconciler, Client, Context, Object, Result, Scheme
-
-### Community 149 - "Protobuf Service"
-Cohesion: 0.11
-Nodes (19): CreateInitiatorGroupRequest, CreateInitiatorGroupResponse, GetMappedGroupsRequest, GetMappedGroupsResponse, MappingContextEntry, MapVolumeRequest, MapVolumeResponse, Context (+11 more)
-
-### Community 150 - "Protobuf Service"
-Cohesion: 0.67
-Nodes (3): sync-daemon DaemonSet, virtio-win Drivers, VMware VIX DiskLib (VDDK) Libraries
-
-### Community 151 - "Protobuf Service"
-Cohesion: 0.67
-Nodes (3): selfsigned-issuer ClusterIssuer, vjailbreak-ca Certificate, vjailbreak-ca-issuer ClusterIssuer
-
-### Community 152 - "Protobuf Service"
-Cohesion: 1.00
-Nodes (3): KubeStateMetrics ClusterRole, KubeStateMetrics Exporter Service, KubeStateMetrics ServiceMonitor
-
-### Community 153 - "Protobuf Service"
-Cohesion: 0.67
-Nodes (3): vJailbreak Functional/Software Requirements Specification Template, Migration Sample CR, MigrationPlan Sample CR
-
-### Community 202 - "Protobuf Service"
-Cohesion: 0.09
-Nodes (26): parameters, description, location, type, description, location, type, parameters (+18 more)
-
-### Community 203 - "Protobuf Service"
+### Community 30 - "Community 30"
 Cohesion: 0.08
 Nodes (24): Critical Path, Dependencies & Execution Order, Error propagation, Format: `[ID] [P?] [Story] Description`, govmomi disk detach, Implementation Notes, Parallel Opportunities, Phase 10: migrate.go Integration (+16 more)
 
-### Community 204 - "Protobuf Service"
-Cohesion: 0.16
-Nodes (17): ArrayCredsScope, ArrayCredsSpec, buildProviderOptionsFromSpec(), getDatastoreInfo(), validateNetAppTargetSelection(), ArrayCredsReconciler, ArrayCredsInfo, BackendTargetGroup (+9 more)
+### Community 31 - "Community 31"
+Cohesion: 0.09
+Nodes (12): PrettyPrint(), TestJSONBuiltinMarshalField(), JSONBuiltin, GenerateXMLConfig(), Devices, Disk, Domain, Driver (+4 more)
 
-### Community 205 - "Server Component"
-Cohesion: 0.08
-Nodes (24): annotations, list, editable, fiscalYearStartMonth, graphTooltip, id, links, liveNow (+16 more)
-
-### Community 206 - "Protobuf Service"
-Cohesion: 0.14
-Nodes (22): HostMaintenanceSpec, Client, Collector, ConfigMap, Context, ManagedObjectReference, RollingMigrationPlan, RollingMigrationPlanScope (+14 more)
-
-### Community 207 - "VMware Component"
+### Community 32 - "Community 32"
 Cohesion: 0.09
 Nodes (22): After Editing CRD Types, Build Targets, Checking Logs, Client Usage, Common Patterns, Controller Development Rules, Controller Reconciliation, Controller-Specific Make Targets (+14 more)
 
-### Community 208 - "Utilities"
-Cohesion: 0.09
-Nodes (23): description, enum, enumDescriptions, type, description, items, type, properties (+15 more)
+### Community 33 - "Community 33"
+Cohesion: 0.13
+Nodes (22): vJailbreak Agents Guide, Business Source License 1.1, vJailbreak Contributing Guide, govmomi, Migration Form Step 1 Screenshot, Migration Form Step 2 Screenshot, Migration Progress List Screenshot, Migration Progress Detail Tooltip Screenshot (+14 more)
 
-### Community 209 - "Component 209"
-Cohesion: 0.16
-Nodes (5): NewClient(), NewClientWithTimeout(), Context, Duration, Client
+### Community 34 - "Community 34"
+Cohesion: 0.1
+Nodes (22): Alertmanager CR (main), Alertmanager PrometheusRule (alertmanager-main-rules), Alertmanager ServiceMonitor (alertmanager-main), BlackboxExporter Deployment, BlackboxExporter ServiceMonitor, Kubernetes ControlPlane ServiceMonitor (kube-apiserver), KubeStateMetrics ClusterRoleBinding, KubeStateMetrics Deployment (+14 more)
 
-### Community 210 - "Protobuf Service"
-Cohesion: 0.23
-Nodes (10): getDiskKeys(), readGuestWWIDs(), hotAddDiskTransfer, vcenterClientGetter, Client, Context, Migrate, VCenterClient (+2 more)
+### Community 35 - "Community 35"
+Cohesion: 0.1
+Nodes (22): ArrayCredsMapping CRD, BMConfig Viewer ClusterRole, Controller Manager Cluster Admin Binding, ClusterMigration Editor ClusterRole, Default Kustomization, Leader Election RoleBinding, Manager Kustomization, Manager Metrics Patch (+14 more)
 
-### Community 211 - "RBAC Manifests"
+### Community 36 - "Community 36"
 Cohesion: 0.11
-Nodes (18): basePath, baseUrl, batchPath, description, discoveryVersion, documentationLink, etag, id (+10 more)
+Nodes (18): code:bash (# One-time setup), code:bash (# Controller logs), Common Pitfalls, CRD Changes, Debugging, Development Rules, External Documentation, Generated Files (+10 more)
 
-### Community 212 - "Test Utilities"
-Cohesion: 0.12
-Nodes (19): parameters, parameters, project, region, requestId, description, location, pattern (+11 more)
+### Community 37 - "Community 37"
+Cohesion: 0.11
+Nodes (18): code:sh (make docker-build docker-push IMG=<some-registry>/migration:), code:sh (make install), code:sh (make deploy IMG=<some-registry>/migration:tag), code:sh (kubectl apply -k config/samples/), code:sh (kubectl delete -k config/samples/), code:sh (make uninstall), code:sh (make undeploy), code:sh (make build-installer IMG=<some-registry>/migration:tag) (+10 more)
 
-### Community 213 - "Component 213"
+### Community 38 - "Community 38"
 Cohesion: 0.11
 Nodes (17): Changes, ConfigMap Keys Added, Data Model: Hot-Add Proxy Migration, Entity Relationships, Modified Entity: MigrationParams (v2v-helper), Modified Entity: MigrationTemplate, New Constants, New Entity: ProxyVM (+9 more)
 
-### Community 214 - "Keystone Auth"
+### Community 39 - "Community 39"
 Cohesion: 0.12
-Nodes (4): get_current_branch(), get_feature_paths(), has_git(), common.sh script
+Nodes (15): Cloud-init Output (generated), code:go (type HostEntry struct {), code:json ([), code:block3 ((absent) --[user sets]--> "requested"), code:typescript (AGENT_HOST_ENTRIES: string  // JSON string, same storage for), code:typescript (interface HostEntry {), code:yaml (#cloud-config), ConfigMap Storage (+7 more)
 
-### Community 215 - "Keystone Auth"
+### Community 40 - "Community 40"
 Cohesion: 0.12
 Nodes (16): Assumptions, Clarifications, Edge Cases, Feature Specification: Hot-Add Proxy Migration, Functional Requirements, Key Entities, Measurable Outcomes, Overview (+8 more)
 
-### Community 216 - "Keystone Auth"
-Cohesion: 0.26
-Nodes (13): display_msg(), execute_main_workflow(), fetch_uuid_time_marker(), has_netplan_get_feature(), invoke_netplan_get(), locate_netplan_if_by_ip(), parse_address_pair(), process_dhclient_history() (+5 more)
-
-### Community 217 - "Config & Samples"
-Cohesion: 0.12
-Nodes (17): description, httpMethod, id, parameters, path, get, description, id (+9 more)
-
-### Community 218 - "Component 218"
+### Community 41 - "Community 41"
 Cohesion: 0.12
 Nodes (15): Auto-Generated Packages for Google Cloud Platform, [Cloud Bigtable](https://cloud.google.com/bigtable/), [Cloud Datastore](https://cloud.google.com/datastore/), [Cloud Identity and Access Management (IAM)](https://cloud.google.com/iam/), [Cloud Natural Language](https://cloud.google.com/natural-language/), [Cloud Pub/Sub](https://cloud.google.com/pubsub/), [Cloud Speech](https://cloud.google.com/speech/), [Cloud Vision](https://cloud.google.com/vision/) (+7 more)
 
-### Community 219 - "Protobuf Service"
-Cohesion: 0.26
-Nodes (14): change_password(), create_user(), delete_user(), ensure_file(), list_users(), _pf9_ht_main(), prompt_new_password(), prompt_user() (+6 more)
+### Community 42 - "Community 42"
+Cohesion: 0.17
+Nodes (16): analytics-keys Secret (Amplitude/Bugsnag), configmap-editor-role Role, vJailbreak UI Deployment (image_builder/deploy/01ui.yaml), migration-system Kubernetes Namespace, NetworkMapping Custom Resource, OpenstackCreds Custom Resource, version-checker-binding RoleBinding, vjailbreak-version-checker CronJob (+8 more)
 
-### Community 220 - "Controller Component"
+### Community 43 - "Community 43"
+Cohesion: 0.28
+Nodes (14): Remove-ControlPanelEntry(), Remove-DriverStore(), Remove-VMwareDevices(), Remove-VMwareDrivers(), Remove-VMwareFolderAggressive(), Remove-VMwareFolders(), Remove-VMwarePnPDevicesAggressive(), Remove-VMwareRegistry() (+6 more)
+
+### Community 44 - "Community 44"
+Cohesion: 0.13
+Nodes (14): Code of Conduct, Code Review Process, code:bash (git clone https://github.com/platform9/vjailbreak.git), code:bash (go mod download), code:bash (make build), code:bash (make test), Contributing to vJailbreak, Development Setup (+6 more)
+
+### Community 45 - "Community 45"
 Cohesion: 0.13
 Nodes (14): After CRD Changes, Developer Quickstart: Hot-Add Proxy Migration, Implementation Order, Key File Paths, Modified Files, Module Locations, New Files, Overview (+6 more)
 
-### Community 221 - "Component 221"
+### Community 46 - "Community 46"
 Cohesion: 0.13
 Nodes (14): Decision 10: Go-First SSH Interaction Principle, Decision 11: Cold-Only Constraint for HotAdd, Decision 12: Migration Phase Tracking, Decision 1: ProxyVM as a First-Class CRD, Decision 2: Extend StorageCopyMethod Enum, Decision 3: New v2v-helper File `hotadd_copy.go`, Decision 4: SSH Access Strategy for ProxyVM, Decision 5: Port Allocation for qemu-nbd (+6 more)
 
-### Community 222 - "Controller Component"
-Cohesion: 0.35
-Nodes (14): aggregateTestScheme(), newMigrationPlan(), newRMP(), TestAggregateAndUpdateMigrationPlanStatuses_AllSucceeded(), TestAggregateAndUpdateMigrationPlanStatuses_BackfillsSpecFromLabel(), TestAggregateAndUpdateMigrationPlanStatuses_IsolatesLabels(), TestAggregateAndUpdateMigrationPlanStatuses_NoPlansFound(), TestAggregateAndUpdateMigrationPlanStatuses_RunningPlan() (+6 more)
-
-### Community 223 - "Component 223"
-Cohesion: 0.37
-Nodes (14): collect_configmaps(), collect_controller_logs(), collect_debug_logs(), collect_migration_logs(), collect_system_info(), collect_v2v_helper_info(), collect_version_info(), create_tarball() (+6 more)
-
-### Community 224 - "Config & Samples"
-Cohesion: 0.13
-Nodes (14): files, .specify/scripts/bash/check-prerequisites.sh, .specify/scripts/bash/common.sh, .specify/scripts/bash/create-new-feature.sh, .specify/scripts/bash/setup-plan.sh, .specify/scripts/bash/setup-tasks.sh, .specify/templates/checklist-template.md, .specify/templates/constitution-template.md (+6 more)
-
-### Community 225 - "VMware Component"
-Cohesion: 0.13
-Nodes (15): auth, oauth2, description, description, description, description, description, description (+7 more)
-
-### Community 226 - "Config & Samples"
+### Community 47 - "Community 47"
 Cohesion: 0.14
-Nodes (13): files, .claude/skills/speckit-analyze/SKILL.md, .claude/skills/speckit-checklist/SKILL.md, .claude/skills/speckit-clarify/SKILL.md, .claude/skills/speckit-constitution/SKILL.md, .claude/skills/speckit-implement/SKILL.md, .claude/skills/speckit-plan/SKILL.md, .claude/skills/speckit-specify/SKILL.md (+5 more)
+Nodes (10): Disk, GPUInfo, GuestNetwork, NIC, OpenStackVolumeRefInfo, VMInfo, VMwareMachine, VMwareMachineList (+2 more)
 
-### Community 227 - "Component 227"
+### Community 48 - "Community 48"
+Cohesion: 0.25
+Nodes (5): generateRandomString(), IsRunningInPod(), NewReporter(), Reporter, ReporterOps
+
+### Community 49 - "Community 49"
+Cohesion: 0.18
+Nodes (4): ExamplepbNumericEnum, MessagePathEnumNestedPathEnum, PathenumPathEnum, unmarshalJSONEnum()
+
+### Community 50 - "Community 50"
 Cohesion: 0.14
-Nodes (13): dependencies, dayjs, @emotion/react, @emotion/styled, @mui/icons-material, @mui/material, @mui/x-date-pickers, react (+5 more)
+Nodes (12): Baseline tooling, code:bash (make setup-hooks), code:bash (yarn), code:bash (make lint), code:bash (make test), code:bash (go test ./...), Commit guidance, Common commands (+4 more)
 
-### Community 228 - "Controller Component"
-Cohesion: 0.24
-Nodes (8): BMConfigReconciler, BMConfigScope, Client, Context, Manager, Request, Result, Scheme
+### Community 51 - "Community 51"
+Cohesion: 0.14
+Nodes (12): Assumptions, Edge Cases, Feature Specification: Agent Node Custom Host Entries, Functional Requirements, Key Entities, Measurable Outcomes, Requirements *(mandatory)*, Success Criteria *(mandatory)* (+4 more)
 
-### Community 229 - "Component 229"
-Cohesion: 0.27
-Nodes (11): migrationLogInfo, AddDebugOutputToFile(), AddDebugOutputToFileWithCommand(), CleanupMigrationLogs(), CloseLogFile(), ParseFraction(), RunCommandWithLogFile(), RunCommandWithLogFileRedacted() (+3 more)
+### Community 52 - "Community 52"
+Cohesion: 0.15
+Nodes (10): HostConfig, OpenstackCreds, OpenStackCredsInfo, OpenstackCredsList, OpenstackCredsSpec, OpenstackCredsStatus, OpenstackInfo, PCDNetworkInfo (+2 more)
 
-### Community 230 - "Component 230"
+### Community 53 - "Community 53"
+Cohesion: 0.15
+Nodes (12): assignHypervisor, bundle, Cluster, Config, Extensions, ExtensionsData, InterfaceAddress, InterfaceDetails (+4 more)
+
+### Community 54 - "Community 54"
+Cohesion: 0.15
+Nodes (12): ABitOfEverythingServiceCheckGetQueryParamsOpts, ABitOfEverythingServiceCheckNestedEnumGetQueryParamsOpts, ABitOfEverythingServiceCheckPostQueryParamsOpts, ABitOfEverythingServiceCreateBookOpts, ABitOfEverythingServiceCreateOpts, ABitOfEverythingServiceCustomOptionsRequestOpts, ABitOfEverythingServiceCustomOpts, ABitOfEverythingServiceDoubleColonOpts (+4 more)
+
+### Community 55 - "Community 55"
 Cohesion: 0.15
 Nodes (12): Assumptions, Edge Cases, Feature Specification: [FEATURE NAME], Functional Requirements, Key Entities *(include if feature involves data)*, Measurable Outcomes, Requirements *(mandatory)*, Success Criteria *(mandatory)* (+4 more)
 
-### Community 231 - "VMware Component"
-Cohesion: 0.24
-Nodes (10): ListMeta, LocalObjectReference, ObjectMeta, Time, TypeMeta, ProxyVM, ProxyVMComponentCheck, ProxyVMList (+2 more)
+### Community 56 - "Community 56"
+Cohesion: 0.17
+Nodes (10): ArrayCreds, ArrayCredsInfo, ArrayCredsList, ArrayCredsSpec, ArrayCredsStatus, BackendTarget, BackendTargetGroup, DatastoreInfo (+2 more)
 
-### Community 232 - "Utilities"
+### Community 57 - "Community 57"
+Cohesion: 0.18
+Nodes (4): NewBMConfigScope(), BMConfigReconciler, BMConfigScope, BMConfigScopeParams
+
+### Community 58 - "Community 58"
+Cohesion: 0.23
+Nodes (7): APIResponse, APIResponse, APIResponse, NewAPIResponse(), NewAPIResponseWithError(), APIResponse, APIResponse
+
+### Community 59 - "Community 59"
 Cohesion: 0.17
 Nodes (11): Core Principles, Critical Requirements, Governance, I. Kubernetes-Native Architecture, II. External Documentation First, III. Generated Code Protection (NON-NEGOTIABLE), IV. Test-First Development (NON-NEGOTIABLE), V. Module Independence (+3 more)
 
-### Community 233 - "Component 233"
-Cohesion: 0.20
-Nodes (3): _extract_highest_number(), get_highest_from_branches(), create-new-feature.sh script
+### Community 60 - "Community 60"
+Cohesion: 0.18
+Nodes (9): AdvancedOptions, MigrationPlan, MigrationPlanList, MigrationPlanSpec, MigrationPlanSpecPerVM, MigrationPlanStatus, MigrationPlanStrategy, NICOverride (+1 more)
 
-### Community 234 - "VMware Component"
+### Community 61 - "Community 61"
+Cohesion: 0.58
+Nodes (9): aggregateTestScheme(), newMigrationPlan(), newRMP(), TestAggregateAndUpdateMigrationPlanStatuses_AllSucceeded(), TestAggregateAndUpdateMigrationPlanStatuses_BackfillsSpecFromLabel(), TestAggregateAndUpdateMigrationPlanStatuses_IsolatesLabels(), TestAggregateAndUpdateMigrationPlanStatuses_NoPlansFound(), TestAggregateAndUpdateMigrationPlanStatuses_RunningPlan() (+1 more)
+
+### Community 62 - "Community 62"
+Cohesion: 0.18
+Nodes (10): EchoServiceEcho2Opts, EchoServiceEcho3Opts, EchoServiceEcho4Opts, EchoServiceEcho5Opts, EchoServiceEcho6Opts, EchoServiceEcho7Opts, EchoServiceEchoBody2Opts, EchoServiceEchoDeleteOpts (+2 more)
+
+### Community 63 - "Community 63"
+Cohesion: 0.18
+Nodes (9): code:go (func reprovisionAllowed(activeMigrations []string) bool), Decision 1: Host Entries Storage Location, Decision 2: No New Files in `k8s/migration` — Use `pkg/common/utils/`, Decision 3: Cloud-init Injection — `BuildUserData` in `pkg/common/utils/hosts.go`, Decision 4: Interface-First + TDD (Constitution Principle IV), Decision 5: `pkg/common/constants` — Add One Constant, Decision 6: Reprovision Mechanism, Decision 7: Module Boundary for Vendor Copies (+1 more)
+
+### Community 64 - "Community 64"
+Cohesion: 0.18
+Nodes (9): Content Quality, Feature Readiness, Notes, Requirement Completeness, Specification Quality Checklist: Agent Node Custom Host Entries, Content Quality, Feature Readiness, Notes (+1 more)
+
+### Community 65 - "Community 65"
 Cohesion: 0.18
 Nodes (10): ConfigMap contract (v2v-helper), CRD Contracts: Hot-Add Proxy Migration, Hot-Add example, kubectl columns (printer columns), kubectl examples, Modified CRD: MigrationTemplate, New CRD: ProxyVM, REST API (UI ↔ backend) (+2 more)
 
-### Community 235 - "RBAC Manifests"
-Cohesion: 0.25
-Nodes (7): BMConfig, BMConfigScope, Client, Logger, BMConfigScope, NewBMConfigScope(), BMConfigScopeParams
-
-### Community 236 - "Config & Samples"
-Cohesion: 0.25
-Nodes (7): Client, Logger, MigrationPlan, MigrationPlanScope, MigrationPlanScope, NewMigrationPlanScope(), MigrationPlanScopeParams
-
-### Community 237 - "Test Utilities"
-Cohesion: 0.25
-Nodes (7): Client, Logger, VMwareCreds, VMwareCredsScope, VMwareCredsScope, NewVMwareCredsScope(), VMwareCredsScopeParams
-
-### Community 238 - "Controller Component"
+### Community 66 - "Community 66"
 Cohesion: 0.18
 Nodes (10): Core Principles, Governance, [PRINCIPLE_1_NAME], [PRINCIPLE_2_NAME], [PRINCIPLE_3_NAME], [PRINCIPLE_4_NAME], [PRINCIPLE_5_NAME], [PROJECT_NAME] Constitution (+2 more)
 
-### Community 239 - "Component 239"
-Cohesion: 0.20
+### Community 67 - "Community 67"
+Cohesion: 0.38
+Nodes (8): GetProjectDir(), InstallCertManager(), InstallPrometheusOperator(), LoadImageToKindClusterWithName(), Run(), UninstallCertManager(), UninstallPrometheusOperator(), warnError()
+
+### Community 68 - "Community 68"
+Cohesion: 0.2
+Nodes (8): ClusterMapping, ClusterMigrationInfo, RollingMigrationPlan, RollingMigrationPlanList, RollingMigrationPlanPhase, RollingMigrationPlanSpec, RollingMigrationPlanStatus, VMSequenceInfo
+
+### Community 69 - "Community 69"
+Cohesion: 0.31
+Nodes (6): RoundTripFunc, NewTestClient(), TestGetEndpointForRegion(), TestGetServiceID(), Equals(), Ok()
+
+### Community 70 - "Community 70"
+Cohesion: 0.38
+Nodes (9): Ensure-64BitPowerShell(), Get-Script(), Init-Table(), Pop-Script(), Push-Script(), Remove-MyTask(), Schedule-MyTask(), Script-Runner() (+1 more)
+
+### Community 71 - "Community 71"
+Cohesion: 0.2
 Nodes (9): Commands, Configuration, Disabling, Git Branching Workflow Extension, Graceful Degradation, Hooks, Installation, Overview (+1 more)
 
-### Community 240 - "Component 240"
-Cohesion: 0.27
-Nodes (10): Network, OpenStackClients, Port, VjailbreakNodeScope, boolPtr(), CreateOpenstackVMForWorkerNode(), createPortForL2Network(), GetCurrentInstanceNetworkInfo() (+2 more)
+### Community 72 - "Community 72"
+Cohesion: 0.24
+Nodes (10): MigrationPlan Editor ClusterRole, MigrationPlan Instance (vm-migration-sample), MigrationTemplate Editor ClusterRole, MigrationTemplate Instance (migration-template-sample), NetworkMapping Instance (nwmap1), OpenstackCreds Instance (sapmo1), StorageMapping Instance (stmap1), StorageMapping Viewer ClusterRole (+2 more)
 
-### Community 241 - "Controller Component"
-Cohesion: 0.31
-Nodes (6): DetectAndHandleNetwork(), isNetplanSupported(), parseVersionID(), MigrationTimes, NICOverride, Time
+### Community 73 - "Community 73"
+Cohesion: 0.22
+Nodes (6): init(), init(), IronicProvider, init(), MaasAccessInfo, RegisterProvider()
 
-### Community 242 - "PCD Integration"
-Cohesion: 0.20
-Nodes (9): invoke_separator, script, default_integration, installed_integrations, integration, integration_settings, claude, integration_state_schema (+1 more)
-
-### Community 243 - "Component 243"
-Cohesion: 0.20
-Nodes (9): schema_version, description, installed_at, name, source, updated_at, version, workflows (+1 more)
-
-### Community 244 - "Test Utilities"
-Cohesion: 0.38
-Nodes (9): T, IsSUSEFamily(), mountPersistenceScriptFlag(), TestFixLegacyMkinitrdOnlyForSUSE(), TestIsBareDisk(), TestIsSUSEFamily(), TestMkinitrdLVMWrapperContent(), TestMkinitrdWrapperWritable() (+1 more)
-
-### Community 245 - "Component 245"
+### Community 74 - "Community 74"
 Cohesion: 0.22
 Nodes (8): Branch Numbering Mode, Create Feature Branch, Environment Variable Override, Execution, Graceful Degradation, Output, Prerequisites, User Input
 
-### Community 246 - "Utilities"
+### Community 75 - "Community 75"
 Cohesion: 0.22
 Nodes (8): Branch Numbering Mode, Create Feature Branch, Environment Variable Override, Execution, Graceful Degradation, Output, Prerequisites, User Input
 
-### Community 247 - "Component 247"
-Cohesion: 0.22
-Nodes (8): Bazel, Building, Discussions, Generate gRPC Source Code, Go gRPC Source Code, Google APIs, Overview, Repository Structure
-
-### Community 248 - "Component 248"
-Cohesion: 0.53
-Nodes (8): check_command(), log(), PATH, set_default_password(), wait_for_k3s(), wait_for_k3s_worker(), wait_for_network(), install.sh script
-
-### Community 249 - "Component 249"
-Cohesion: 0.39
-Nodes (6): ArrayCreds, Client, Logger, ArrayCredsScope, NewArrayCredsScope(), ArrayCredsScopeParams
-
-### Community 250 - "Component 250"
-Cohesion: 0.39
-Nodes (7): ConvertTo-CleanBranchName(), Get-BranchName(), Get-HighestNumberFromBranches(), Get-HighestNumberFromNames(), Get-HighestNumberFromRemoteRefs(), Get-HighestNumberFromSpecs(), Get-NextBranchNumber()
-
-### Community 251 - "Component 251"
-Cohesion: 0.22
-Nodes (8): ai, ai_skills, branch_numbering, context_file, here, integration, script, speckit_version
-
-### Community 252 - "Utilities"
-Cohesion: 0.25
-Nodes (3): _extract_highest_number(), get_highest_from_branches(), create-new-feature.sh script
-
-### Community 253 - "Component 253"
+### Community 76 - "Community 76"
 Cohesion: 0.22
 Nodes (8): Complexity Tracking, Constitution Check, Documentation (this feature), Implementation Plan: [FEATURE], Project Structure, Source Code (repository root), Summary, Technical Context
 
-### Community 254 - "Component 254"
+### Community 77 - "Community 77"
 Cohesion: 0.22
-Nodes (9): description, location, type, parameters, key, quotaUser, description, location (+1 more)
+Nodes (8): Bazel, Building, Discussions, Generate gRPC Source Code, Go gRPC Source Code, Google APIs, Overview, Repository Structure
 
-### Community 255 - "Component 255"
+### Community 78 - "Community 78"
+Cohesion: 0.22
+Nodes (9): CoreDNS ServiceMonitor, Node Exporter ClusterRole, Node Exporter ClusterRoleBinding, Node Exporter DaemonSet, Node Exporter NetworkPolicy, Node Exporter PrometheusRule (node-exporter-rules), Node Exporter Service, Node Exporter ServiceAccount (+1 more)
+
+### Community 79 - "Community 79"
+Cohesion: 0.25
+Nodes (6): BMConfig, BMConfigList, BMConfigSpec, BMConfigStatus, BMCProviderName, BootSource
+
+### Community 80 - "Community 80"
 Cohesion: 0.25
 Nodes (7): Anti-Examples: What NOT To Do, Checklist Purpose: "Unit Tests for English", Example Checklist Types & Sample Items, Execution Steps, Post-Execution Checks, Pre-Execution Checks, User Input
 
-### Community 256 - "Component 256"
+### Community 81 - "Community 81"
 Cohesion: 0.25
 Nodes (7): Key rules, Outline, Phase 0: Outline & Research, Phase 1: Design & Contracts, Phases, Pre-Execution Checks, User Input
 
-### Community 257 - "Component 257"
+### Community 82 - "Community 82"
 Cohesion: 0.25
 Nodes (7): For AI Generation, Outline, Pre-Execution Checks, Quick Guidelines, Section Requirements, Success Criteria Guidelines, User Input
 
-### Community 258 - "Config & Samples"
+### Community 83 - "Community 83"
 Cohesion: 0.25
 Nodes (7): Checklist Format (REQUIRED), Outline, Phase Structure, Pre-Execution Checks, Task Generation Rules, Task Organization, User Input
 
-### Community 259 - "Test Utilities"
+### Community 84 - "Community 84"
 Cohesion: 0.25
 Nodes (7): Architecture, Check, Managed services, Next steps, Operations, Report, Why use Service Control?
 
-### Community 260 - "Controller Component"
-Cohesion: 0.25
-Nodes (8): description, properties, type, description, items, type, error, errors
+### Community 85 - "Community 85"
+Cohesion: 0.32
+Nodes (8): BMConfig CRD, ClusterMigration CRD, ESXIMigration CRD, PCDCluster CRD, PCDHost CRD, RollingMigrationPlan CRD, VMwareCluster CRD, VMwareHost CRD
 
-### Community 261 - "Controller Component"
+### Community 86 - "Community 86"
+Cohesion: 0.29
+Nodes (5): ArrayCredsMapping, ArrayCredsMappingList, ArrayCredsMappingSpec, ArrayCredsMappingStatus, DatastoreArrayCredsMapping
+
+### Community 87 - "Community 87"
+Cohesion: 0.29
+Nodes (5): ProxyVM, ProxyVMComponentCheck, ProxyVMList, ProxyVMSpec, ProxyVMStatus
+
+### Community 88 - "Community 88"
+Cohesion: 0.29
+Nodes (5): VjailbreakNode, VjailbreakNodeList, VjailbreakNodePhase, VjailbreakNodeSpec, VjailbreakNodeStatus
+
+### Community 89 - "Community 89"
+Cohesion: 0.29
+Nodes (5): MigrationTemplate, MigrationTemplateDestination, MigrationTemplateList, MigrationTemplateSource, MigrationTemplateSpec
+
+### Community 90 - "Community 90"
+Cohesion: 0.29
+Nodes (5): Storage, StorageMapping, StorageMappingList, StorageMappingSpec, StorageMappingStatus
+
+### Community 91 - "Community 91"
+Cohesion: 0.29
+Nodes (5): PCDHost, PCDHostInterface, PCDHostList, PCDHostSpec, PCDHostStatus
+
+### Community 92 - "Community 92"
+Cohesion: 0.29
+Nodes (5): VMwareCluster, VMwareClusterList, VMwareClusterPhase, VMwareClusterSpec, VMwareClusterStatus
+
+### Community 93 - "Community 93"
+Cohesion: 0.29
+Nodes (5): Network, NetworkMapping, NetworkMappingList, NetworkMappingSpec, NetworkMappingStatus
+
+### Community 94 - "Community 94"
+Cohesion: 0.29
+Nodes (5): ESXIMigration, ESXIMigrationList, ESXIMigrationPhase, ESXIMigrationSpec, ESXIMigrationStatus
+
+### Community 95 - "Community 95"
+Cohesion: 0.29
+Nodes (5): OpenstackVolumeRef, RDMDisk, RDMDiskList, RDMDiskSpec, RDMDiskStatus
+
+### Community 96 - "Community 96"
+Cohesion: 0.29
+Nodes (5): VMwareCreds, VMwareCredsInfo, VMwareCredsList, VMwareCredsSpec, VMwareCredsStatus
+
+### Community 97 - "Community 97"
+Cohesion: 0.29
+Nodes (5): ClusterMigration, ClusterMigrationList, ClusterMigrationPhase, ClusterMigrationSpec, ClusterMigrationStatus
+
+### Community 98 - "Community 98"
+Cohesion: 0.29
+Nodes (5): ESXiSSHCreds, ESXiSSHCredsInfo, ESXiSSHCredsList, ESXiSSHCredsSpec, ESXiSSHCredsStatus
+
+### Community 99 - "Community 99"
+Cohesion: 0.29
+Nodes (4): APIKey, BasicAuth, Configuration, contextKey
+
+### Community 100 - "Community 100"
+Cohesion: 0.29
+Nodes (4): APIKey, BasicAuth, Configuration, contextKey
+
+### Community 101 - "Community 101"
+Cohesion: 0.29
+Nodes (4): APIKey, BasicAuth, Configuration, contextKey
+
+### Community 102 - "Community 102"
+Cohesion: 0.29
+Nodes (4): APIKey, BasicAuth, Configuration, contextKey
+
+### Community 103 - "Community 103"
 Cohesion: 0.29
 Nodes (6): Data Model, Deletion, Overview, Publisher Flow, Reliability Semantics, Subscriber Flow
 
-### Community 262 - "Controller Component"
-Cohesion: 0.29
-Nodes (7): default, description, enum, enumDescriptions, location, type, alt
-
-### Community 263 - "Controller Component"
+### Community 104 - "Community 104"
 Cohesion: 0.33
-Nodes (5): API Protos, Authentication, Documentation, HTTP and REST, Using these protos
+Nodes (4): VMwareHost, VMwareHostList, VMwareHostSpec, VMwareHostStatus
 
-### Community 264 - "Controller Component"
+### Community 105 - "Community 105"
+Cohesion: 0.33
+Nodes (4): PCDCluster, PCDClusterList, PCDClusterSpec, PCDClusterStatus
+
+### Community 106 - "Community 106"
+Cohesion: 0.33
+Nodes (5): DatastoreInfo, DiskInfo, ESXiCredentials, StorageDeviceInfo, VMInfo
+
+### Community 107 - "Community 107"
+Cohesion: 0.33
+Nodes (4): APIKey, BasicAuth, Configuration, contextKey
+
+### Community 108 - "Community 108"
 Cohesion: 0.33
 Nodes (5): Specification Quality Checklist: Hot-Add Proxy Migration, Content Quality, Feature Readiness, Notes, Requirement Completeness
 
-### Community 265 - "Controller Component"
-Cohesion: 0.33
-Nodes (5): Auto-Commit Changes, Behavior, Configuration, Execution, Graceful Degradation
-
-### Community 266 - "Controller Component"
-Cohesion: 0.33
-Nodes (5): Customization, Execution, Graceful Degradation, Initialize Git Repository, Output
-
-### Community 267 - "Controller Component"
+### Community 109 - "Community 109"
 Cohesion: 0.33
 Nodes (5): Detect Git Remote URL, Execution, Graceful Degradation, Output, Prerequisites
 
-### Community 268 - "Controller Component"
+### Community 110 - "Community 110"
 Cohesion: 0.33
 Nodes (5): Execution, Graceful Degradation, Prerequisites, Validate Feature Branch, Validation Rules
 
-### Community 269 - "CRD API Types"
-Cohesion: 0.33
-Nodes (5): Auto-Commit Changes, Behavior, Configuration, Execution, Graceful Degradation
-
-### Community 270 - "CRD API Types"
+### Community 111 - "Community 111"
 Cohesion: 0.33
 Nodes (5): Customization, Execution, Graceful Degradation, Initialize Git Repository, Output
 
-### Community 271 - "Component 271"
+### Community 112 - "Community 112"
+Cohesion: 0.33
+Nodes (5): Auto-Commit Changes, Behavior, Configuration, Execution, Graceful Degradation
+
+### Community 113 - "Community 113"
 Cohesion: 0.33
 Nodes (5): Detect Git Remote URL, Execution, Graceful Degradation, Output, Prerequisites
 
-### Community 272 - "Component 272"
+### Community 114 - "Community 114"
+Cohesion: 0.33
+Nodes (5): Auto-Commit Changes, Behavior, Configuration, Execution, Graceful Degradation
+
+### Community 115 - "Community 115"
 Cohesion: 0.33
 Nodes (5): Execution, Graceful Degradation, Prerequisites, Validate Feature Branch, Validation Rules
 
-### Community 273 - "Component 273"
-Cohesion: 0.60
-Nodes (5): main(), update_python_versions(), use_map_namespace(), use_markdown_readme(), postprocessing_py.sh script
+### Community 116 - "Community 116"
+Cohesion: 0.33
+Nodes (5): Customization, Execution, Graceful Degradation, Initialize Git Repository, Output
 
-### Community 274 - "Component 274"
+### Community 117 - "Community 117"
+Cohesion: 0.33
+Nodes (5): API Protos, Authentication, Documentation, HTTP and REST, Using these protos
+
+### Community 118 - "Community 118"
 Cohesion: 0.33
 Nodes (5): Managed services, Service configuration, Service consumers, Service producers, Service rollout
 
-### Community 275 - "Component 275"
+### Community 119 - "Community 119"
 Cohesion: 0.33
-Nodes (5): apiVersion, converterVersion, discoveryRevision, inlineSchemas, updateTime
+Nodes (6): Blackbox Exporter ClusterRole, Blackbox Exporter ClusterRoleBinding, Blackbox Exporter Configuration ConfigMap, Blackbox Exporter NetworkPolicy, Blackbox Exporter Service, Blackbox Exporter ServiceAccount
 
-### Community 276 - "Component 276"
-Cohesion: 0.33
-Nodes (6): required, annotations, description, pattern, type, name
+### Community 120 - "Community 120"
+Cohesion: 0.4
+Nodes (3): VolumeImageProfile, VolumeImageProfileList, VolumeImageProfileSpec
 
-### Community 277 - "Component 277"
-Cohesion: 0.50
-Nodes (4): AuthRequestAuth, AuthRequest, Credentials, credentialsToKeystoneAuthRequest()
-
-### Community 279 - "Component 279"
-Cohesion: 0.40
+### Community 121 - "Community 121"
+Cohesion: 0.4
 Nodes (4): Outline, Post-Execution Checks, Pre-Execution Checks, User Input
 
-### Community 280 - "Component 280"
-Cohesion: 0.40
+### Community 122 - "Community 122"
+Cohesion: 0.4
 Nodes (4): Outline, Post-Execution Checks, Pre-Execution Checks, User Input
 
-### Community 281 - "Component 281"
-Cohesion: 0.40
+### Community 123 - "Community 123"
+Cohesion: 0.4
 Nodes (4): Outline, Post-Execution Checks, Pre-Execution Checks, User Input
 
-### Community 282 - "VMware Component"
-Cohesion: 0.40
-Nodes (3): initProvider(), populateBMCredsFromCMD(), Command
-
-### Community 283 - "Component 283"
-Cohesion: 0.40
+### Community 124 - "Community 124"
+Cohesion: 0.4
 Nodes (4): Special notes for your reviewer, Testing done, What this PR does / why we need it, Which issue(s) this PR fixes
 
-### Community 284 - "Community 284"
-Cohesion: 0.40
-Nodes (4): Additional note, How to contribute, Legal requirements, Technical requirements
-
-### Community 286 - "Community 286"
-Cohesion: 0.70
-Nodes (4): add_gradle_publish(), change_group(), main(), postprocessing_java.sh script
-
-### Community 287 - "Community 287"
-Cohesion: 0.70
-Nodes (4): add_gradle_publish(), change_group(), main(), postprocessing_python.sh script
-
-### Community 288 - "Community 288"
-Cohesion: 0.60
-Nodes (3): fix_grub_config(), print_help(), generate-mount-persistence.sh script
-
-### Community 289 - "Community 289"
-Cohesion: 0.40
+### Community 125 - "Community 125"
+Cohesion: 0.4
 Nodes (4): [Category 1], [Category 2], [CHECKLIST TYPE] Checklist: [FEATURE NAME], Notes
 
-### Community 290 - "Community 290"
-Cohesion: 0.40
-Nodes (5): description, enum, enumDescriptions, type, ipVersion
+### Community 126 - "Community 126"
+Cohesion: 0.4
+Nodes (4): Additional note, How to contribute, Legal requirements, Technical requirements
 
-### Community 291 - "Community 291"
-Cohesion: 0.40
-Nodes (5): prettyPrint, default, description, location, type
+### Community 128 - "Community 128"
+Cohesion: 0.5
+Nodes (3): Appliance VM, code:bash (vagrant up), Quickstart
 
-### Community 292 - "Community 292"
-Cohesion: 0.40
-Nodes (5): status, description, enum, enumDescriptions, type
-
-### Community 293 - "Community 293"
-Cohesion: 0.50
-Nodes (3): Documentation, Google App Engine Admin API, Overview
-
-### Community 294 - "Community 294"
-Cohesion: 0.50
-Nodes (3): hooks, PreToolUse, Stop
-
-### Community 295 - "Community 295"
-Cohesion: 0.50
+### Community 129 - "Community 129"
+Cohesion: 0.5
 Nodes (3): Outline, Pre-Execution Checks, User Input
 
-### Community 296 - "Community 296"
-Cohesion: 0.50
+### Community 130 - "Community 130"
+Cohesion: 0.5
+Nodes (3): Documentation, Google App Engine Admin API, Overview
+
+### Community 131 - "Community 131"
+Cohesion: 0.5
 Nodes (3): IAM (Identity and Access Management) Protos, Key Concepts, Key Service definitions
 
-### Community 297 - "Community 297"
-Cohesion: 1.00
-Nodes (3): log(), stop_and_disable_service(), vmware-tools-cleanup.sh script
-
-### Community 298 - "Community 298"
-Cohesion: 0.50
-Nodes (3): IsSimpleNetwork(), Context, ServiceClient
-
-### Community 299 - "Community 299"
-Cohesion: 0.50
+### Community 132 - "Community 132"
+Cohesion: 0.5
 Nodes (3): Details, Introduction, Setup
 
+### Community 133 - "Community 133"
+Cohesion: 0.5
+Nodes (4): Addons Kustomization, CRD Kustomize Config, Migration Controller README, vpwned-sdk Addon Deployment and Service
+
+### Community 134 - "Community 134"
+Cohesion: 0.83
+Nodes (4): vpwned-sdk Kubernetes Deployment, vpwned-ingress Nginx Ingress (path: /dev-api/sdk/), vpwned-service Kubernetes ClusterIP Service, vpwned Kubernetes Namespace
+
+### Community 135 - "Community 135"
+Cohesion: 1.0
+Nodes (2): Remove-StaleNetworkAdapter(), Write-Log()
+
+### Community 137 - "Community 137"
+Cohesion: 0.67
+Nodes (2): Release notes, Tasks
+
+### Community 138 - "Community 138"
+Cohesion: 0.67
+Nodes (2): Build files (experimental), Google Ads API
+
+### Community 139 - "Community 139"
+Cohesion: 0.67
+Nodes (2): API v1 Shutdown, Migrating to v2
+
+### Community 140 - "Community 140"
+Cohesion: 0.67
+Nodes (2): Long-running Operations API, Operation
+
+### Community 141 - "Community 141"
+Cohesion: 0.67
+Nodes (2): Key Concepts, RPC (Remote Procedure Call) Types
+
+### Community 142 - "Community 142"
+Cohesion: 0.67
+Nodes (2): Key Concepts, Logging types
+
+### Community 143 - "Community 143"
+Cohesion: 0.67
+Nodes (3): selfsigned-issuer ClusterIssuer, vjailbreak-ca Certificate, vjailbreak-ca-issuer ClusterIssuer
+
+### Community 144 - "Community 144"
+Cohesion: 0.67
+Nodes (3): sync-daemon DaemonSet, virtio-win Drivers, VMware VIX DiskLib (VDDK) Libraries
+
+### Community 145 - "Community 145"
+Cohesion: 1.0
+Nodes (3): KubeStateMetrics ClusterRole, KubeStateMetrics Exporter Service, KubeStateMetrics ServiceMonitor
+
+### Community 146 - "Community 146"
+Cohesion: 0.67
+Nodes (3): vJailbreak Functional/Software Requirements Specification Template, Migration Sample CR, MigrationPlan Sample CR
+
+### Community 149 - "Community 149"
+Cohesion: 1.0
+Nodes (1): ESXiOperations
+
+### Community 151 - "Community 151"
+Cohesion: 1.0
+Nodes (1): VjailbreakSettings
+
+### Community 155 - "Community 155"
+Cohesion: 1.0
+Nodes (1): UpgradeProgress
+
+### Community 157 - "Community 157"
+Cohesion: 1.0
+Nodes (1): Generator
+
+### Community 158 - "Community 158"
+Cohesion: 1.0
+Nodes (1): RpcStatus
+
+### Community 159 - "Community 159"
+Cohesion: 1.0
+Nodes (1): ProtobufAny
+
+### Community 160 - "Community 160"
+Cohesion: 1.0
+Nodes (1): RuntimeError
+
+### Community 161 - "Community 161"
+Cohesion: 1.0
+Nodes (1): ExamplepbGenerateUnboundMethodsSimpleMessage
+
+### Community 162 - "Community 162"
+Cohesion: 1.0
+Nodes (1): ABitOfEverythingNested
+
+### Community 163 - "Community 163"
+Cohesion: 1.0
+Nodes (1): ABitOfEverythingServiceDeepPathEchoBody
+
+### Community 164 - "Community 164"
+Cohesion: 1.0
+Nodes (1): ExamplepbErrorResponse
+
+### Community 165 - "Community 165"
+Cohesion: 1.0
+Nodes (1): ABitOfEverything4
+
+### Community 166 - "Community 166"
+Cohesion: 1.0
+Nodes (1): ExamplepbABitOfEverythingServiceUpdateBody
+
+### Community 167 - "Community 167"
+Cohesion: 1.0
+Nodes (1): ExamplepbCheckStatusResponse
+
+### Community 168 - "Community 168"
+Cohesion: 1.0
+Nodes (1): ABitOfEverything5
+
+### Community 169 - "Community 169"
+Cohesion: 1.0
+Nodes (1): ABitOfEverythingServiceUpdateBody
+
+### Community 170 - "Community 170"
+Cohesion: 1.0
+Nodes (1): ABitOfEverything1
+
+### Community 171 - "Community 171"
+Cohesion: 1.0
+Nodes (1): UpdateV2RequestRequestForUpdateIncludesTheMessageAndTheUpdateMask
+
+### Community 172 - "Community 172"
+Cohesion: 1.0
+Nodes (1): RpcStatus
+
+### Community 173 - "Community 173"
+Cohesion: 1.0
+Nodes (1): V1exampledeepPathsingleNestedNameSingleNested
+
+### Community 174 - "Community 174"
+Cohesion: 1.0
+Nodes (1): NestedDeepEnum
+
+### Community 175 - "Community 175"
+Cohesion: 1.0
+Nodes (1): ExamplepbABitOfEverythingRepeated
+
+### Community 176 - "Community 176"
+Cohesion: 1.0
+Nodes (1): TheBookToUpdate_
+
+### Community 177 - "Community 177"
+Cohesion: 1.0
+Nodes (1): ABitOfEverything
+
+### Community 178 - "Community 178"
+Cohesion: 1.0
+Nodes (1): ProtoexamplepbFoo
+
+### Community 179 - "Community 179"
+Cohesion: 1.0
+Nodes (1): ExamplepbBook
+
+### Community 180 - "Community 180"
+Cohesion: 1.0
+Nodes (1): PathenumsnakeCaseForImport
+
+### Community 181 - "Community 181"
+Cohesion: 1.0
+Nodes (1): SubStringMessage
+
+### Community 182 - "Community 182"
+Cohesion: 1.0
+Nodes (1): ExamplepbBar
+
+### Community 183 - "Community 183"
+Cohesion: 1.0
+Nodes (1): ABitOfEverything8
+
+### Community 184 - "Community 184"
+Cohesion: 1.0
+Nodes (1): UpdateV2RequestRequestForUpdateIncludesTheMessageAndTheUpdateMask1
+
+### Community 185 - "Community 185"
+Cohesion: 1.0
+Nodes (1): OneofenumExampleEnum
+
+### Community 186 - "Community 186"
+Cohesion: 1.0
+Nodes (1): ExamplepbRequiredMessageTypeRequest
+
+### Community 187 - "Community 187"
+Cohesion: 1.0
+Nodes (1): ABitOfEverythingServiceUpdateV2Body
+
+### Community 188 - "Community 188"
+Cohesion: 1.0
+Nodes (1): TheBookToUpdateTheBooksNameFieldIsUsedToIdentifyTheBookToBeUpdatedFormatPublisherspublisherbooksbook
+
+### Community 189 - "Community 189"
+Cohesion: 1.0
+Nodes (1): ExamplepbFoo
+
+### Community 190 - "Community 190"
+Cohesion: 1.0
+Nodes (1): ABitOfEverythingServiceDeepPathEchoBodySingleNested
+
+### Community 191 - "Community 191"
+Cohesion: 1.0
+Nodes (1): ABitOfEverything6
+
+### Community 192 - "Community 192"
+Cohesion: 1.0
+Nodes (1): TheBookToUpdate1
+
+### Community 193 - "Community 193"
+Cohesion: 1.0
+Nodes (1): ABitOfEverythingServicePostWithEmptyBodyBody
+
+### Community 194 - "Community 194"
+Cohesion: 1.0
+Nodes (1): ExamplepbErrorObject
+
+### Community 195 - "Community 195"
+Cohesion: 1.0
+Nodes (1): ExamplepbSnakeEnumResponse
+
+### Community 196 - "Community 196"
+Cohesion: 1.0
+Nodes (1): ABitOfEverything2
+
+### Community 197 - "Community 197"
+Cohesion: 1.0
+Nodes (1): ExamplepbsnakeCase0Enum
+
+### Community 198 - "Community 198"
+Cohesion: 1.0
+Nodes (1): ExamplepbABitOfEverything
+
+### Community 199 - "Community 199"
+Cohesion: 1.0
+Nodes (1): ExamplepbBody
+
+### Community 200 - "Community 200"
+Cohesion: 1.0
+Nodes (1): ExamplepbsnakeCaseEnum
+
+### Community 201 - "Community 201"
+Cohesion: 1.0
+Nodes (1): ABitOfEverything3
+
+### Community 202 - "Community 202"
+Cohesion: 1.0
+Nodes (1): Book
+
+### Community 203 - "Community 203"
+Cohesion: 1.0
+Nodes (1): ProtobufAny
+
+### Community 204 - "Community 204"
+Cohesion: 1.0
+Nodes (1): ABitOfEverything7
+
+### Community 205 - "Community 205"
+Cohesion: 1.0
+Nodes (1): ExamplepbUnannotatedSimpleMessage
+
+### Community 206 - "Community 206"
+Cohesion: 1.0
+Nodes (1): RpcStatus
+
+### Community 207 - "Community 207"
+Cohesion: 1.0
+Nodes (1): ExamplepbNumericEnum
+
+### Community 208 - "Community 208"
+Cohesion: 1.0
+Nodes (1): ExamplepbUnannotatedEmbedded
+
+### Community 209 - "Community 209"
+Cohesion: 1.0
+Nodes (1): ExamplepbUnannotatedNestedMessage
+
+### Community 210 - "Community 210"
+Cohesion: 1.0
+Nodes (1): ProtobufAny
+
+### Community 211 - "Community 211"
+Cohesion: 1.0
+Nodes (1): ExamplepbDynamicMessageUpdate
+
+### Community 212 - "Community 212"
+Cohesion: 1.0
+Nodes (1): ExamplepbSimpleMessage
+
+### Community 213 - "Community 213"
+Cohesion: 1.0
+Nodes (1): RpcStatus
+
+### Community 214 - "Community 214"
+Cohesion: 1.0
+Nodes (1): ExamplepbEmbedded
+
+### Community 215 - "Community 215"
+Cohesion: 1.0
+Nodes (1): ProtobufNullValue
+
+### Community 216 - "Community 216"
+Cohesion: 1.0
+Nodes (1): ExamplepbDynamicMessage
+
+### Community 217 - "Community 217"
+Cohesion: 1.0
+Nodes (1): ExamplepbNestedMessage
+
+### Community 218 - "Community 218"
+Cohesion: 1.0
+Nodes (1): ProtobufAny
+
+### Community 219 - "Community 219"
+Cohesion: 1.0
+Nodes (1): ExamplepbRepeatedResponseBodyOutResponse
+
+### Community 220 - "Community 220"
+Cohesion: 1.0
+Nodes (1): ExamplepbResponseBodyValue
+
+### Community 221 - "Community 221"
+Cohesion: 1.0
+Nodes (1): ResponseResponseType
+
+### Community 222 - "Community 222"
+Cohesion: 1.0
+Nodes (1): RpcStatus
+
+### Community 223 - "Community 223"
+Cohesion: 1.0
+Nodes (1): ExamplepbRepeatedResponseStrings
+
+### Community 224 - "Community 224"
+Cohesion: 1.0
+Nodes (1): ExamplepbRepeatedResponseBodyOut
+
+### Community 225 - "Community 225"
+Cohesion: 1.0
+Nodes (1): ExamplepbResponseBodyOutResponse
+
+### Community 226 - "Community 226"
+Cohesion: 1.0
+Nodes (1): ExamplepbResponseBodyOut
+
+### Community 227 - "Community 227"
+Cohesion: 1.0
+Nodes (1): StreamResultOfExamplepbResponseBodyOut
+
+### Community 228 - "Community 228"
+Cohesion: 1.0
+Nodes (1): ProtobufAny
+
+### Community 230 - "Community 230"
+Cohesion: 1.0
+Nodes (1): v2v-helper
+
+### Community 231 - "Community 231"
+Cohesion: 1.0
+Nodes (1): Contributor Code of Conduct
+
+### Community 232 - "Community 232"
+Cohesion: 1.0
+Nodes (1): Security Policy
+
+### Community 233 - "Community 233"
+Cohesion: 1.0
+Nodes (1): Google Data Loss Prevention (DLP) API
+
+### Community 234 - "Community 234"
+Cohesion: 1.0
+Nodes (1): Introduction
+
+### Community 235 - "Community 235"
+Cohesion: 1.0
+Nodes (1): Google Cloud Storage Audit Logs
+
+### Community 236 - "Community 236"
+Cohesion: 1.0
+Nodes (1): Cloud Storage API
+
+### Community 237 - "Community 237"
+Cohesion: 1.0
+Nodes (1): Cloud Storage API Logging Integration
+
+### Community 238 - "Community 238"
+Cohesion: 1.0
+Nodes (1): Google Common Types
+
+### Community 239 - "Community 239"
+Cohesion: 1.0
+Nodes (1): GCE Disaster Recovery Event Logging
+
+### Community 240 - "Community 240"
+Cohesion: 1.0
+Nodes (1): Global DNS Usage Logging
+
+### Community 241 - "Community 241"
+Cohesion: 1.0
+Nodes (1): Workstations API Logging Integration
+
+### Community 242 - "Community 242"
+Cohesion: 1.0
+Nodes (1): Cloud Datastream Service API Logging
+
+### Community 243 - "Community 243"
+Cohesion: 1.0
+Nodes (1): Service health API Logging Integration
+
+### Community 244 - "Community 244"
+Cohesion: 1.0
+Nodes (1): Cloud Backup and DR Logging Integration
+
+### Community 245 - "Community 245"
+Cohesion: 1.0
+Nodes (1): About
+
+### Community 246 - "Community 246"
+Cohesion: 1.0
+Nodes (1): Introduction
+
+### Community 247 - "Community 247"
+Cohesion: 1.0
+Nodes (1): Google Compute Engine Minimal API (for Testing Purposes Only)
+
+### Community 248 - "Community 248"
+Cohesion: 1.0
+Nodes (1): Eventarc API Logging Integration
+
+### Community 249 - "Community 249"
+Cohesion: 1.0
+Nodes (1): Dataform API Platform Logging
+
+### Community 250 - "Community 250"
+Cohesion: 1.0
+Nodes (1): Cloud Spanner Executor test API
+
+### Community 251 - "Community 251"
+Cohesion: 1.0
+Nodes (1): Card
+
+### Community 252 - "Community 252"
+Cohesion: 1.0
+Nodes (1): Introduction
+
+### Community 253 - "Community 253"
+Cohesion: 1.0
+Nodes (1): Analytics Data API Logging Integration
+
+### Community 254 - "Community 254"
+Cohesion: 1.0
+Nodes (2): Prometheus Operator PrometheusRule, Prometheus Operator ServiceMonitor
+
+### Community 255 - "Community 255"
+Cohesion: 1.0
+Nodes (2): Kubernetes Control Plane PrometheusRule (kubernetes-monitoring-rules), KubeScheduler ServiceMonitor
+
+### Community 256 - "Community 256"
+Cohesion: 1.0
+Nodes (2): Prometheus Adapter Service, Prometheus Adapter ServiceMonitor
+
+### Community 257 - "Community 257"
+Cohesion: 1.0
+Nodes (2): RDMDisk CRD, VMwareMachine CRD
+
+### Community 258 - "Community 258"
+Cohesion: 1.0
+Nodes (2): ESXi SSH Key Secret (esxi-ssh-key), ESXiSSHCreds Sample CR (esxisshcreds-sample)
+
+### Community 293 - "Community 293"
+Cohesion: 1.0
+Nodes (1): Appliance VM README
+
+### Community 294 - "Community 294"
+Cohesion: 1.0
+Nodes (1): VDDK Libraries (VMware Virtual Disk Dev Kit)
+
+### Community 295 - "Community 295"
+Cohesion: 1.0
+Nodes (1): Cold Migration Strategy
+
+### Community 296 - "Community 296"
+Cohesion: 1.0
+Nodes (1): Flatcar Linux
+
+### Community 297 - "Community 297"
+Cohesion: 1.0
+Nodes (1): vjailbreak-api-ingress Ingress
+
+### Community 298 - "Community 298"
+Cohesion: 1.0
+Nodes (1): CRD Kustomization Registry
+
+### Community 299 - "Community 299"
+Cohesion: 1.0
+Nodes (1): ESXiSSHCreds CRD
+
+### Community 300 - "Community 300"
+Cohesion: 1.0
+Nodes (1): VjailbreakNode CRD
+
 ### Community 301 - "Community 301"
-Cohesion: 0.50
-Nodes (4): description, location, type, fields
+Cohesion: 1.0
+Nodes (1): VMwareHost Sample CR
 
 ### Community 302 - "Community 302"
-Cohesion: 0.50
-Nodes (4): description, location, type, oauth_token
-
-### Community 303 - "Community 303"
-Cohesion: 0.50
-Nodes (4): userIp, description, location, type
-
-### Community 314 - "Community 314"
-Cohesion: 0.67
-Nodes (3): icons, x16, x32
+Cohesion: 1.0
+Nodes (1): v2v-helper README (Migration Worker)
 
 ## Knowledge Gaps
-- **2147 isolated node(s):** `@emotion/react`, `@emotion/styled`, `@mui/icons-material`, `@mui/material`, `@mui/x-date-pickers` (+2142 more)
+- **1272 isolated node(s):** `hostValidationResult`, `ArrayCredsMappingSpec`, `DatastoreArrayCredsMapping`, `ArrayCredsMappingStatus`, `ArrayCredsMapping` (+1267 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **463 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **Thin community `Community 135`** (3 nodes): `Remove-StaleNetworkAdapter()`, `Write-Log()`, `Cleanup-GhostNICs.ps1`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 137`** (3 nodes): `release_tracking.md`, `Release notes`, `Tasks`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 138`** (3 nodes): `Build files (experimental)`, `Google Ads API`, `README.md`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 139`** (3 nodes): `readme.md`, `API v1 Shutdown`, `Migrating to v2`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 140`** (3 nodes): `Long-running Operations API`, `Operation`, `README.md`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 141`** (3 nodes): `README.md`, `Key Concepts`, `RPC (Remote Procedure Call) Types`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 142`** (3 nodes): `README.md`, `Key Concepts`, `Logging types`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 149`** (2 nodes): `ESXiOperations`, `operations.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 151`** (2 nodes): `VjailbreakSettings`, `types.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 155`** (2 nodes): `progress.go`, `UpgradeProgress`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 157`** (2 nodes): `Generator`, `generator.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 158`** (2 nodes): `RpcStatus`, `model_rpc_status.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 159`** (2 nodes): `ProtobufAny`, `model_protobuf_any.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 160`** (2 nodes): `RuntimeError`, `model_runtime_error.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 161`** (2 nodes): `ExamplepbGenerateUnboundMethodsSimpleMessage`, `model_examplepb_generate_unbound_methods_simple_message.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 162`** (2 nodes): `ABitOfEverythingNested`, `model_a_bit_of_everything_nested.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 163`** (2 nodes): `ABitOfEverythingServiceDeepPathEchoBody`, `model_a_bit_of_everything_service_deep_path_echo_body.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 164`** (2 nodes): `ExamplepbErrorResponse`, `model_examplepb_error_response.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 165`** (2 nodes): `ABitOfEverything4`, `model_a_bit_of_everything_4.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 166`** (2 nodes): `ExamplepbABitOfEverythingServiceUpdateBody`, `model_examplepb_a_bit_of_everything_service_update_body.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 167`** (2 nodes): `ExamplepbCheckStatusResponse`, `model_examplepb_check_status_response.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 168`** (2 nodes): `ABitOfEverything5`, `model_a_bit_of_everything_5.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 169`** (2 nodes): `ABitOfEverythingServiceUpdateBody`, `model_a_bit_of_everything_service_update_body.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 170`** (2 nodes): `ABitOfEverything1`, `model_a_bit_of_everything_1.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 171`** (2 nodes): `UpdateV2RequestRequestForUpdateIncludesTheMessageAndTheUpdateMask`, `model_update_v2_request_request_for_update_includes_the_message_and_the_update_mask.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 172`** (2 nodes): `RpcStatus`, `model_rpc_status.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 173`** (2 nodes): `V1exampledeepPathsingleNestedNameSingleNested`, `model_v1exampledeep_pathsingle_nested_name_single_nested.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 174`** (2 nodes): `NestedDeepEnum`, `model_nested_deep_enum.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 175`** (2 nodes): `ExamplepbABitOfEverythingRepeated`, `model_examplepb_a_bit_of_everything_repeated.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 176`** (2 nodes): `TheBookToUpdate_`, `model_the_book_to_update_.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 177`** (2 nodes): `ABitOfEverything`, `model_a_bit_of_everything.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 178`** (2 nodes): `ProtoexamplepbFoo`, `model_protoexamplepb_foo.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 179`** (2 nodes): `ExamplepbBook`, `model_examplepb_book.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 180`** (2 nodes): `PathenumsnakeCaseForImport`, `model_pathenumsnake_case_for_import.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 181`** (2 nodes): `SubStringMessage`, `model_sub_string_message.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 182`** (2 nodes): `ExamplepbBar`, `model_examplepb_bar.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 183`** (2 nodes): `ABitOfEverything8`, `model_a_bit_of_everything_8.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 184`** (2 nodes): `UpdateV2RequestRequestForUpdateIncludesTheMessageAndTheUpdateMask1`, `model_update_v2_request_request_for_update_includes_the_message_and_the_update_mask_1.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 185`** (2 nodes): `OneofenumExampleEnum`, `model_oneofenum_example_enum.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 186`** (2 nodes): `ExamplepbRequiredMessageTypeRequest`, `model_examplepb_required_message_type_request.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 187`** (2 nodes): `ABitOfEverythingServiceUpdateV2Body`, `model_a_bit_of_everything_service_update_v2_body.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 188`** (2 nodes): `TheBookToUpdateTheBooksNameFieldIsUsedToIdentifyTheBookToBeUpdatedFormatPublisherspublisherbooksbook`, `model_the_book_to_update_the_books_name_field_is_used_to_identify_the_book_to_be_updated_format_publisherspublisherbooksbook.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 189`** (2 nodes): `ExamplepbFoo`, `model_examplepb_foo.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 190`** (2 nodes): `ABitOfEverythingServiceDeepPathEchoBodySingleNested`, `model_a_bit_of_everything_service_deep_path_echo_body_single_nested.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 191`** (2 nodes): `ABitOfEverything6`, `model_a_bit_of_everything_6.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 192`** (2 nodes): `TheBookToUpdate1`, `model_the_book_to_update__1.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 193`** (2 nodes): `ABitOfEverythingServicePostWithEmptyBodyBody`, `model_a_bit_of_everything_service_post_with_empty_body_body.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 194`** (2 nodes): `ExamplepbErrorObject`, `model_examplepb_error_object.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 195`** (2 nodes): `ExamplepbSnakeEnumResponse`, `model_examplepb_snake_enum_response.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 196`** (2 nodes): `ABitOfEverything2`, `model_a_bit_of_everything_2.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 197`** (2 nodes): `ExamplepbsnakeCase0Enum`, `model_examplepbsnake_case_0_enum.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 198`** (2 nodes): `ExamplepbABitOfEverything`, `model_examplepb_a_bit_of_everything.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 199`** (2 nodes): `ExamplepbBody`, `model_examplepb_body.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 200`** (2 nodes): `ExamplepbsnakeCaseEnum`, `model_examplepbsnake_case_enum.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 201`** (2 nodes): `ABitOfEverything3`, `model_a_bit_of_everything_3.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 202`** (2 nodes): `Book`, `model_book.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 203`** (2 nodes): `ProtobufAny`, `model_protobuf_any.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 204`** (2 nodes): `ABitOfEverything7`, `model_a_bit_of_everything_7.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 205`** (2 nodes): `model_examplepb_unannotated_simple_message.go`, `ExamplepbUnannotatedSimpleMessage`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 206`** (2 nodes): `model_rpc_status.go`, `RpcStatus`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 207`** (2 nodes): `model_examplepb_numeric_enum.go`, `ExamplepbNumericEnum`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 208`** (2 nodes): `model_examplepb_unannotated_embedded.go`, `ExamplepbUnannotatedEmbedded`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 209`** (2 nodes): `model_examplepb_unannotated_nested_message.go`, `ExamplepbUnannotatedNestedMessage`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 210`** (2 nodes): `model_protobuf_any.go`, `ProtobufAny`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 211`** (2 nodes): `ExamplepbDynamicMessageUpdate`, `model_examplepb_dynamic_message_update.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 212`** (2 nodes): `ExamplepbSimpleMessage`, `model_examplepb_simple_message.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 213`** (2 nodes): `RpcStatus`, `model_rpc_status.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 214`** (2 nodes): `ExamplepbEmbedded`, `model_examplepb_embedded.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 215`** (2 nodes): `ProtobufNullValue`, `model_protobuf_null_value.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 216`** (2 nodes): `ExamplepbDynamicMessage`, `model_examplepb_dynamic_message.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 217`** (2 nodes): `ExamplepbNestedMessage`, `model_examplepb_nested_message.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 218`** (2 nodes): `ProtobufAny`, `model_protobuf_any.go`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 219`** (2 nodes): `model_examplepb_repeated_response_body_out_response.go`, `ExamplepbRepeatedResponseBodyOutResponse`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 220`** (2 nodes): `model_examplepb_response_body_value.go`, `ExamplepbResponseBodyValue`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 221`** (2 nodes): `model_response_response_type.go`, `ResponseResponseType`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 222`** (2 nodes): `model_rpc_status.go`, `RpcStatus`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 223`** (2 nodes): `model_examplepb_repeated_response_strings.go`, `ExamplepbRepeatedResponseStrings`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 224`** (2 nodes): `model_examplepb_repeated_response_body_out.go`, `ExamplepbRepeatedResponseBodyOut`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 225`** (2 nodes): `model_examplepb_response_body_out_response.go`, `ExamplepbResponseBodyOutResponse`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 226`** (2 nodes): `model_examplepb_response_body_out.go`, `ExamplepbResponseBodyOut`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 227`** (2 nodes): `model_stream_result_of_examplepb_response_body_out.go`, `StreamResultOfExamplepbResponseBodyOut`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 228`** (2 nodes): `model_protobuf_any.go`, `ProtobufAny`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 230`** (2 nodes): `README.md`, `v2v-helper`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 231`** (2 nodes): `Contributor Code of Conduct`, `CODE_OF_CONDUCT.md`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 232`** (2 nodes): `Security Policy`, `SECURITY.md`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 233`** (2 nodes): `Google Data Loss Prevention (DLP) API`, `README.md`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 234`** (2 nodes): `Introduction`, `README.md`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 235`** (2 nodes): `README.md`, `Google Cloud Storage Audit Logs`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 236`** (2 nodes): `README.md`, `Cloud Storage API`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 237`** (2 nodes): `README.md`, `Cloud Storage API Logging Integration`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 238`** (2 nodes): `README.md`, `Google Common Types`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 239`** (2 nodes): `README.md`, `GCE Disaster Recovery Event Logging`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 240`** (2 nodes): `README.md`, `Global DNS Usage Logging`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 241`** (2 nodes): `README.md`, `Workstations API Logging Integration`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 242`** (2 nodes): `README.md`, `Cloud Datastream Service API Logging`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 243`** (2 nodes): `README.md`, `Service health API Logging Integration`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 244`** (2 nodes): `README.md`, `Cloud Backup and DR Logging Integration`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 245`** (2 nodes): `README.md`, `About`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 246`** (2 nodes): `README.md`, `Introduction`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 247`** (2 nodes): `README.md`, `Google Compute Engine Minimal API (for Testing Purposes Only)`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 248`** (2 nodes): `README.md`, `Eventarc API Logging Integration`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 249`** (2 nodes): `README.md`, `Dataform API Platform Logging`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 250`** (2 nodes): `README.md`, `Cloud Spanner Executor test API`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 251`** (2 nodes): `README.md`, `Card`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 252`** (2 nodes): `Introduction`, `README.md`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 253`** (2 nodes): `Analytics Data API Logging Integration`, `README.md`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 254`** (2 nodes): `Prometheus Operator PrometheusRule`, `Prometheus Operator ServiceMonitor`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 255`** (2 nodes): `Kubernetes Control Plane PrometheusRule (kubernetes-monitoring-rules)`, `KubeScheduler ServiceMonitor`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 256`** (2 nodes): `Prometheus Adapter Service`, `Prometheus Adapter ServiceMonitor`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 257`** (2 nodes): `RDMDisk CRD`, `VMwareMachine CRD`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 258`** (2 nodes): `ESXi SSH Key Secret (esxi-ssh-key)`, `ESXiSSHCreds Sample CR (esxisshcreds-sample)`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 293`** (1 nodes): `Appliance VM README`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 294`** (1 nodes): `VDDK Libraries (VMware Virtual Disk Dev Kit)`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 295`** (1 nodes): `Cold Migration Strategy`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 296`** (1 nodes): `Flatcar Linux`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 297`** (1 nodes): `vjailbreak-api-ingress Ingress`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 298`** (1 nodes): `CRD Kustomization Registry`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 299`** (1 nodes): `ESXiSSHCreds CRD`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 300`** (1 nodes): `VjailbreakNode CRD`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 301`** (1 nodes): `VMwareHost Sample CR`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 302`** (1 nodes): `v2v-helper README (Migration Worker)`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Contains()` connect `OpenStack Mock Recorder` to `vpwned Upgrade & Version`, `ESXi Migration Reconciler`, `MigrationPlan API Types`, `Keystone Auth (PCD)`, `Migration Credential Utils`, `virt-v2v OS Detection`, `OpenStack Client`, `PCD Auth & Keystone SDK`, `OpenStack Cinder Operations`, `RBAC Roles & CRD Docs`, `Monitoring Stack (Alertmanager)`, `VMwareMachine API Types`, `OpenStack Component`, `vpwned Update Response Protobuf`, `vpwned gRPC Server (Storage)`, `RollingMigrationPlan API Types`, `Mock / Test Double`, `CRD API Types`, `CRD API Types`, `CRD API Types`, `CRD API Types`, `Mock / Test Double`, `Utilities`, `CRD API Types`, `Protobuf Service`, `OpenStack Component`, `VMware Component`, `Component 80`, `Component 209`, `Controller Component`, `Component 229`, `Protobuf Service`, `Controller Component`, `Test Utilities`, `Test Utilities`, `Test Utilities`, `PCD Integration`?**
-  _High betweenness centrality (0.062) - this node is a cross-community bridge._
-- **Why does `Info` connect `Controller Component` to `ESXi Migration Reconciler`, `NetApp Storage Provider`, `Controller Component`, `Component 42`, `OpenStack Component`, `BM Mock Provider`, `VMware Component`, `RBAC Roles & CRD Docs`, `ESXi SSH Client`, `OpenStack Mock Operations`, `virt-v2v Mock Operations`?**
-  _High betweenness centrality (0.022) - this node is a cross-community bridge._
-- **Why does `VMOps` connect `OpenStack Mock Recorder` to `Component 89`, `Utilities`?**
-  _High betweenness centrality (0.013) - this node is a cross-community bridge._
-- **Are the 105 inferred relationships involving `Contains()` (e.g. with `.discoverDatastores()` and `.moveVMToFolder()`) actually correct?**
-  _`Contains()` has 105 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 65 inferred relationships involving `PrintLog()` (e.g. with `.addUdevRulesForUbuntu()` and `.CheckCutoverOptions()`) actually correct?**
-  _`PrintLog()` has 65 INFERRED edges - model-reasoned connections that need verification._
-- **What connects `@emotion/react`, `@emotion/styled`, `@mui/icons-material` to the rest of the system?**
-  _2151 weakly-connected nodes found - possible documentation gaps or missing edges._
-- **Should `vpwned Upgrade & Version` be split into smaller, more focused modules?**
-  _Cohesion score 0.0869215291750503 - nodes in this community are weakly interconnected._
+- **Why does `New()` connect `Community 2` to `Community 0`, `Community 1`, `Community 3`, `Community 4`, `Community 5`, `Community 6`, `Community 7`, `Community 8`, `Community 9`, `Community 10`, `Community 11`, `Community 12`, `Community 15`?**
+  _High betweenness centrality (0.056) - this node is a cross-community bridge._
+- **Why does `main()` connect `Community 3` to `Community 1`, `Community 2`, `Community 4`, `Community 5`, `Community 7`, `Community 48`?**
+  _High betweenness centrality (0.018) - this node is a cross-community bridge._
+- **Why does `contains()` connect `Community 5` to `Community 0`, `Community 1`, `Community 2`, `Community 3`, `Community 4`, `Community 6`, `Community 7`, `Community 8`, `Community 10`, `Community 48`?**
+  _High betweenness centrality (0.016) - this node is a cross-community bridge._
+- **Are the 215 inferred relationships involving `New()` (e.g. with `main()` and `.createArrayCreds()`) actually correct?**
+  _`New()` has 215 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 149 inferred relationships involving `Info` (e.g. with `main()` and `.Reconcile()`) actually correct?**
+  _`Info` has 149 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 144 inferred relationships involving `PopulateQueryParameters()` (e.g. with `BenchmarkPopulateQueryParameters()` and `TestPopulateParameters()`) actually correct?**
+  _`PopulateQueryParameters()` has 144 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 101 inferred relationships involving `readAll()` (e.g. with `getSecurityGroupsFromMetadata()` and `GetCurrentInstanceNetworkInfo()`) actually correct?**
+  _`readAll()` has 101 INFERRED edges - model-reasoned connections that need verification._

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -872,7 +872,7 @@ func (osclient *OpenStackClients) createPortLowLevel(ctx context.Context, create
 	// failing migration outright.
 	isL2Network, l2Err := osclient.GetIsSimpleNetwork(ctx, createOpts.NetworkID)
 	if l2Err != nil {
-		PrintLog(fmt.Sprintf("failed to determine if network %s is L2, creating port without l2-port binding profile: %s", createOpts.NetworkID, l2Err))
+		return nil, fmt.Errorf("failed determine if network %s is L2: %s", createOpts.NetworkID, l2Err)
 	}
 
 	for i := 0; i < constants.DeleteOperationRetryCount; i++ {

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servergroups"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/volumeattach"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/portsbinding"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/portsecurity"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
@@ -821,21 +822,62 @@ func (osclient *OpenStackClients) CreatePort(ctx context.Context, networkid *net
 	return osclient.createPortLowLevel(ctx, createOpts)
 }
 
+// l2PortBindingProfileKey is the binding profile flag PCD expects on ports that
+// belong to an L2-only network. Downstream consumers (e.g. the PCD Veeam Proxy)
+// use it to detect that a port is on an L2 network; without it, backup/restore
+// of migrated workloads fails. See PCD docs:
+//
+//	pcdctl port create ... --binding-profile '{"l2-port": true}'
+const l2PortBindingProfileKey = "l2-port"
+
+// buildPortCreateOptions layers the OpenStack port extensions required by
+// vJailbreak onto the base create options:
+//   - L2-only networks get the {"l2-port": true} binding profile so PCD treats
+//     the port as belonging to an L2 network.
+//   - Ports with no security groups get port security disabled.
+//
+// Both extensions implement ports.CreateOptsBuilder and compose, so they can be
+// layered together when both conditions apply. Kept as a pure function so the
+// option-building logic can be unit tested without an OpenStack client.
+func buildPortCreateOptions(createOpts ports.CreateOpts, isL2Network bool) ports.CreateOptsBuilder {
+	var optsBuilder ports.CreateOptsBuilder = createOpts
+
+	// For L2-only networks, attach the binding profile expected by PCD.
+	if isL2Network {
+		optsBuilder = portsbinding.CreateOptsExt{
+			CreateOptsBuilder: optsBuilder,
+			Profile:           map[string]any{l2PortBindingProfileKey: true},
+		}
+	}
+
+	// When no security groups are selected, disable port security.
+	if createOpts.SecurityGroups == nil || len(*createOpts.SecurityGroups) == 0 {
+		disabled := false
+		optsBuilder = portsecurity.PortCreateOptsExt{
+			CreateOptsBuilder:   optsBuilder,
+			PortSecurityEnabled: &disabled,
+		}
+	}
+
+	return optsBuilder
+}
+
 func (osclient *OpenStackClients) createPortLowLevel(ctx context.Context, createOpts ports.CreateOpts) (*ports.Port, error) {
 	var port *ports.Port
 	var err error
+
+	// Determine once (before the retry loop) whether this is an L2-only network
+	// so we can attach the required l2-port binding profile. A lookup failure is
+	// non-fatal: log it and create the port without the profile rather than
+	// failing migration outright.
+	isL2Network, l2Err := osclient.GetIsSimpleNetwork(ctx, createOpts.NetworkID)
+	if l2Err != nil {
+		PrintLog(fmt.Sprintf("failed to determine if network %s is L2, creating port without l2-port binding profile: %s", createOpts.NetworkID, l2Err))
+	}
+
 	for i := 0; i < constants.DeleteOperationRetryCount; i++ {
-		// When no security groups are selected, disable port security
-		if createOpts.SecurityGroups == nil || len(*createOpts.SecurityGroups) == 0 {
-			disabled := false
-			extOpts := portsecurity.PortCreateOptsExt{
-				CreateOptsBuilder:   createOpts,
-				PortSecurityEnabled: &disabled,
-			}
-			port, err = ports.Create(ctx, osclient.NetworkingClient, extOpts).Extract()
-		} else {
-			port, err = ports.Create(ctx, osclient.NetworkingClient, createOpts).Extract()
-		}
+		opts := buildPortCreateOptions(createOpts, isL2Network)
+		port, err = ports.Create(ctx, osclient.NetworkingClient, opts).Extract()
 		if err == nil {
 			return port, nil
 		}

--- a/v2v-helper/pkg/utils/openstackopsutils_test.go
+++ b/v2v-helper/pkg/utils/openstackopsutils_test.go
@@ -1,0 +1,100 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
+)
+
+// TestBuildPortCreateOptions verifies that buildPortCreateOptions layers the
+// correct OpenStack port extensions onto the base create options:
+//   - L2-only networks must carry the {"l2-port": true} binding profile that PCD
+//     (and the PCD Veeam Proxy) requires.
+//   - Ports without security groups must have port security disabled.
+//   - Both extensions must compose when both conditions apply.
+func TestBuildPortCreateOptions(t *testing.T) {
+	emptyGroups := []string{}
+	withGroups := []string{"sg-1"}
+
+	tests := []struct {
+		name                string
+		createOpts          ports.CreateOpts
+		isL2Network         bool
+		wantBindingProfile  bool
+		wantPortSecurityKey bool // whether "port_security_enabled" should be present
+	}{
+		{
+			name:                "L2 network with security groups => binding profile only",
+			createOpts:          ports.CreateOpts{NetworkID: "net-1", SecurityGroups: &withGroups},
+			isL2Network:         true,
+			wantBindingProfile:  true,
+			wantPortSecurityKey: false,
+		},
+		{
+			name:                "non-L2 network with security groups => neither extension",
+			createOpts:          ports.CreateOpts{NetworkID: "net-1", SecurityGroups: &withGroups},
+			isL2Network:         false,
+			wantBindingProfile:  false,
+			wantPortSecurityKey: false,
+		},
+		{
+			name:                "non-L2 network with no security groups => port security disabled only",
+			createOpts:          ports.CreateOpts{NetworkID: "net-1", SecurityGroups: &emptyGroups},
+			isL2Network:         false,
+			wantBindingProfile:  false,
+			wantPortSecurityKey: true,
+		},
+		{
+			name:                "non-L2 network with nil security groups => port security disabled only",
+			createOpts:          ports.CreateOpts{NetworkID: "net-1", SecurityGroups: nil},
+			isL2Network:         false,
+			wantBindingProfile:  false,
+			wantPortSecurityKey: true,
+		},
+		{
+			name:                "L2 network with no security groups => both extensions compose",
+			createOpts:          ports.CreateOpts{NetworkID: "net-1", SecurityGroups: &emptyGroups},
+			isL2Network:         true,
+			wantBindingProfile:  true,
+			wantPortSecurityKey: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := buildPortCreateOptions(tt.createOpts, tt.isL2Network)
+
+			body, err := builder.ToPortCreateMap()
+			if err != nil {
+				t.Fatalf("ToPortCreateMap() returned error: %v", err)
+			}
+
+			port, ok := body["port"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected body[\"port\"] to be map[string]any, got %T", body["port"])
+			}
+
+			// Binding profile assertions.
+			profile, hasProfile := port["binding:profile"]
+			if tt.wantBindingProfile {
+				if !hasProfile {
+					t.Fatalf("expected binding:profile to be set, got none. port=%v", port)
+				}
+				profileMap, ok := profile.(map[string]any)
+				if !ok {
+					t.Fatalf("expected binding:profile to be map[string]any, got %T", profile)
+				}
+				if v, ok := profileMap[l2PortBindingProfileKey].(bool); !ok || !v {
+					t.Fatalf("expected binding:profile[%q] == true, got %v", l2PortBindingProfileKey, profileMap[l2PortBindingProfileKey])
+				}
+			} else if hasProfile {
+				t.Fatalf("did not expect binding:profile to be set, got %v", profile)
+			}
+
+			// Port security assertions.
+			if _, hasPortSec := port["port_security_enabled"]; hasPortSec != tt.wantPortSecurityKey {
+				t.Fatalf("port_security_enabled present = %v, want %v. port=%v", hasPortSec, tt.wantPortSecurityKey, port)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it
All workload port creation funnels through a single chokepoint, createPortLowLevel in v2v-helper/pkg/utils/openstackopsutils.go:880 (the only ports.Create call in the repo). It set port security but never attached the L2 binding profile, even though the code already detects L2 networks via the simple_network tag (GetIsSimpleNetwork).

Changes — v2v-helper/pkg/utils/openstackopsutils.go

1. Added the portsbinding import (already part of the in-use gophercloud/v2 v2.9.0 — no go.mod change).
2. Extracted a pure helper buildPortCreateOptions(createOpts, isL2Network) that layers the OpenStack port extensions:
  - L2 network → portsbinding.CreateOptsExt with Profile: {"l2-port": true}
  - No security groups → portsecurity.PortCreateOptsExt with port security disabled
  - Both compose when both conditions apply (each implements ports.CreateOptsBuilder).
3. createPortLowLevel now resolves isL2Network once (via the existing GetIsSimpleNetwork) before the retry loop and uses the helper. A lookup failure is non-fatal — it logs and creates the port without the profile rather than failing the migration.

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #2014 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/2015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->