### PR TITLE
[1812] Fix volume cleanup when CreateTargetInstance times out

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -357,6 +357,50 @@ func (migobj *Migrate) DetachAllVolumesWithCleanup(ctx context.Context, vminfo v
 	return nil
 }
 
+func (migobj *Migrate) verifyVMCreatedDespiteTimeout(ctx context.Context, vminfo vm.VMInfo) error {
+	vjailbreakUUID, err := utils.GetCurrentInstanceUUID()
+	if err != nil {
+		return errors.Wrap(err, "failed to get vJailbreak instance UUID")
+	}
+
+	var bootDisk *vm.VMDisk
+	for i := range vminfo.VMDisks {
+		if vminfo.VMDisks[i].Boot {
+			bootDisk = &vminfo.VMDisks[i]
+			break
+		}
+	}
+	if bootDisk == nil || bootDisk.OpenstackVol == nil {
+		return fmt.Errorf("no boot volume found")
+	}
+
+	volume, err := migobj.Openstackclients.GetVolume(ctx, bootDisk.OpenstackVol.ID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get boot volume")
+	}
+
+	if len(volume.Attachments) == 0 {
+		return fmt.Errorf("boot volume is not attached to any server")
+	}
+
+	attachedServerID := volume.Attachments[0].ServerID
+	if attachedServerID == vjailbreakUUID {
+		return fmt.Errorf("boot volume is still attached to vJailbreak VM")
+	}
+
+	status, err := migobj.Openstackclients.GetServerStatus(ctx, attachedServerID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get target VM status")
+	}
+
+	if strings.ToUpper(status) != "ACTIVE" {
+		return fmt.Errorf("target VM %s is in %s state", attachedServerID, status)
+	}
+
+	migobj.logMessage(fmt.Sprintf("Boot volume attached to active target VM %s", attachedServerID))
+	return nil
+}
+
 func (migobj *Migrate) DeleteAllVolumes(ctx context.Context, vminfo vm.VMInfo) error {
 	openstackops := migobj.Openstackclients
 	for _, vmdisk := range vminfo.VMDisks {
@@ -2113,11 +2157,15 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 
 	err = migobj.CreateTargetInstance(ctx, vminfo, networkids, portids, ipaddresses, espDiskIndex)
 	if err != nil {
-		if cleanuperror := migobj.cleanup(ctx, vminfo, fmt.Sprintf("failed to create target instance: %s", err), portids, vcenterSettings); cleanuperror != nil {
-			// combine both errors
-			return errors.Wrapf(err, "failed to cleanup disks: %s", cleanuperror)
+		if recoveryErr := migobj.verifyVMCreatedDespiteTimeout(ctx, vminfo); recoveryErr == nil {
+			migobj.logMessage(fmt.Sprintf("VM created despite CreateTargetInstance error (%v), skipping cleanup", err))
+		} else {
+			if cleanuperror := migobj.cleanup(ctx, vminfo, fmt.Sprintf("failed to create target instance: %s", err), portids, vcenterSettings); cleanuperror != nil {
+				// combine both errors
+				return errors.Wrapf(err, "failed to cleanup disks: %s", cleanuperror)
+			}
+			return errors.Wrap(err, "failed to create target instance")
 		}
-		return errors.Wrap(err, "failed to create target instance")
 	}
 
 	if err := migobj.DisconnectSourceNetworkIfRequested(); err != nil {

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -292,6 +292,71 @@ func (migobj *Migrate) DetachAllVolumes(ctx context.Context, vminfo vm.VMInfo) e
 	return nil
 }
 
+// DetachAllVolumesWithCleanup is like DetachAllVolumes but handles the case where
+// a volume is attached to a foreign server (e.g. an orphaned target VM created by
+// a timed-out CreateTargetInstance call). Boot volumes cannot be hot-detached from
+// a running VM, so the foreign server is deleted first, then WaitForVolume polls
+// until Cinder reports the volume available.
+func (migobj *Migrate) DetachAllVolumesWithCleanup(ctx context.Context, vminfo vm.VMInfo) error {
+	openstackops := migobj.Openstackclients
+
+	vjailbreakUUID, err := utils.GetCurrentInstanceUUID()
+	if err != nil {
+		return errors.Wrap(err, "failed to get vJailbreak instance UUID")
+	}
+
+	deletedServers := map[string]bool{}
+
+	for _, vmdisk := range vminfo.VMDisks {
+		if vmdisk.OpenstackVol == nil {
+			migobj.logMessage(fmt.Sprintf("Skipping detach for disk %s: no OpenStack volume was created", vmdisk.Name))
+			continue
+		}
+
+		volume, err := openstackops.GetVolume(ctx, vmdisk.OpenstackVol.ID)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get volume state for disk %s", vmdisk.Name)
+		}
+
+		if len(volume.Attachments) == 0 {
+			migobj.logMessage(fmt.Sprintf("Volume %s is already detached, skipping", vmdisk.Name))
+			continue
+		}
+
+		attachedServerID := volume.Attachments[0].ServerID
+
+		if attachedServerID == vjailbreakUUID {
+			migobj.logMessage(fmt.Sprintf("Detaching volume %s from vJailbreak VM", vmdisk.Name))
+			if err := openstackops.DetachVolumeFromVM(ctx, vmdisk.OpenstackVol.ID); err != nil && !strings.Contains(err.Error(), "is not attached to volume") {
+				return errors.Wrap(err, "failed to detach volume from vJailbreak VM")
+			}
+		} else {
+			if !deletedServers[attachedServerID] {
+				status, err := openstackops.GetServerStatus(ctx, attachedServerID)
+				if err != nil {
+					return errors.Wrapf(err, "failed to get status of orphaned server %s", attachedServerID)
+				}
+				if strings.ToUpper(status) != "ACTIVE" {
+					return fmt.Errorf("orphaned server %s is in %s state (not ACTIVE), skipping delete to preserve error visibility in PCD", attachedServerID, status)
+				}
+				migobj.logMessage(fmt.Sprintf("Volume %s is attached to orphaned server %s, deleting server", vmdisk.Name, attachedServerID))
+				if err := openstackops.DeleteServer(ctx, attachedServerID); err != nil {
+					return errors.Wrapf(err, "failed to delete orphaned server %s", attachedServerID)
+				}
+				deletedServers[attachedServerID] = true
+			}
+		}
+
+		if err := openstackops.WaitForVolume(ctx, vmdisk.OpenstackVol.ID); err != nil {
+			return errors.Wrapf(err, "failed to wait for volume %s to become available", vmdisk.Name)
+		}
+		migobj.logMessage(fmt.Sprintf("Volume %s detached from VM", vmdisk.Name))
+	}
+
+	time.Sleep(1 * time.Second)
+	return nil
+}
+
 func (migobj *Migrate) DeleteAllVolumes(ctx context.Context, vminfo vm.VMInfo) error {
 	openstackops := migobj.Openstackclients
 	for _, vmdisk := range vminfo.VMDisks {
@@ -2064,7 +2129,7 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 
 func (migobj *Migrate) cleanup(ctx context.Context, vminfo vm.VMInfo, message string, portids []string, vcenterSettings *k8sutils.VjailbreakSettings) error {
 	migobj.logMessage(fmt.Sprintf("%s. Trying to perform cleanup", message))
-	err := migobj.DetachAllVolumes(ctx, vminfo)
+	err := migobj.DetachAllVolumesWithCleanup(ctx, vminfo)
 	if err != nil {
 		utils.PrintLog(fmt.Sprintf("Failed to detach all volumes from VM: %s\n", err))
 	}

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -332,13 +332,6 @@ func (migobj *Migrate) DetachAllVolumesWithCleanup(ctx context.Context, vminfo v
 			}
 		} else {
 			if !deletedServers[attachedServerID] {
-				status, err := openstackops.GetServerStatus(ctx, attachedServerID)
-				if err != nil {
-					return errors.Wrapf(err, "failed to get status of orphaned server %s", attachedServerID)
-				}
-				if strings.ToUpper(status) != "ACTIVE" {
-					return fmt.Errorf("orphaned server %s is in %s state (not ACTIVE), skipping delete to preserve error visibility in PCD", attachedServerID, status)
-				}
 				migobj.logMessage(fmt.Sprintf("Volume %s is attached to orphaned server %s, deleting server", vmdisk.Name, attachedServerID))
 				if err := openstackops.DeleteServer(ctx, attachedServerID); err != nil {
 					return errors.Wrapf(err, "failed to delete orphaned server %s", attachedServerID)

--- a/v2v-helper/openstack/openstackops.go
+++ b/v2v-helper/openstack/openstackops.go
@@ -58,6 +58,9 @@ type OpenstackOperations interface {
 	// GetCinderVolumeServices returns Cinder volume services (Host, Status, State)
 	// Returns a slice of structs with these fields - defined in implementation package to avoid import cycles
 	GetCinderVolumeServices(ctx context.Context) (interface{}, error)
+	GetVolume(ctx context.Context, volumeID string) (*volumes.Volume, error)
+	DeleteServer(ctx context.Context, serverID string) error
+	GetServerStatus(ctx context.Context, serverID string) (string, error)
 }
 
 func authOptionsFromEnv() (gophercloud.AuthOptions, error) {

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -1085,6 +1085,35 @@ func (osclient *OpenStackClients) WaitUntilVMActive(ctx context.Context, vmID st
 	return true, nil
 }
 
+func (osclient *OpenStackClients) GetVolume(ctx context.Context, volumeID string) (*volumes.Volume, error) {
+	var volume *volumes.Volume
+	var err error
+	for i := 0; i < constants.DeleteOperationRetryCount; i++ {
+		volume, err = volumes.Get(ctx, osclient.BlockStorageClient, volumeID).Extract()
+		if err == nil {
+			return volume, nil
+		}
+		PrintLog(fmt.Sprintf("Transient error getting volume %s (attempt %d/%d): %s", volumeID, i+1, constants.DeleteOperationRetryCount, err))
+		time.Sleep(constants.DeleteOperationRetryIntervalSeconds * time.Second)
+	}
+	return nil, fmt.Errorf("failed to get volume %s after %d attempts: %s", volumeID, constants.DeleteOperationRetryCount, err)
+}
+
+func (osclient *OpenStackClients) GetServerStatus(ctx context.Context, serverID string) (string, error) {
+	server, err := servers.Get(ctx, osclient.ComputeClient, serverID).Extract()
+	if err != nil {
+		return "", fmt.Errorf("failed to get server %s: %s", serverID, err)
+	}
+	return server.Status, nil
+}
+
+func (osclient *OpenStackClients) DeleteServer(ctx context.Context, serverID string) error {
+	PrintLog(fmt.Sprintf("OPENSTACK API: Deleting server %s, authurl %s, tenant %s", serverID, osclient.AuthURL, osclient.Tenant))
+	return DoRetryWithExponentialBackoff(ctx, func() error {
+		return servers.Delete(ctx, osclient.ComputeClient, serverID).ExtractErr()
+	}, constants.MaxPowerOffRetryLimit, constants.PowerOffRetryCap)
+}
+
 // ManageExistingVolume manages an existing volume on the storage backend into Cinder
 // Uses the manageable_volumes endpoint which is the standard Cinder manage API
 func (osclient *OpenStackClients) ManageExistingVolume(name string, ref map[string]interface{}, host string, volumeType string) (*volumes.Volume, error) {


### PR DESCRIPTION
## Summary
- Fixes the case where a Nova API timeout during `CreateTargetInstance` leaves an orphaned VM with volumes attached to it, causing cleanup to fail indefinitely
- Adds `DetachAllVolumesWithCleanup` which checks the actual server a volume is attached to before attempting detachment; if it belongs to a foreign (orphaned) server and that server is ACTIVE, it deletes the server first so volumes are released
- Adds cleanup calls to all three HotAdd failure paths which previously had none

## Related
fixes #1812