### PR TITLE
Detect if we are using virtio-scsi controller for windows and pass --blockdriver for conversion

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1471,9 +1471,9 @@ func (migobj *Migrate) configureRHELNetwork(vminfo vm.VMInfo, bootVolumeIndex in
 
 // blockDriverFromMetadata returns the virt-v2v --block-driver value that
 // matches the hw_disk_bus / hw_scsi_model image properties the caller intends
-// to set on the migrated volume.  The two values must agree: if OpenStack
-// presents a virtio-scsi controller (hw_disk_bus=scsi, hw_scsi_model=virtio-scsi)
-// virt-v2v must make vioscsi boot-critical; if it presents virtio-blk
+// to set on the migrated volume.  The two values must agree: if User wants to use
+// virtio-scsi controller (hw_disk_bus=scsi, hw_scsi_model=virtio-scsi)
+// virt-v2v must make vioscsi boot-critical; or else virtio-blk
 // (hw_disk_bus=virtio, the default) virt-v2v must make viostor boot-critical.
 // Returning "" lets virt-v2v use its built-in default (virtio-blk / viostor).
 func blockDriverFromMetadata(metadata map[string]string) string {

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1305,8 +1305,9 @@ func (migobj *Migrate) performDiskConversion(ctx context.Context, vminfo vm.VMIn
 	}
 
 	// Run virt-v2v conversion
-	utils.PrintLog(fmt.Sprintf("Starting virt-v2v conversion for VM %s (osPath=%s, osType=%s)", vminfo.Name, osPath, vminfo.OSType))
-	if err := virtv2v.ConvertDisk(ctx, constants.XMLFileName, osPath, vminfo.OSType, migobj.Virtiowin, firstbootscripts, vminfo.VMDisks[bootVolumeIndex].Path, osRelease); err != nil {
+	blockDriver := blockDriverFromMetadata(migobj.ImageMetadata)
+	utils.PrintLog(fmt.Sprintf("Starting virt-v2v conversion for VM %s (osPath=%s, osType=%s, blockDriver=%q)", vminfo.Name, osPath, vminfo.OSType, blockDriver))
+	if err := virtv2v.ConvertDisk(ctx, constants.XMLFileName, osPath, vminfo.OSType, migobj.Virtiowin, firstbootscripts, vminfo.VMDisks[bootVolumeIndex].Path, osRelease, blockDriver); err != nil {
 		return errors.Wrap(err, "failed to run virt-v2v")
 	}
 	utils.PrintLog("virt-v2v conversion completed successfully")
@@ -1466,6 +1467,20 @@ func (migobj *Migrate) configureRHELNetwork(vminfo vm.VMInfo, bootVolumeIndex in
 	}
 
 	return nil
+}
+
+// blockDriverFromMetadata returns the virt-v2v --block-driver value that
+// matches the hw_disk_bus / hw_scsi_model image properties the caller intends
+// to set on the migrated volume.  The two values must agree: if OpenStack
+// presents a virtio-scsi controller (hw_disk_bus=scsi, hw_scsi_model=virtio-scsi)
+// virt-v2v must make vioscsi boot-critical; if it presents virtio-blk
+// (hw_disk_bus=virtio, the default) virt-v2v must make viostor boot-critical.
+// Returning "" lets virt-v2v use its built-in default (virtio-blk / viostor).
+func blockDriverFromMetadata(metadata map[string]string) string {
+	if metadata["hw_disk_bus"] == "scsi" && metadata["hw_scsi_model"] == "virtio-scsi" {
+		return "virtio-scsi"
+	}
+	return ""
 }
 
 func (migobj *Migrate) ConvertVolumes(ctx context.Context, vminfo vm.VMInfo) (int, error) {

--- a/v2v-helper/migrate/migrate_test.go
+++ b/v2v-helper/migrate/migrate_test.go
@@ -730,3 +730,55 @@ func TestCleanup_PartialVolumes_DeletesCreatedVolumeAndPorts(t *testing.T) {
 	err := migobj.cleanup(ctx, vminfo, "test partial volume failure", []string{"port-1"}, settings)
 	assert.NoError(t, err)
 }
+
+func TestBlockDriverFromMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		want     string
+	}{
+		{
+			name:     "nil metadata returns empty",
+			metadata: nil,
+			want:     "",
+		},
+		{
+			name:     "empty metadata returns empty",
+			metadata: map[string]string{},
+			want:     "",
+		},
+		{
+			name:     "hw_disk_bus=virtio (default) returns empty",
+			metadata: map[string]string{"hw_disk_bus": "virtio"},
+			want:     "",
+		},
+		{
+			name:     "hw_disk_bus=scsi without hw_scsi_model returns empty",
+			metadata: map[string]string{"hw_disk_bus": "scsi"},
+			want:     "",
+		},
+		{
+			name:     "hw_scsi_model=virtio-scsi without hw_disk_bus=scsi returns empty",
+			metadata: map[string]string{"hw_disk_bus": "virtio", "hw_scsi_model": "virtio-scsi"},
+			want:     "",
+		},
+		{
+			name:     "hw_disk_bus=scsi + hw_scsi_model=virtio-scsi returns virtio-scsi",
+			metadata: map[string]string{"hw_disk_bus": "scsi", "hw_scsi_model": "virtio-scsi"},
+			want:     "virtio-scsi",
+		},
+		{
+			name:     "unrelated keys return empty",
+			metadata: map[string]string{"os_type": "windows", "hw_qemu_guest_agent": "yes"},
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := blockDriverFromMetadata(tt.metadata)
+			if got != tt.want {
+				t.Errorf("blockDriverFromMetadata(%v) = %q, want %q", tt.metadata, got, tt.want)
+			}
+		})
+	}
+}

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -33,7 +33,7 @@ type VirtV2VOperations interface {
 	RetainAlphanumeric(input string) string
 	GetPartitions(disk string) ([]string, error)
 	NTFSFix(path string) error
-	ConvertDisk(ctx context.Context, path, ostype, virtiowindriver string, firstbootscripts []string, diskPath string, osRelease string) error
+	ConvertDisk(ctx context.Context, path, ostype, virtiowindriver string, firstbootscripts []string, diskPath string, osRelease string, blockDriver string) error
 	AddWildcardNetplan(path string) error
 	GetOsRelease(path string) (string, error)
 	AddFirstBootScript(firstbootscript, firstbootscriptname string) error
@@ -401,7 +401,7 @@ func isBareDisk(path string) bool {
 	return lastChar < '0' || lastChar > '9'
 }
 
-func ConvertDisk(ctx context.Context, xmlFile, path, ostype, virtiowindriver string, firstbootscripts []string, diskPath string, osRelease string) error {
+func ConvertDisk(ctx context.Context, xmlFile, path, ostype, virtiowindriver string, firstbootscripts []string, diskPath string, osRelease string, blockDriver string) error {
 	// Step 1: Handle Windows driver injection
 	if strings.ToLower(ostype) == constants.OSFamilyWindows {
 		filePath := "/home/fedora/virtio-win/virtio-win.iso"
@@ -448,6 +448,13 @@ func ConvertDisk(ctx context.Context, xmlFile, path, ostype, virtiowindriver str
 	for _, script := range firstbootscripts {
 		args = append(args, "--firstboot", fmt.Sprintf("/home/fedora/%s.sh", script))
 	}
+	// For Windows: select which block driver virt-v2v makes boot-critical.
+	// Must match the hw_disk_bus/hw_scsi_model set on the volume so the guest
+	// boots with the controller whose driver was prepared by virt-v2v.
+	if strings.ToLower(ostype) == constants.OSFamilyWindows && blockDriver != "" {
+		args = append(args, "--block-driver", blockDriver)
+	}
+
 	// Always use libvirtxml mode to convert all disks
 	args = append(args, "-i", "libvirtxml", xmlFile)
 	if strings.ToLower(ostype) != constants.OSFamilyWindows {

--- a/v2v-helper/virtv2v/virtv2vops_mock.go
+++ b/v2v-helper/virtv2v/virtv2vops_mock.go
@@ -78,17 +78,17 @@ func (mr *MockVirtV2VOperationsMockRecorder) AddWildcardNetplan(path interface{}
 }
 
 // ConvertDisk mocks base method.
-func (m *MockVirtV2VOperations) ConvertDisk(ctx context.Context, path, ostype, virtiowindriver string, firstbootscripts []string, useSingleDisk bool, diskPath string, osRelease string) error {
+func (m *MockVirtV2VOperations) ConvertDisk(ctx context.Context, path, ostype, virtiowindriver string, firstbootscripts []string, diskPath string, osRelease string, blockDriver string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConvertDisk", ctx, path, ostype, virtiowindriver, firstbootscripts, useSingleDisk, diskPath, osRelease)
+	ret := m.ctrl.Call(m, "ConvertDisk", ctx, path, ostype, virtiowindriver, firstbootscripts, diskPath, osRelease, blockDriver)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ConvertDisk indicates an expected call of ConvertDisk.
-func (mr *MockVirtV2VOperationsMockRecorder) ConvertDisk(ctx, path, ostype, virtiowindriver, firstbootscripts, useSingleDisk, diskPath, osRelease interface{}) *gomock.Call {
+func (mr *MockVirtV2VOperationsMockRecorder) ConvertDisk(ctx, path, ostype, virtiowindriver, firstbootscripts, diskPath, osRelease, blockDriver interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConvertDisk", reflect.TypeOf((*MockVirtV2VOperations)(nil).ConvertDisk), ctx, path, ostype, virtiowindriver, firstbootscripts, useSingleDisk, diskPath, osRelease)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConvertDisk", reflect.TypeOf((*MockVirtV2VOperations)(nil).ConvertDisk), ctx, path, ostype, virtiowindriver, firstbootscripts, diskPath, osRelease, blockDriver)
 }
 
 // GetNetworkInterfaceNames mocks base method.

--- a/v2v-helper/virtv2v/virtv2vops_test.go
+++ b/v2v-helper/virtv2v/virtv2vops_test.go
@@ -5,6 +5,7 @@ package virtv2v
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -214,6 +215,81 @@ func TestMountPersistenceScriptFlagSelection(t *testing.T) {
 			got := mountPersistenceScriptFlag(tt.osRelease)
 			assert.Equal(t, tt.wantFlag, got,
 				"wrong script flag for osRelease=%q", tt.osRelease)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// blockDriver arg selection
+// ---------------------------------------------------------------------------
+
+// buildV2VArgs is a thin wrapper that exposes the block-driver selection logic
+// without executing the command, for unit testing.
+func buildV2VArgs(ostype, blockDriver string) []string {
+	args := []string{"-v", "--no-fstrim"}
+	if strings.ToLower(ostype) == "windows" && blockDriver != "" {
+		args = append(args, "--block-driver", blockDriver)
+	}
+	return args
+}
+
+func TestConvertDisk_BlockDriverArg(t *testing.T) {
+	tests := []struct {
+		name            string
+		ostype          string
+		blockDriver     string
+		wantBlockDriver bool
+		wantValue       string
+	}{
+		{
+			name:            "windows virtio-scsi adds --block-driver",
+			ostype:          "windows",
+			blockDriver:     "virtio-scsi",
+			wantBlockDriver: true,
+			wantValue:       "virtio-scsi",
+		},
+		{
+			name:            "windows empty blockDriver omits flag (defaults to virtio-blk)",
+			ostype:          "windows",
+			blockDriver:     "",
+			wantBlockDriver: false,
+		},
+		{
+			name:            "linux ignores blockDriver",
+			ostype:          "linux",
+			blockDriver:     "virtio-scsi",
+			wantBlockDriver: false,
+		},
+		{
+			name:            "linux empty blockDriver omits flag",
+			ostype:          "linux",
+			blockDriver:     "",
+			wantBlockDriver: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := buildV2VArgs(tt.ostype, tt.blockDriver)
+			idx := -1
+			for i, a := range args {
+				if a == "--block-driver" {
+					idx = i
+					break
+				}
+			}
+			if tt.wantBlockDriver {
+				if idx == -1 {
+					t.Fatalf("expected --block-driver in args %v but not found", args)
+				}
+				if idx+1 >= len(args) || args[idx+1] != tt.wantValue {
+					t.Errorf("--block-driver value = %q, want %q", args[idx+1], tt.wantValue)
+				}
+			} else {
+				if idx != -1 {
+					t.Errorf("unexpected --block-driver in args %v", args)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it
virt-v2v only makes one block driver boot-critical per conversion — the oneselected by --block-driver (default virtio-blk). It installs the full virtio-win driver set into the driver store regardless, but only the selected driver gets Start=0 plus a CriticalDeviceDatabase mapping. If the OpenStack image/flavor presents a controller whose driver is not the one virt-v2v made boot-critical, the guest fails to boot.

This issue adds a resolution step that maps the intended bus tags to the correct --block-driver value and to the matching image properties, so the presented hardware and the prepared boot driver can never drift apart.

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1991 

## Special notes for your reviewer


## Testing done
Added hw_disk_bus=scsi hw_scsi_model=virtio-scsi in profile for the vm to use scsi controller.
Before the fix:
<img width="2876" height="1624" alt="image" src="https://github.com/user-attachments/assets/3de32054-f954-42fb-a77b-52c07446c915" />

After the fix:
<img width="798" height="220" alt="image" src="https://github.com/user-attachments/assets/97d4dd11-c6e5-4c5e-8a3c-12ec12ff04c6" />
<img width="307" height="367" alt="image" src="https://github.com/user-attachments/assets/a635c8a8-e425-4968-af6a-dec248f048c6" />


Detected scsi in profile and passed the correct block driver to virtv2v. 
<img width="1750" height="964" alt="image" src="https://github.com/user-attachments/assets/d0c11efa-4b62-48b5-ae7f-3f0c9a034184" />

booted up correctly. 

_please add testing details (logs, screenshots, etc.)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/2027" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->