### PR TITLE
Fix: Check hardware version and migration type only then check for cbt

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -907,7 +907,10 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 		return vminfo, errors.Wrap(err, "failed to take snapshot of source VM")
 	}
 
-	err = vmops.UpdateDisksInfo(&vminfo)
+	// Cold migrations never use CBT, so the snapshot disks have no change IDs
+	// (especially on legacy hardware version < 7). Only require change IDs for
+	// non-cold migrations, which rely on them for incremental copies.
+	err = vmops.UpdateDisksInfo(&vminfo, migobj.MigrationType != "cold")
 	if err != nil {
 		return vminfo, errors.Wrap(err, "failed to update disk info")
 	}
@@ -1113,6 +1116,25 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 		if err != nil {
 			return vminfo, errors.Wrap(err, "failed to cleanup snapshot of source VM")
 		}
+
+		// If migration type is cold, check power state and exit the live replicate function.
+		if migobj.MigrationType == "cold" {
+			// Verify VM is actually powered off
+			if err := utils.DoRetryWithExponentialBackoff(ctx, func() error {
+				currState, stateErr := vmops.GetVMObj().PowerState(ctx)
+				if stateErr != nil {
+					return stateErr
+				}
+				if currState != types.VirtualMachinePowerStatePoweredOff {
+					return fmt.Errorf("Cold migration requires the VM to remain powered off. However, the VM was found in the '%s' state after power-off and snapshot copy. Aborting migration to avoid data inconsistency.", currState)
+				}
+				return nil
+			}, constants.MaxPowerOffRetryLimit, constants.PowerOffRetryCap); err != nil {
+				return vminfo, errors.Wrap(err, "failed to verify VM power state after power off")
+			}
+			break
+		}
+
 		err = vmops.TakeSnapshot(constants.MigrationSnapshotName)
 		if err != nil {
 			return vminfo, errors.Wrap(err, "failed to take snapshot of source VM")

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -480,23 +480,20 @@ func (migobj *Migrate) validateDiskMapping(vminfo vm.VMInfo) error {
 func (migobj *Migrate) EnableCBTWrapper() error {
 	vmops := migobj.VMops
 
-	// Cold migrations copy each disk once while the source VM is powered off, so
-	// Changed Block Tracking (CBT) is never needed. Skip it entirely. This also
-	// allows VMs on legacy virtual hardware (version < 7), which cannot support
-	// CBT at all, to be migrated successfully via cold migration.
+	// If it is cold migration we do not need to enable CBT.
 	if migobj.MigrationType == "cold" {
 		migobj.logMessage("Cold migration selected: skipping CBT check and enablement")
 		return nil
 	}
 
-	// CBT requires virtual hardware version 7 or newer (VMware KB 1020128). On
-	// older VMs the changeTrackingEnabled property is absent in the vCenter API
-	// response, which previously caused a nil-pointer panic. Detect this up front
-	// and fail with a clear, actionable error instead of crashing.
-	hwVersion, err := vmops.GetHardwareVersion()
-	if err != nil {
-		return errors.Wrap(err, "failed to determine virtual hardware version")
+	// CBT requires virtual hardware >= 7. Fail with a clear error if
+	// changeTrackingEnabled is unavailable, instead of panicking.
+	hwVersion, VersionErr := vmops.GetHardwareVersion()
+	if VersionErr != nil {
+		migobj.logMessage(fmt.Sprintf("Could not determine hardware version, Trying to enable CBT: %s", VersionErr))
 	}
+	migobj.logMessage(fmt.Sprintf("Hardware version detected: %s", hwVersion))
+
 	if hwVersion > 0 && hwVersion < vm.MinCBTHardwareVersion {
 		return fmt.Errorf(
 			"changed block tracking (CBT) is not supported on virtual hardware version %d "+

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -479,6 +479,31 @@ func (migobj *Migrate) validateDiskMapping(vminfo vm.VMInfo) error {
 // This function enables CBT on the VM if it is not enabled and takes a snapshot for initializing CBT
 func (migobj *Migrate) EnableCBTWrapper() error {
 	vmops := migobj.VMops
+
+	// Cold migrations copy each disk once while the source VM is powered off, so
+	// Changed Block Tracking (CBT) is never needed. Skip it entirely. This also
+	// allows VMs on legacy virtual hardware (version < 7), which cannot support
+	// CBT at all, to be migrated successfully via cold migration.
+	if migobj.MigrationType == "cold" {
+		migobj.logMessage("Cold migration selected: skipping CBT check and enablement")
+		return nil
+	}
+
+	// CBT requires virtual hardware version 7 or newer (VMware KB 1020128). On
+	// older VMs the changeTrackingEnabled property is absent in the vCenter API
+	// response, which previously caused a nil-pointer panic. Detect this up front
+	// and fail with a clear, actionable error instead of crashing.
+	hwVersion, err := vmops.GetHardwareVersion()
+	if err != nil {
+		return errors.Wrap(err, "failed to determine virtual hardware version")
+	}
+	if hwVersion > 0 && hwVersion < vm.MinCBTHardwareVersion {
+		return fmt.Errorf(
+			"changed block tracking (CBT) is not supported on virtual hardware version %d "+
+				"(requires version %d or newer); please use cold migration for this VM",
+			hwVersion, vm.MinCBTHardwareVersion)
+	}
+
 	cbt, err := vmops.IsCBTEnabled()
 	if err != nil {
 		return errors.Wrap(err, "failed to check if CBT is enabled")

--- a/v2v-helper/migrate/migrate_test.go
+++ b/v2v-helper/migrate/migrate_test.go
@@ -133,24 +133,67 @@ func TestCreateVolumes(t *testing.T) {
 }
 
 func TestEnableCBTWrapper(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	// Hot migration on CBT-capable hardware enables CBT as before.
+	t.Run("hot migration enables CBT on supported hardware", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	mockVMOps := vm.NewMockVMOperations(ctrl)
-	gomock.InOrder(
-		mockVMOps.EXPECT().IsCBTEnabled().Return(false, nil).AnyTimes(),
-		mockVMOps.EXPECT().EnableCBT().Return(nil).AnyTimes(),
-		mockVMOps.EXPECT().IsCBTEnabled().Return(true, nil).AnyTimes(),
-		mockVMOps.EXPECT().TakeSnapshot(gomock.Any()).Return(nil).AnyTimes(),
-		mockVMOps.EXPECT().DeleteSnapshot(gomock.Any()).Return(nil).AnyTimes(),
-	)
+		mockVMOps := vm.NewMockVMOperations(ctrl)
+		mockVMOps.EXPECT().GetHardwareVersion().Return(13, nil)
+		gomock.InOrder(
+			mockVMOps.EXPECT().IsCBTEnabled().Return(false, nil),
+			mockVMOps.EXPECT().EnableCBT().Return(nil),
+			mockVMOps.EXPECT().IsCBTEnabled().Return(true, nil),
+			mockVMOps.EXPECT().TakeSnapshot(gomock.Any()).Return(nil),
+			mockVMOps.EXPECT().DeleteSnapshot(gomock.Any()).Return(nil),
+		)
 
-	migobj := Migrate{
-		VMops:         mockVMOps,
-		EventReporter: make(chan string),
-	}
-	err := migobj.EnableCBTWrapper()
-	assert.NoError(t, err)
+		migobj := Migrate{
+			VMops:         mockVMOps,
+			MigrationType: "hot",
+			EventReporter: make(chan string, 16),
+		}
+		err := migobj.EnableCBTWrapper()
+		assert.NoError(t, err)
+	})
+
+	// Cold migration must not touch CBT at all - no hardware-version check and
+	// no CBT calls are made.
+	t.Run("cold migration skips CBT entirely", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockVMOps := vm.NewMockVMOperations(ctrl)
+		// No EXPECT() calls: gomock fails the test if any VM operation is invoked.
+
+		migobj := Migrate{
+			VMops:         mockVMOps,
+			MigrationType: "cold",
+			EventReporter: make(chan string, 16),
+		}
+		err := migobj.EnableCBTWrapper()
+		assert.NoError(t, err)
+	})
+
+	// Legacy hardware (version < 7) cannot support CBT. A hot migration must fail
+	// gracefully with an actionable error instead of panicking, and must never
+	// attempt to read or enable CBT.
+	t.Run("legacy hardware fails gracefully on hot migration", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockVMOps := vm.NewMockVMOperations(ctrl)
+		mockVMOps.EXPECT().GetHardwareVersion().Return(4, nil)
+
+		migobj := Migrate{
+			VMops:         mockVMOps,
+			MigrationType: "hot",
+			EventReporter: make(chan string, 16),
+		}
+		err := migobj.EnableCBTWrapper()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cold migration")
+	})
 }
 
 func TestLiveReplicateDisks(t *testing.T) {

--- a/v2v-helper/migrate/migrate_test.go
+++ b/v2v-helper/migrate/migrate_test.go
@@ -257,7 +257,7 @@ func TestLiveReplicateDisks(t *testing.T) {
 	gomock.InOrder(
 		mockVMOps.EXPECT().TakeSnapshot("migration-snap").Return(nil).AnyTimes(),
 		mockVMOps.EXPECT().UpdateDiskInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes(),
-		mockVMOps.EXPECT().UpdateDisksInfo(gomock.Any()).Return(nil).AnyTimes(),
+		mockVMOps.EXPECT().UpdateDisksInfo(gomock.Any(), gomock.Any()).Return(nil).AnyTimes(),
 		mockVMOps.EXPECT().GetVMInfo("linux", gomock.Any()).Return(vm.VMInfo{
 			Name:   "test-vm",
 			OSType: "linux",

--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,12 +27,18 @@ import (
 
 //go:generate mockgen -source=vmops.go -destination=vmops_mock.go -package=vm
 
+// MinCBTHardwareVersion is the minimum VMware virtual hardware version that
+// supports Changed Block Tracking (CBT). VMs on older hardware versions cannot
+// use CBT and must be migrated using cold migration. See VMware KB 1020128.
+const MinCBTHardwareVersion = 7
+
 type VMOperations interface {
 	GetVMInfo(ostype string, rdmDisks []string) (VMInfo, error)
 	GetVMObj() *object.VirtualMachine
 	UpdateDiskInfo(*VMInfo, VMDisk, bool) error
 	UpdateDisksInfo(*VMInfo) error
 	IsCBTEnabled() (bool, error)
+	GetHardwareVersion() (int, error)
 	EnableCBT() error
 	TakeSnapshot(name string) error
 	DeleteSnapshot(name string) error
@@ -552,7 +559,55 @@ func (vmops *VMOps) IsCBTEnabled() (bool, error) {
 			return false, fmt.Errorf("failed to get VM properties: %s", err)
 		}
 	}
+	// On VMs running virtual hardware version < 7, the changeTrackingEnabled
+	// property is not present in the VMware API response (CBT is unsupported on
+	// such hardware - see VMware KB 1020128). Treat an absent value as "CBT not
+	// enabled" instead of dereferencing a nil pointer and panicking.
+	if o.Config == nil || o.Config.ChangeTrackingEnabled == nil {
+		return false, nil
+	}
 	return *o.Config.ChangeTrackingEnabled, nil
+}
+
+// parseHardwareVersion extracts the numeric virtual hardware version from a
+// VMware config.version string such as "vmx-07". It returns 0 when the value is
+// empty or cannot be parsed.
+func parseHardwareVersion(version string) int {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(version), "vmx-")
+	if trimmed == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// GetHardwareVersion returns the numeric virtual hardware version of the VM
+// (e.g. 4 for "vmx-04", 13 for "vmx-13"). It returns 0 when the version cannot
+// be determined.
+func (vmops *VMOps) GetHardwareVersion() (int, error) {
+	vm := vmops.VMObj
+	var o mo.VirtualMachine
+	err := vm.Properties(vmops.ctx, vm.Reference(), []string{"config.version"}, &o)
+	if err != nil {
+		if !vcenter.IsTransientVCenterError(err) {
+			return 0, fmt.Errorf("failed to get VM properties: %s", err)
+		}
+		if err := vmops.RefreshVM(); err != nil {
+			return 0, fmt.Errorf("failed to refresh VM reference: %s", err)
+		}
+		vm = vmops.VMObj
+		err = vm.Properties(vmops.ctx, vm.Reference(), []string{"config.version"}, &o)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get VM properties: %s", err)
+		}
+	}
+	if o.Config == nil {
+		return 0, nil
+	}
+	return parseHardwareVersion(o.Config.Version), nil
 }
 
 func (vmops *VMOps) EnableCBT() error {

--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -386,12 +386,6 @@ func getChangeID(disk *types.VirtualDisk) (*ChangeID, error) {
 	return parseChangeID(changeId)
 }
 
-// UpdateDisksInfo records, for each VM disk, the backing file and name of the
-// current snapshot (needed to copy from the snapshot over NBD) and the CBT
-// change ID. When requireChangeID is false (cold migrations, which copy each
-// disk once in full while the VM is powered off and never use Changed Block
-// Tracking), a missing change ID is tolerated instead of failing - this is
-// expected on legacy virtual hardware (version < 7) where CBT is unsupported.
 func (vmops *VMOps) UpdateDisksInfo(vminfo *VMInfo, requireChangeID bool) error {
 	pc := vmops.vcclient.VCPropertyCollector
 	var snapbackingdisk []string
@@ -440,10 +434,8 @@ func (vmops *VMOps) UpdateDisksInfo(vminfo *VMInfo, requireChangeID bool) error 
 				var changeIDValue string
 				changeid, err := getChangeID(disk)
 				if err != nil {
-					// On cold migrations (requireChangeID == false) CBT is never
-					// used, so a missing change ID is expected - particularly on
-					// legacy hardware (version < 7). Record the backing disk info
-					// and continue without a change ID instead of failing.
+					// For cold migrations, CBT is not used. Missing change IDs are expected
+					// (especially on hardware version < 7), so continue without failing.
 					if requireChangeID {
 						return fmt.Errorf("failed to get change ID for device key %d: %s", disk.Key, err)
 					}
@@ -575,10 +567,8 @@ func (vmops *VMOps) IsCBTEnabled() (bool, error) {
 			return false, fmt.Errorf("failed to get VM properties: %s", err)
 		}
 	}
-	// On VMs running virtual hardware version < 7, the changeTrackingEnabled
-	// property is not present in the VMware API response (CBT is unsupported on
-	// such hardware - see VMware KB 1020128). Treat an absent value as "CBT not
-	// enabled" instead of dereferencing a nil pointer and panicking.
+	// CBT is unsupported on virtual hardware < 7. If changeTrackingEnabled
+	// is absent, treat CBT as disabled and avoid nil pointer dereferences.
 	if o.Config == nil || o.Config.ChangeTrackingEnabled == nil {
 		return false, nil
 	}
@@ -593,11 +583,11 @@ func parseHardwareVersion(version string) int {
 	if trimmed == "" {
 		return 0
 	}
-	n, err := strconv.Atoi(trimmed)
+	parsedHarwareVersion, err := strconv.Atoi(trimmed)
 	if err != nil {
 		return 0
 	}
-	return n
+	return parsedHarwareVersion
 }
 
 // GetHardwareVersion returns the numeric virtual hardware version of the VM

--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -36,7 +36,7 @@ type VMOperations interface {
 	GetVMInfo(ostype string, rdmDisks []string) (VMInfo, error)
 	GetVMObj() *object.VirtualMachine
 	UpdateDiskInfo(*VMInfo, VMDisk, bool) error
-	UpdateDisksInfo(*VMInfo) error
+	UpdateDisksInfo(*VMInfo, bool) error
 	IsCBTEnabled() (bool, error)
 	GetHardwareVersion() (int, error)
 	EnableCBT() error
@@ -386,7 +386,13 @@ func getChangeID(disk *types.VirtualDisk) (*ChangeID, error) {
 	return parseChangeID(changeId)
 }
 
-func (vmops *VMOps) UpdateDisksInfo(vminfo *VMInfo) error {
+// UpdateDisksInfo records, for each VM disk, the backing file and name of the
+// current snapshot (needed to copy from the snapshot over NBD) and the CBT
+// change ID. When requireChangeID is false (cold migrations, which copy each
+// disk once in full while the VM is powered off and never use Changed Block
+// Tracking), a missing change ID is tolerated instead of failing - this is
+// expected on legacy virtual hardware (version < 7) where CBT is unsupported.
+func (vmops *VMOps) UpdateDisksInfo(vminfo *VMInfo, requireChangeID bool) error {
 	pc := vmops.vcclient.VCPropertyCollector
 	var snapbackingdisk []string
 	var snapname []string
@@ -431,16 +437,26 @@ func (vmops *VMOps) UpdateDisksInfo(vminfo *VMInfo) error {
 			case *types.VirtualDisk:
 				backing := disk.Backing.(types.BaseVirtualDeviceFileBackingInfo)
 				info := backing.GetVirtualDeviceFileBackingInfo()
+				var changeIDValue string
 				changeid, err := getChangeID(disk)
 				if err != nil {
-					return fmt.Errorf("failed to get change ID for device key %d: %s", disk.Key, err)
+					// On cold migrations (requireChangeID == false) CBT is never
+					// used, so a missing change ID is expected - particularly on
+					// legacy hardware (version < 7). Record the backing disk info
+					// and continue without a change ID instead of failing.
+					if requireChangeID {
+						return fmt.Errorf("failed to get change ID for device key %d: %s", disk.Key, err)
+					}
+					log.Printf("Change ID unavailable for device key %d (%s); continuing without CBT", disk.Key, err)
+				} else {
+					changeIDValue = changeid.Value
 				}
 				snapshotInfo[disk.Key] = struct {
 					FileName string
 					ChangeID string
 				}{
 					FileName: info.FileName,
-					ChangeID: changeid.Value,
+					ChangeID: changeIDValue,
 				}
 			}
 		}

--- a/v2v-helper/vm/vmops_mock.go
+++ b/v2v-helper/vm/vmops_mock.go
@@ -193,6 +193,21 @@ func (mr *MockVMOperationsMockRecorder) IsCBTEnabled() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsCBTEnabled", reflect.TypeOf((*MockVMOperations)(nil).IsCBTEnabled))
 }
 
+// GetHardwareVersion mocks base method.
+func (m *MockVMOperations) GetHardwareVersion() (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHardwareVersion")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHardwareVersion indicates an expected call of GetHardwareVersion.
+func (mr *MockVMOperationsMockRecorder) GetHardwareVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHardwareVersion", reflect.TypeOf((*MockVMOperations)(nil).GetHardwareVersion))
+}
+
 // ListSnapshots mocks base method.
 func (m *MockVMOperations) ListSnapshots() ([]types.VirtualMachineSnapshotTree, error) {
 	m.ctrl.T.Helper()

--- a/v2v-helper/vm/vmops_mock.go
+++ b/v2v-helper/vm/vmops_mock.go
@@ -252,17 +252,17 @@ func (mr *MockVMOperationsMockRecorder) UpdateDiskInfo(arg0, arg1, arg2 interfac
 }
 
 // UpdateDisksInfo mocks base method.
-func (m *MockVMOperations) UpdateDisksInfo(arg0 *VMInfo) error {
+func (m *MockVMOperations) UpdateDisksInfo(arg0 *VMInfo, arg1 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateDisksInfo", arg0)
+	ret := m.ctrl.Call(m, "UpdateDisksInfo", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateDisksInfo indicates an expected call of UpdateDisksInfo.
-func (mr *MockVMOperationsMockRecorder) UpdateDisksInfo(arg0 interface{}) *gomock.Call {
+func (mr *MockVMOperationsMockRecorder) UpdateDisksInfo(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDisksInfo", reflect.TypeOf((*MockVMOperations)(nil).UpdateDisksInfo), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDisksInfo", reflect.TypeOf((*MockVMOperations)(nil).UpdateDisksInfo), arg0, arg1)
 }
 
 // VMGuestShutdown mocks base method.

--- a/v2v-helper/vm/vmops_test.go
+++ b/v2v-helper/vm/vmops_test.go
@@ -161,6 +161,47 @@ func TestIsCBTEnabled(t *testing.T) {
 	assert.True(t, enabled)
 }
 
+func TestParseHardwareVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    int
+	}{
+		{name: "legacy hardware version 4", version: "vmx-04", want: 4},
+		{name: "minimum CBT-capable version 7", version: "vmx-07", want: 7},
+		{name: "modern double-digit version", version: "vmx-13", want: 13},
+		{name: "version without leading zero", version: "vmx-4", want: 4},
+		{name: "surrounding whitespace", version: " vmx-09 ", want: 9},
+		{name: "empty string", version: "", want: 0},
+		{name: "missing numeric suffix", version: "vmx-", want: 0},
+		{name: "unparseable value", version: "vmx-abc", want: 0},
+		{name: "unexpected format", version: "esx-7", want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseHardwareVersion(tt.version); got != tt.want {
+				t.Errorf("parseHardwareVersion(%q) = %d, want %d", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetHardwareVersion(t *testing.T) {
+	simVC, model, server, err := simulateVCenter()
+	defer cleanupSimulator(model, server)
+	assert.Nil(t, err)
+
+	vmName := "DC0_H0_VM0"
+	vmops, _ := VMOpsBuilder(context.Background(), *simVC, vmName, "", nil)
+
+	hwVersion, err := vmops.GetHardwareVersion()
+	assert.NoError(t, err)
+	// The govmomi simulator reports a modern, CBT-capable hardware version for
+	// its default VMs. We assert it is positive and at least the CBT minimum so
+	// the test stays robust against simulator version bumps.
+	assert.GreaterOrEqual(t, hwVersion, MinCBTHardwareVersion)
+}
+
 func TestTakeSnapshot(t *testing.T) {
 	simVC, model, server, err := simulateVCenter()
 	defer cleanupSimulator(model, server)

--- a/v2v-helper/vm/vmops_test.go
+++ b/v2v-helper/vm/vmops_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
@@ -200,6 +201,100 @@ func TestGetHardwareVersion(t *testing.T) {
 	// its default VMs. We assert it is positive and at least the CBT minimum so
 	// the test stays robust against simulator version bumps.
 	assert.GreaterOrEqual(t, hwVersion, MinCBTHardwareVersion)
+}
+
+func TestGetChangeID(t *testing.T) {
+	tests := []struct {
+		name      string
+		disk      *types.VirtualDisk
+		wantErr   string
+		wantValue string
+	}{
+		{
+			name: "CBT disabled - empty change ID on flat backing",
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					Key:     2000,
+					Backing: &types.VirtualDiskFlatVer2BackingInfo{ChangeId: ""},
+				},
+			},
+			wantErr: "CBT is not enabled on disk 2000",
+		},
+		{
+			name: "CBT enabled - valid change ID is parsed",
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					Key:     2000,
+					Backing: &types.VirtualDiskFlatVer2BackingInfo{ChangeId: "52 3c/446"},
+				},
+			},
+			wantValue: "52 3c/446",
+		},
+		{
+			name: "unsupported backing type",
+			disk: &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					Key:     2000,
+					Backing: &types.VirtualDeviceFileBackingInfo{},
+				},
+			},
+			wantErr: "failed to get change ID",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changeID, err := getChangeID(tt.disk)
+			if tt.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantValue, changeID.Value)
+		})
+	}
+}
+
+// TestUpdateDisksInfoToleratesMissingChangeID verifies the cold-migration fix:
+// when requireChangeID is false, a snapshot disk without a CBT change ID (as on
+// legacy hardware version < 7) does not fail the call, and the snapshot backing
+// disk/name still get recorded so the disk can be copied over NBD.
+func TestUpdateDisksInfoToleratesMissingChangeID(t *testing.T) {
+	simVC, model, server, err := simulateVCenter()
+	defer cleanupSimulator(model, server)
+	assert.Nil(t, err)
+
+	vmName := "DC0_H0_VM0"
+	vmops, _ := VMOpsBuilder(context.Background(), *simVC, vmName, "", nil)
+
+	// Deliberately do NOT enable CBT, then snapshot - this mirrors a cold
+	// migration of a VM whose disks carry no change ID.
+	err = vmops.TakeSnapshot("cold-test-snap")
+	assert.NoError(t, err)
+
+	// Build VMInfo disks from the simulator VM's actual virtual disks so the
+	// device keys match what UpdateDisksInfo reads from the snapshot.
+	var o mo.VirtualMachine
+	err = vmops.VMObj.Properties(context.Background(), vmops.VMObj.Reference(), []string{"config.hardware.device"}, &o)
+	assert.NoError(t, err)
+
+	vminfo := &VMInfo{}
+	for _, device := range o.Config.Hardware.Device {
+		if vd, ok := device.(*types.VirtualDisk); ok {
+			vminfo.VMDisks = append(vminfo.VMDisks, VMDisk{
+				Name: "disk-0",
+				Disk: vd,
+			})
+		}
+	}
+	assert.NotEmpty(t, vminfo.VMDisks, "simulator VM should have at least one disk")
+
+	// requireChangeID == false: cold migration must not fail on a missing CBT
+	// change ID, and the snapshot backing disk must still be recorded.
+	err = vmops.UpdateDisksInfo(vminfo, false)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, vminfo.VMDisks[0].SnapBackingDisk)
+	assert.NotEmpty(t, vminfo.VMDisks[0].Snapname)
 }
 
 func TestTakeSnapshot(t *testing.T) {


### PR DESCRIPTION
## What this PR does / why we need it
This PR Fixes the panic in the code when we check for iscbtenabled. also added guardrails to check for cbt only when necessary. For cold migration we do not need to check for cbt and if hardware version is less than 4 we need to error out gracefully and give the appropriate error. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1901 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/2037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->