### PR TITLE
prebake proxy VM OVA into appliance image

### DIFF
--- a/image_builder/scripts/install.sh
+++ b/image_builder/scripts/install.sh
@@ -497,33 +497,6 @@ if [ "$IS_MASTER" == "true" ]; then
     fi
   fi
 
-  # Fetch the proxy VM OVA so Hot-Add migrations are ready immediately.
-  # Re-running this block (or the fetch function directly) replaces the file,
-  # allowing OVA updates by changing PROXY_VM_OVA_URL in vjailbreak-settings.
-  fetch_proxy_vm_ova() {
-    local ova_dir="/home/ubuntu/proxy-vm-template"
-    local ova_file="${ova_dir}/ha-proxy-vm.ova"
-    local default_url="https://vjailbreak-dev.s3.us-west-2.amazonaws.com/hot-add/ha-proxy-vm.ova"
-    local ova_url
-
-    log "Creating proxy VM OVA directory: ${ova_dir}"
-    mkdir -p "$ova_dir"
-
-    ova_url=$(kubectl -n migration-system get configmap vjailbreak-settings \
-      -o jsonpath="{.data.PROXY_VM_OVA_URL}" 2>/dev/null || true)
-    ova_url="${ova_url:-$default_url}"
-
-    log "Fetching proxy VM OVA from ${ova_url}..."
-    if curl -fsSL --retry 3 --retry-delay 5 -o "${ova_file}.tmp" "$ova_url"; then
-      mv "${ova_file}.tmp" "$ova_file"
-      log "Proxy VM OVA saved to ${ova_file}"
-    else
-      rm -f "${ova_file}.tmp"
-      log "WARNING: Failed to download proxy VM OVA from ${ova_url}. Hot-Add will not be available until the OVA is present."
-    fi
-  }
-  fetch_proxy_vm_ova
-
 else
   log "Setting up K3s Worker..."
 

--- a/image_builder/vjailbreak-image.pkr.hcl
+++ b/image_builder/vjailbreak-image.pkr.hcl
@@ -32,6 +32,11 @@ variable "ingress_nginx_version" {
   default = "4.14.3"
 }
 
+variable "proxy_vm_ova_url" {
+  type    = string
+  default = "https://vjailbreak-dev.s3.us-west-2.amazonaws.com/hot-add/ha-proxy-vm.ova"
+}
+
 source "qemu" "vjailbreak-image" {
   disk_image           = true
   skip_compaction      = true
@@ -182,6 +187,19 @@ build {
     "sudo helm pull ingress-nginx/ingress-nginx --version ${var.ingress_nginx_version} --untar --untardir /etc/pf9/",
     "sudo apt-get clean",
     "sudo rm -rf /var/lib/apt/lists/*",
+    ]
+  }
+
+  provisioner "shell" {
+    environment_vars = [
+      "PROXY_VM_OVA_URL=${var.proxy_vm_ova_url}"
+    ]
+    inline = [
+      "sudo mkdir -p /home/ubuntu/proxy-vm-template",
+      "sudo chown ubuntu:ubuntu /home/ubuntu/proxy-vm-template",
+      "echo 'Downloading proxy VM OVA from '\"$PROXY_VM_OVA_URL\"' ...'",
+      "curl -fsSL --retry 3 --retry-delay 10 -o /home/ubuntu/proxy-vm-template/ha-proxy-vm.ova \"$PROXY_VM_OVA_URL\"",
+      "echo 'Proxy VM OVA downloaded successfully.'",
     ]
   }
 }

--- a/pkg/vpwned/server/ova_prefetch.go
+++ b/pkg/vpwned/server/ova_prefetch.go
@@ -2,16 +2,23 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/platform9/vjailbreak/pkg/common/constants"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 )
+
+var ovaDownloadMu sync.Mutex
 
 func resolveOVAURL() string {
 	if k8sAuthClient == nil {
@@ -30,59 +37,160 @@ func resolveOVAURL() string {
 	return constants.ProxyVMOVAURLDefault
 }
 
-func prefetchProxyVMOVA() {
+// validateOVAURL checks that rawURL is a reachable http/https URL.
+func validateOVAURL(rawURL string) error {
+	if rawURL == "" {
+		return fmt.Errorf("URL is empty")
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %v", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("URL scheme must be http or https, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("URL has no host")
+	}
+	resp, err := http.Head(rawURL) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("URL not reachable: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		return fmt.Errorf("URL returned HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// downloadOVAFromURL downloads ovaURL and atomically replaces the OVA file.
+// A mutex serialises concurrent calls so only one download runs at a time.
+func downloadOVAFromURL(ovaURL string) error {
+	ovaDownloadMu.Lock()
+	defer ovaDownloadMu.Unlock()
+
 	dest := filepath.Join(constants.ProxyVMOVADir, constants.ProxyVMOVAFileName)
+	tmp := dest + ".tmp"
 
 	if err := os.MkdirAll(constants.ProxyVMOVADir, 0755); err != nil {
-		logrus.Errorf("ova-prefetch: failed to create directory %s: %v", constants.ProxyVMOVADir, err)
-		return
+		return fmt.Errorf("mkdir: %v", err)
 	}
 
-	if _, err := os.Stat(dest); err == nil {
-		logrus.Infof("ova-prefetch: %s already exists, skipping download", dest)
-		return
-	}
-
-	url := resolveOVAURL()
-	logrus.Infof("ova-prefetch: downloading %s → %s", url, dest)
-
-	tmp := dest + ".tmp"
 	f, err := os.Create(tmp)
 	if err != nil {
-		logrus.Errorf("ova-prefetch: failed to create temp file: %v", err)
-		return
+		return fmt.Errorf("create temp file: %v", err)
 	}
 	defer func() {
 		f.Close()
 		os.Remove(tmp)
 	}()
 
-	resp, err := http.Get(url) //nolint:gosec
+	resp, err := http.Get(ovaURL) //nolint:gosec
 	if err != nil {
-		logrus.Errorf("ova-prefetch: download failed: %v", err)
-		return
+		return fmt.Errorf("download: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		logrus.Errorf("ova-prefetch: unexpected HTTP status %d", resp.StatusCode)
-		return
+		return fmt.Errorf("unexpected HTTP status %d", resp.StatusCode)
 	}
 
 	if _, err := io.Copy(f, resp.Body); err != nil {
-		logrus.Errorf("ova-prefetch: write failed: %v", err)
-		return
+		return fmt.Errorf("write: %v", err)
 	}
-
 	if err := f.Close(); err != nil {
-		logrus.Errorf("ova-prefetch: close failed: %v", err)
+		return fmt.Errorf("close: %v", err)
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		return fmt.Errorf("rename: %v", err)
+	}
+	return nil
+}
+
+// prefetchProxyVMOVA downloads the OVA at startup if it is not already present.
+func prefetchProxyVMOVA() {
+	dest := filepath.Join(constants.ProxyVMOVADir, constants.ProxyVMOVAFileName)
+
+	if _, err := os.Stat(dest); err == nil {
+		logrus.Infof("ova-prefetch: %s already exists, skipping download", dest)
 		return
 	}
 
-	if err := os.Rename(tmp, dest); err != nil {
-		logrus.Errorf("ova-prefetch: rename failed: %v", err)
+	ovaURL := resolveOVAURL()
+	logrus.Infof("ova-prefetch: downloading %s → %s", ovaURL, dest)
+
+	if err := downloadOVAFromURL(ovaURL); err != nil {
+		logrus.Errorf("ova-prefetch: %v", err)
 		return
 	}
 
 	logrus.Infof("ova-prefetch: download complete → %s", dest)
+}
+
+// watchOVAURLChanges watches vjailbreak-settings for PROXY_VM_OVA_URL updates.
+// When the URL changes to a valid, reachable value the OVA is re-downloaded and
+// the existing file is atomically replaced (filename stays ha-proxy-vm.ova).
+func watchOVAURLChanges(ctx context.Context) {
+	if k8sAuthClient == nil {
+		logrus.Warn("ova-watch-url: k8s client not available, skipping URL watcher")
+		return
+	}
+
+	currentURL := resolveOVAURL()
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		watcher, err := k8sAuthClient.CoreV1().ConfigMaps(migrationSystemNamespace).Watch(ctx, metav1.ListOptions{
+			FieldSelector: "metadata.name=vjailbreak-settings",
+		})
+		if err != nil {
+			logrus.Warnf("ova-watch-url: watch error: %v — retrying in 30s", err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(30 * time.Second):
+				continue
+			}
+		}
+
+		for event := range watcher.ResultChan() {
+			if event.Type != watch.Modified {
+				continue
+			}
+			cm, ok := event.Object.(*corev1.ConfigMap)
+			if !ok {
+				continue
+			}
+			newURL := cm.Data[constants.ProxyVMOVAURLKey]
+			if newURL == "" || newURL == currentURL {
+				continue
+			}
+
+			logrus.Infof("ova-watch-url: PROXY_VM_OVA_URL changed to %q — validating...", newURL)
+
+			if err := validateOVAURL(newURL); err != nil {
+				logrus.Errorf("ova-watch-url: new URL %q failed validation: %v — keeping existing OVA", newURL, err)
+				continue
+			}
+
+			logrus.Infof("ova-watch-url: downloading new OVA from %q", newURL)
+			if err := downloadOVAFromURL(newURL); err != nil {
+				logrus.Errorf("ova-watch-url: download failed: %v — keeping existing OVA", err)
+				continue
+			}
+
+			currentURL = newURL
+			logrus.Infof("ova-watch-url: OVA updated successfully from %q", newURL)
+		}
+
+		watcher.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(5 * time.Second):
+		}
+	}
 }

--- a/pkg/vpwned/server/server.go
+++ b/pkg/vpwned/server/server.go
@@ -209,6 +209,7 @@ func StartServer(host, port, apiPort, apiHost string) error {
 	defer cncl()
 
 	go prefetchProxyVMOVA()
+	go watchOVAURLChanges(ctx)
 
 	go func() {
 		if err := startgRPCServer(ctx, "tcp", host+":"+port); err != nil {


### PR DESCRIPTION
prebaking the proxy VM template and adding a watcher on configmap proxy url value on change the template pulled from the updated url with appropriate url validations and failsafe mechanisms

fixes: #2039


__Testing Done__

### Pre baked ova template
<img width="1440" height="877" alt="image" src="https://github.com/user-attachments/assets/9b64ea5f-d9f6-479d-8ef6-77c4169fc9e9" />

### Re-fetch on url change in configmap
<img width="1440" height="420" alt="image" src="https://github.com/user-attachments/assets/0711d057-810a-4e1c-b410-412e9984cd74" />
