### PR TITLE
Don't call openstackcreds per cluster to get tenant name

### DIFF
--- a/ui/src/api/openstack-creds/openstackCreds.ts
+++ b/ui/src/api/openstack-creds/openstackCreds.ts
@@ -3,12 +3,37 @@ import axios from '../axios'
 import { VJAILBREAK_API_BASE_PATH, VJAILBREAK_DEFAULT_NAMESPACE } from '../constants'
 import { GetOpenstackCredsList, OpenstackCreds } from './model'
 
-export const getOpenstackCredentialsList = async (namespace = VJAILBREAK_DEFAULT_NAMESPACE) => {
+// Page size for the paginated list below. Keeps each response small/fast and
+// avoids a single oversized list response at scale (100s of large creds).
+const OPENSTACK_CREDS_LIST_PAGE_SIZE = 50
+
+export const getOpenstackCredentialsList = async (
+  namespace = VJAILBREAK_DEFAULT_NAMESPACE
+): Promise<OpenstackCreds[]> => {
   const endpoint = `${VJAILBREAK_API_BASE_PATH}/namespaces/${namespace}/openstackcreds`
-  const response = await axios.get<GetOpenstackCredsList>({
-    endpoint
-  })
-  return response?.items
+
+  // Fetch all credentials by following the Kubernetes list `continue` token.
+  // The token is an opaque bookmark; we echo it back until the API returns an
+  // empty one, which signals the last page. For small datasets this is a single
+  // request (no token returned), identical to the previous unpaginated call.
+  const allCreds: OpenstackCreds[] = []
+  let continueToken: string | undefined
+
+  do {
+    const response = await axios.get<GetOpenstackCredsList>({
+      endpoint,
+      config: {
+        params: {
+          limit: OPENSTACK_CREDS_LIST_PAGE_SIZE,
+          ...(continueToken ? { continue: continueToken } : {})
+        }
+      }
+    })
+    allCreds.push(...(response?.items || []))
+    continueToken = response?.metadata?.continue || undefined
+  } while (continueToken)
+
+  return allCreds
 }
 
 export const getOpenstackCredentials = async (name, namespace = VJAILBREAK_DEFAULT_NAMESPACE) => {

--- a/ui/src/features/migration/hooks/useClusterData.ts
+++ b/ui/src/features/migration/hooks/useClusterData.ts
@@ -114,13 +114,6 @@ export const useClusterData = (autoFetch: boolean = true): UseClusterDataReturn 
     setLoadingPCD(true)
     setError(null)
     try {
-      // Fetch PCD clusters and all OpenStack credentials in parallel. Fetching
-      // the full creds list once (instead of one request per cluster) avoids an
-      // N+1 request storm that, at scale (100s of creds), causes some per-cred
-      // requests to be throttled/fail and leaves the tenant field unpopulated.
-      // Tenant name is a non-critical display detail, so a failure to load the
-      // credentials list must not block the cluster list from rendering. Catch
-      // it independently and fall back to an empty list (blank tenant names).
       const [pcdClusters, openstackCredsList] = await Promise.all([
         getPCDClusters(VJAILBREAK_DEFAULT_NAMESPACE),
         getOpenstackCredentialsList(VJAILBREAK_DEFAULT_NAMESPACE).catch((err) => {

--- a/ui/src/features/migration/hooks/useClusterData.ts
+++ b/ui/src/features/migration/hooks/useClusterData.ts
@@ -2,11 +2,12 @@ import { useState, useEffect } from 'react'
 import { getVmwareCredentialsList } from 'src/api/vmware-creds/vmwareCreds'
 import { getVMwareClusters } from 'src/api/vmware-clusters/vmwareClusters'
 import { getPCDClusters } from 'src/api/pcd-clusters'
-import { getOpenstackCredentials } from 'src/api/openstack-creds/openstackCreds'
+import { getOpenstackCredentialsList } from 'src/api/openstack-creds/openstackCreds'
 import { VJAILBREAK_DEFAULT_NAMESPACE } from 'src/api/constants'
 import { VMwareCreds } from 'src/api/vmware-creds/model'
 import { VMwareCluster } from 'src/api/vmware-clusters/model'
 import { PCDCluster } from 'src/api/pcd-clusters/model'
+import { OpenstackCreds } from 'src/api/openstack-creds/model'
 
 export interface SourceDataItem {
   credName: string
@@ -113,40 +114,47 @@ export const useClusterData = (autoFetch: boolean = true): UseClusterDataReturn 
     setLoadingPCD(true)
     setError(null)
     try {
-      const pcdClusters = await getPCDClusters(VJAILBREAK_DEFAULT_NAMESPACE)
+      // Fetch PCD clusters and all OpenStack credentials in parallel. Fetching
+      // the full creds list once (instead of one request per cluster) avoids an
+      // N+1 request storm that, at scale (100s of creds), causes some per-cred
+      // requests to be throttled/fail and leaves the tenant field unpopulated.
+      // Tenant name is a non-critical display detail, so a failure to load the
+      // credentials list must not block the cluster list from rendering. Catch
+      // it independently and fall back to an empty list (blank tenant names).
+      const [pcdClusters, openstackCredsList] = await Promise.all([
+        getPCDClusters(VJAILBREAK_DEFAULT_NAMESPACE),
+        getOpenstackCredentialsList(VJAILBREAK_DEFAULT_NAMESPACE).catch((err) => {
+          console.error('Failed to fetch OpenStack credentials list:', err)
+          return undefined
+        })
+      ])
 
       if (!pcdClusters || pcdClusters.items.length === 0) {
         setPcdData([])
         return
       }
 
-      const clusterDataPromises = pcdClusters.items.map(async (cluster: PCDCluster) => {
+      // Build an in-memory lookup of credential name -> tenant (projectName).
+      const projectNameByCred = new Map<string, string>(
+        (openstackCredsList || []).map((cred: OpenstackCreds) => [
+          cred.metadata.name,
+          cred.spec?.projectName || ''
+        ])
+      )
+
+      const clusterData = pcdClusters.items.map((cluster: PCDCluster) => {
         const clusterName = cluster.spec.clusterName
         const openstackCredName =
           cluster.metadata.labels?.['vjailbreak.k8s.pf9.io/openstackcreds'] || ''
-
-        let tenantName = ''
-        if (openstackCredName) {
-          try {
-            const openstackCreds = await getOpenstackCredentials(
-              openstackCredName,
-              VJAILBREAK_DEFAULT_NAMESPACE
-            )
-            tenantName = openstackCreds?.spec?.projectName || ''
-          } catch (error) {
-            console.error(`Failed to fetch OpenStack credentials for ${openstackCredName}:`, error)
-          }
-        }
 
         return {
           id: cluster.metadata.name,
           name: clusterName,
           openstackCredName: openstackCredName,
-          tenantName: tenantName
+          tenantName: openstackCredName ? projectNameByCred.get(openstackCredName) || '' : ''
         }
       })
 
-      const clusterData = await Promise.all(clusterDataPromises)
       setPcdData(clusterData)
     } catch (error) {
       console.error('Failed to fetch PCD clusters:', error)


### PR DESCRIPTION
## What this PR does / why we need it
This PR adds the change instead of calling every openstackcreds to get tenant. get list of openstackcreds before hand and get tenant name from in memory objectl. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #2053. 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/2057" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->