### PR TITLE
[2054] fix(retry): prefilled IP overrides not shown in Assign IP dialog on retry form

### DIFF
--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -3285,7 +3285,7 @@
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/deploy/05controller-deployment.yaml": {
-    "mtime": 1782457646.4173617,
+    "mtime": 1782717789.0692325,
     "ast_hash": "4958f2c242d98fc181ba0ed022fe0fbe",
     "semantic_hash": ""
   },
@@ -3300,7 +3300,7 @@
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/deploy/installer.yaml": {
-    "mtime": 1782494474.751115,
+    "mtime": 1782717788.9970345,
     "ast_hash": "c17deb083747b821d88406b3965e7f1c",
     "semantic_hash": ""
   },
@@ -3315,7 +3315,7 @@
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/deploy/06vpwned-deployment.yaml": {
-    "mtime": 1782457646.4175577,
+    "mtime": 1782717789.1032274,
     "ast_hash": "4928810eefdb14b286b5c7fb26aeaaf5",
     "semantic_hash": ""
   },
@@ -3325,7 +3325,7 @@
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/deploy/00crds.yaml": {
-    "mtime": 1782494474.7494135,
+    "mtime": 1782717789.0332675,
     "ast_hash": "cbdbfdd2ec104b2d8f5510c6bde6429c",
     "semantic_hash": ""
   },
@@ -3345,7 +3345,7 @@
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/deploy/07ui-deployment.yaml": {
-    "mtime": 1782457646.417734,
+    "mtime": 1782717789.1370435,
     "ast_hash": "e2ea31d8c15a51c62f71a431e4e123a4",
     "semantic_hash": ""
   },
@@ -3880,7 +3880,7 @@
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/rbac/role.yaml": {
-    "mtime": 1782457667.9468489,
+    "mtime": 1782717785.7926183,
     "ast_hash": "b32981280259721798f38ce2e5438e3a",
     "semantic_hash": ""
   },
@@ -4060,7 +4060,7 @@
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/addons/kustomization.yaml": {
-    "mtime": 1782394217.0796108,
+    "mtime": 1782717788.6013343,
     "ast_hash": "348e7aaa75a4a09fe2f441f0470cc511",
     "semantic_hash": ""
   },
@@ -4075,117 +4075,117 @@
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_rollingmigrationplans.yaml": {
-    "mtime": 1782394214.3330824,
+    "mtime": 1782717785.948288,
     "ast_hash": "3700b16634d9e18b8efe9e405a26e0aa",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationplans.yaml": {
-    "mtime": 1782394214.3027878,
+    "mtime": 1782717785.9389164,
     "ast_hash": "1ff61b359a5a6be2c77c4832e0d3ed29",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_clustermigrations.yaml": {
-    "mtime": 1782394214.297223,
+    "mtime": 1782717785.9337366,
     "ast_hash": "b703489ec168a2d51e0d0a7ffd27b8d3",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_networkmappings.yaml": {
-    "mtime": 1782394214.304766,
+    "mtime": 1782717785.9404368,
     "ast_hash": "2e017ff73b3071e819dc50f27bce7c13",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_esxisshcreds.yaml": {
-    "mtime": 1782394214.2996716,
+    "mtime": 1782717785.9361336,
     "ast_hash": "cfc1c923810570621643034c59749aa5",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_vmwarecreds.yaml": {
-    "mtime": 1782394214.345948,
+    "mtime": 1782717785.9509172,
     "ast_hash": "4bd2abf3f0e8eee320c9f7fb5b88c83f",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrations.yaml": {
-    "mtime": 1782394214.3011537,
+    "mtime": 1782717785.937354,
     "ast_hash": "f49e3a94582174ad80d2b99f1d67cf90",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationtemplates.yaml": {
-    "mtime": 1782394214.303929,
+    "mtime": 1782717785.939757,
     "ast_hash": "6c7a1492b4da016cc9fa1e938c494593",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_bmconfigs.yaml": {
-    "mtime": 1782394214.2957928,
+    "mtime": 1782717785.9318688,
     "ast_hash": "6f58073453ee91a43273ae067bb41fce",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_vmwareclusters.yaml": {
-    "mtime": 1782394214.3441393,
+    "mtime": 1782717785.9499617,
     "ast_hash": "9bb05b646372c28a81558c7870f1fa3f",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_rdmdisks.yaml": {
-    "mtime": 1782394214.3128119,
+    "mtime": 1782717785.946423,
     "ast_hash": "752cbc3c4a05b56222c17aaa703bbc8c",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_esximigrations.yaml": {
-    "mtime": 1782394214.2985706,
+    "mtime": 1782717785.9352121,
     "ast_hash": "8eb05afb799f0c6dc4fa67633cfd9d96",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_storagemappings.yaml": {
-    "mtime": 1782394214.3384445,
+    "mtime": 1782717785.949236,
     "ast_hash": "4b79c3a90d612e848220ea74f28c30db",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_pcdhosts.yaml": {
-    "mtime": 1782394214.3088615,
+    "mtime": 1782717785.944193,
     "ast_hash": "d2bc8e4c7fa18a9af32f98a9fc3a9035",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_pcdclusters.yaml": {
-    "mtime": 1782394214.3077006,
+    "mtime": 1782717785.9431672,
     "ast_hash": "46a6370fca8de4ecd53c672fdc763a2c",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_openstackcreds.yaml": {
-    "mtime": 1782394214.3067589,
+    "mtime": 1782717785.9423397,
     "ast_hash": "9194656da423ed488262147bafcb55b3",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_vjailbreaknodes.yaml": {
-    "mtime": 1782457646.4407895,
+    "mtime": 1782717785.9544375,
     "ast_hash": "3c4d381b3bdcbc614156b1bb0f000637",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_volumeimageprofiles.yaml": {
-    "mtime": 1782394214.3533356,
+    "mtime": 1782717785.9553366,
     "ast_hash": "f67713091e6a26b256477f98fa8afcc5",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_vmwaremachines.yaml": {
-    "mtime": 1782394214.3488193,
+    "mtime": 1782717785.9533389,
     "ast_hash": "de5125abc2028642131bd90a856e522f",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_proxyvms.yaml": {
-    "mtime": 1782457646.4401762,
+    "mtime": 1782717785.9451654,
     "ast_hash": "1d2eb5b505d11d5f0d81ba15c3961a01",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_vmwarehosts.yaml": {
-    "mtime": 1782394214.3471704,
+    "mtime": 1782717785.9519198,
     "ast_hash": "53df19f968c2bf691cddc50a1070f3fe",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_arraycreds.yaml": {
-    "mtime": 1782394214.2925894,
+    "mtime": 1782717785.924122,
     "ast_hash": "db3a84900edc7604179c66dac9c2885a",
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_arraycredsmappings.yaml": {
-    "mtime": 1782394214.2941453,
+    "mtime": 1782717785.929739,
     "ast_hash": "ac6a58529799e44faec64d1e5c58480d",
     "semantic_hash": ""
   },
@@ -4340,7 +4340,7 @@
     "semantic_hash": ""
   },
   "/Users/sarikagautam/vjailbreak/k8s/migration/config/manager/kustomization.yaml": {
-    "mtime": 1782394217.043608,
+    "mtime": 1782717788.5698712,
     "ast_hash": "5fb4cbd4e8d6c225264dc1f1742b359d",
     "semantic_hash": ""
   },

--- a/ui/e2e/migration/retry.spec.ts
+++ b/ui/e2e/migration/retry.spec.ts
@@ -598,6 +598,24 @@ test.describe('RET-005 — IP overrides are preserved and sent on Retry', () => 
     const cloneSpec = clonePlanPost?.body?.spec as Record<string, unknown>
     expect(cloneSpec?.networkOverridesPerVM).toBeNull()
   })
+
+  test('"Assign IP" dialog shows user-assigned IP from original plan, not raw VMware IP', async ({
+    page,
+  }) => {
+    // The IP-override plan is already set in beforeEach.
+    // VMware machine CR has ipAddress '192.168.1.150'; the plan override has
+    // preserveIP=false + UserAssignedIP='10.0.0.50'. The dialog must show 10.0.0.50.
+    await openRetryDrawer(page)
+    await expect(page.getByTestId('migration-form-retry')).toBeEnabled({ timeout: 10_000 })
+
+    await page.getByTestId('bulk-ip-edit-button').click()
+    const dialog = page.getByTestId('bulk-ip-dialog')
+    await expect(dialog).toBeVisible()
+
+    // User-assigned IP must appear; raw VMware IP must not.
+    await expect(dialog).toContainText('10.0.0.50')
+    await expect(dialog).not.toContainText('192.168.1.150')
+  })
 })
 
 // ─── RET-006: multi-VM plan warning banner ────────────────────────────────────

--- a/ui/src/features/migration/hooks/useVmsSelectionState.ts
+++ b/ui/src/features/migration/hooks/useVmsSelectionState.ts
@@ -4,7 +4,7 @@ import { useVMwareMachinesQuery } from 'src/hooks/api/useVMwareMachinesQuery'
 import { useErrorHandler } from 'src/hooks/useErrorHandler'
 import { useAmplitude } from 'src/hooks/useAmplitude'
 import { useRdmConfigValidation } from 'src/hooks/useRdmConfigValidation'
-import { VmData } from 'src/features/migration/api/migration-templates/model'
+import { VmData, VmNetworkInterface } from 'src/features/migration/api/migration-templates/model'
 import { patchVMwareMachine } from 'src/api/vmware-machines/vmwareMachines'
 import { VJAILBREAK_DEFAULT_NAMESPACE } from 'src/api/constants'
 import { getMissingInterfaceIpWarnings } from '../components/missingInterfaceIpWarnings'
@@ -23,6 +23,26 @@ import { fromVmDataWithFlavor, fromVM, normalizeNetworkInterfaces } from '../uti
 import { useVmwareRevalidation } from 'src/hooks/api/useVmwareRevalidation'
 
 const { useCallback, useEffect, useMemo, useState } = React
+
+// Merges user-assigned IP addresses from the retry prefill into the VMware-fetched
+// NIC list. Only overrides ipAddress for NICs where preserveIp[i] === false
+// (user had a custom assignment). NICs with preserveIp[i] !== false keep the
+// VMware-fetched IP unchanged.
+function mergeNicIpOverrides(
+  existingNics: VmNetworkInterface[],
+  prefillNics: VmNetworkInterface[],
+  preserveIpMap: Record<number, boolean>,
+): VmNetworkInterface[] {
+  if (existingNics.length === 0) return existingNics
+  return existingNics.map((nic, i) => {
+    if (preserveIpMap[i] !== false) return nic
+    const prefillNic = prefillNics[i]
+    if (!prefillNic) return nic
+    const prefillIp = prefillNic.ipAddress
+    if (!prefillIp || prefillIp.length === 0) return nic
+    return { ...nic, ipAddress: prefillIp }
+  })
+}
 
 export function useVmsSelectionState(props: VmsSelectionStepProps) {
   const {
@@ -415,18 +435,17 @@ export function useVmsSelectionState(props: VmsSelectionStepProps) {
       const idx = prev.findIndex((v) => v.name === retryVmName)
       if (idx === -1) return prev
       const existing = prev[idx]
+      const mergedNetworkInterfaces = mergeNicIpOverrides(
+        existing.networkInterfaces ?? [],
+        retryPrefillVm.networkInterfaces ?? [],
+        retryPrefillVm.preserveIp ?? {},
+      )
       const updated = [...prev]
       updated[idx] = {
         ...existing,
         preserveIp: retryPrefillVm.preserveIp ?? existing.preserveIp,
         preserveMac: retryPrefillVm.preserveMac ?? existing.preserveMac,
-        // Only override ipAddress for NICs where user had a custom assignment
-        // (preserveIP=false). NICs with preserveIP=true keep the VMware-fetched IP.
-        networkInterfaces: existing.networkInterfaces?.map((nic, i) => {
-          const isUserAssigned = retryPrefillVm.preserveIp?.[i] === false
-          const prefillIp = retryPrefillVm.networkInterfaces?.[i]?.ipAddress
-          return isUserAssigned && prefillIp ? { ...nic, ipAddress: prefillIp } : nic
-        }) ?? existing.networkInterfaces,
+        networkInterfaces: mergedNetworkInterfaces,
       }
       return updated
     })

--- a/ui/src/features/migration/hooks/useVmsSelectionState.ts
+++ b/ui/src/features/migration/hooks/useVmsSelectionState.ts
@@ -40,6 +40,7 @@ export function useVmsSelectionState(props: VmsSelectionStepProps) {
     useGPU = false,
     showHeader = true,
     retryVmName,
+    retryPrefillVm,
     error,
     vmsWithAssignments: vmsWithAssignmentsProp = [],
     setVmsWithAssignments: setVmsWithAssignmentsProp,
@@ -391,14 +392,46 @@ export function useVmsSelectionState(props: VmsSelectionStepProps) {
   }, [vmsWithFlavor, retryVmName])
 
   // Auto-select the locked VM when it appears in retry mode.
+  // setFormVms is intentionally omitted: useRetryPrefill already sets params.vms
+  // with correct preserveIp/preserveMac/networkInterfaces from the original plan.
+  // Calling setFormVms here with raw API data would overwrite those values.
   useEffect(() => {
     if (!retryVmName || isRolling) return
     const vm = displayVmsWithFlavor.find((v) => v.name === retryVmName)
     if (!vm) return
     setSelectedVMs(new Set([vm.id]))
-    setFormVms([vm])
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [retryVmName, displayVmsWithFlavor])
+
+  // Merge prefilled IP override data into vmsWithFlavor so the "Assign IP" dialog
+  // shows the user's previous assignment instead of raw VMware machine IPs.
+  // Runs when either retryPrefillVm or displayVmsWithFlavor changes, covering both
+  // timing cases: prefill arrives before or after the VM list loads.
+  useEffect(() => {
+    if (!retryVmName || !retryPrefillVm || isRolling) return
+    const vmInList = displayVmsWithFlavor.find((v) => v.name === retryVmName)
+    if (!vmInList) return
+    setVmsWithFlavor((prev) => {
+      const idx = prev.findIndex((v) => v.name === retryVmName)
+      if (idx === -1) return prev
+      const existing = prev[idx]
+      const updated = [...prev]
+      updated[idx] = {
+        ...existing,
+        preserveIp: retryPrefillVm.preserveIp ?? existing.preserveIp,
+        preserveMac: retryPrefillVm.preserveMac ?? existing.preserveMac,
+        // Only override ipAddress for NICs where user had a custom assignment
+        // (preserveIP=false). NICs with preserveIP=true keep the VMware-fetched IP.
+        networkInterfaces: existing.networkInterfaces?.map((nic, i) => {
+          const isUserAssigned = retryPrefillVm.preserveIp?.[i] === false
+          const prefillIp = retryPrefillVm.networkInterfaces?.[i]?.ipAddress
+          return isUserAssigned && prefillIp ? { ...nic, ipAddress: prefillIp } : nic
+        }) ?? existing.networkInterfaces,
+      }
+      return updated
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [retryVmName, retryPrefillVm, displayVmsWithFlavor, isRolling])
 
   // --- Missing IP warnings ---
   const missingInterfaceIpWarnings = useMemo(

--- a/ui/src/features/migration/hooks/useVmsSelectionState.ts
+++ b/ui/src/features/migration/hooks/useVmsSelectionState.ts
@@ -22,7 +22,7 @@ import { useRollingColumns } from './useRollingColumns'
 import { fromVmDataWithFlavor, fromVM, normalizeNetworkInterfaces } from '../utils/vmAdapters'
 import { useVmwareRevalidation } from 'src/hooks/api/useVmwareRevalidation'
 
-const { useCallback, useEffect, useMemo, useState } = React
+const { useCallback, useEffect, useMemo, useRef, useState } = React
 
 // Merges user-assigned IP addresses from the retry prefill into the VMware-fetched
 // NIC list. Only overrides ipAddress for NICs where preserveIp[i] === false
@@ -87,6 +87,10 @@ export function useVmsSelectionState(props: VmsSelectionStepProps) {
   const [migratedVms, setMigratedVms] = useState<Set<string>>(new Set())
   const [loadingMigratedVms, setLoadingMigratedVms] = useState(false)
   const [vmsWithFlavor, setVmsWithFlavor] = useState<VmDataWithFlavor[]>([])
+  // Tracks whether the one-time retry prefill merge has been applied.
+  // Prevents the merge effect from re-firing when user changes vmsWithFlavor
+  // (e.g. via "Assign IP" dialog), which would overwrite their edits.
+  const retryPrefillMergedRef = useRef(false)
   // Stabilize openstackFlavors reference — default [] in destructuring creates new ref each render,
   // which would make the rebuild effect fire on every render (infinite loop).
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -398,6 +402,12 @@ export function useVmsSelectionState(props: VmsSelectionStepProps) {
           ipValidationStatus: 'pending' as const,
           ipValidationMessage: '',
           networkInterfaces: preferredNetworkInterfaces,
+          // Preserve user-applied IP override state (e.g. from retry prefill).
+          // Without this, rebuilds triggered by migratedVms/flavor changes would
+          // drop preserveIp, causing StandardIpAddressCell to fall back to the
+          // original VMware IP even when a custom IP was assigned.
+          ...(existingVm?.preserveIp !== undefined && { preserveIp: existingVm.preserveIp }),
+          ...(existingVm?.preserveMac !== undefined && { preserveMac: existingVm.preserveMac }),
         }
       })
     })
@@ -425,12 +435,15 @@ export function useVmsSelectionState(props: VmsSelectionStepProps) {
 
   // Merge prefilled IP override data into vmsWithFlavor so the "Assign IP" dialog
   // shows the user's previous assignment instead of raw VMware machine IPs.
-  // Runs when either retryPrefillVm or displayVmsWithFlavor changes, covering both
-  // timing cases: prefill arrives before or after the VM list loads.
+  // The ref guard ensures this runs exactly once: subsequent setVmsWithFlavor calls
+  // (e.g. user edits in "Assign IP" dialog) change displayVmsWithFlavor, which would
+  // re-trigger this effect and overwrite the user's changes without the guard.
   useEffect(() => {
     if (!retryVmName || !retryPrefillVm || isRolling) return
+    if (retryPrefillMergedRef.current) return
     const vmInList = displayVmsWithFlavor.find((v) => v.name === retryVmName)
     if (!vmInList) return
+    retryPrefillMergedRef.current = true
     setVmsWithFlavor((prev) => {
       const idx = prev.findIndex((v) => v.name === retryVmName)
       if (idx === -1) return prev

--- a/ui/src/features/migration/pages/MigrationForm.tsx
+++ b/ui/src/features/migration/pages/MigrationForm.tsx
@@ -529,6 +529,7 @@ export default function MigrationFormDrawer({
                     useGPU={params.useGPU}
                     showHeader={false}
                     retryVmName={retryConfig?.vmName}
+                    retryPrefillVm={params.vms?.[0]}
                   />
                 ) : (
                   <>

--- a/ui/src/features/migration/types.ts
+++ b/ui/src/features/migration/types.ts
@@ -314,6 +314,10 @@ export interface VmsSelectionStepProps {
   showHeader?: boolean
   // When set, the table shows only this VM (by name) and treats it as not migrated.
   retryVmName?: string
+  // Prefilled VmData from useRetryPrefill (carries preserveIp/preserveMac/networkInterfaces
+  // from the original plan). Merged into vmsWithFlavor so the "Assign IP" dialog shows
+  // the user's previous configuration instead of raw VMware machine data.
+  retryPrefillVm?: VmData
 
   // Rolling-mode props
   vmsWithAssignments?: VM[]


### PR DESCRIPTION
## What this PR does / why we need it
- Root Cause
  - useVmsSelectionState auto-selects the locked VM by calling setFormVms([vm]) with fresh VMware machine API data, overwriting the IP override data (preserveIp, networkInterfaces) that useRetryPrefill had correctly populated into params.vms from the original plan's networkOverridesPerVM.

- Fix
  - Removed setFormVms from the auto-select effect (prefill already owns params.vms). Added a separate effect that merges the prefilled IP override data into vmsWithFlavor — the local state that the "Assign IP" dialog reads from — so the dialog reflects the user's previous assignment instead of the raw VMware machine CR data.

## Which issue(s) this PR fixes

fixes #2054


## Testing done

https://github.com/user-attachments/assets/140d2ff2-1d4e-4909-a48b-3ecb9fb3574d


