### PR TITLE
[2062] fix - ssh keypair name missmatch

### DIFF
--- a/v2v-helper/pkg/k8sutils/k8sutils.go
+++ b/v2v-helper/pkg/k8sutils/k8sutils.go
@@ -273,9 +273,19 @@ func GetArrayCreds(ctx context.Context, k8sClient client.Client, arrayCredsName 
 }
 
 // GetHotAddPrivateKey retrieves the SSH private key used to connect to the given Proxy VM.
-// The secret is named "{proxyVMName}-hot-add-ssh-key" and is created during Proxy VM onboarding.
+// It checks ProxyVM.Spec.SSHKeyPairRef for an explicit secret name before falling back to
+// the default "{proxyVMName}-hot-add-ssh-key" convention.
 func GetHotAddPrivateKey(ctx context.Context, k8sClient client.Client, proxyVMName string) ([]byte, error) {
 	secretName := commonutils.HotAddSSHSecretName(proxyVMName)
+
+	proxyVM := &vjailbreakv1alpha1.ProxyVM{}
+	if err := k8sClient.Get(ctx, k8stypes.NamespacedName{
+		Name:      proxyVMName,
+		Namespace: constants.NamespaceMigrationSystem,
+	}, proxyVM); err == nil && proxyVM.Spec.SSHKeyPairRef != nil && proxyVM.Spec.SSHKeyPairRef.Name != "" {
+		secretName = proxyVM.Spec.SSHKeyPairRef.Name
+	}
+
 	secret := &corev1.Secret{}
 	if err := k8sClient.Get(ctx, k8stypes.NamespacedName{
 		Name:      secretName,


### PR DESCRIPTION


Fixes SSH secret lookup in v2v-helper for hot-add proxy VMs created via OVA template or generated key pair.

Fixes: #2062 
### Disk being attached properly on vcenter
<img width="1440" height="839" alt="image" src="https://github.com/user-attachments/assets/08e30563-239a-4368-a6c1-54b11144f3f9" />

### successfully established ssh connection, copy in progress
<img width="1113" height="685" alt="image" src="https://github.com/user-attachments/assets/007d7bfc-9a00-48e3-996a-5b0377ce64d5" />
