### PR TITLE
docs: update hot-add proxy docs and vCenter permission requirements

### DIFF
--- a/docs/src/content/docs/concepts/hot-add-proxy.md
+++ b/docs/src/content/docs/concepts/hot-add-proxy.md
@@ -54,30 +54,22 @@ The Proxy VM must be a **Linux-based OS** (recommended: Ubuntu, Alpine, or Debia
 
 ## Setting Up the Proxy VM
 
-### Option A: Deploy the Recommended OVA (Easiest)
+### Option A: Deploy from the vJailbreak UI (Easiest)
 
-Platform9 provides a pre-configured OVA with all required components installed:
+vJailbreak can deploy and register the Proxy VM in a single step directly from the UI:
 
-1. In vSphere Client, right-click the desired cluster or resource pool and select **Deploy OVF Template**
-2. Enter the following URL directly in the OVF source field:
-   ```
-   https://vjailbreak-dev.s3.us-west-2.amazonaws.com/hot-add/ha-proxy-vm.ova
-   ```
-3. Follow the deployment wizard, selecting the target datastore and network
-4. Power on the VM once deployed
+1. Navigate to **Hot-Add Proxy** in the left sidebar
+2. Click **Add Proxy VM** and select **Deploy a new vJailbreak Proxy VM**
+3. Select your VMware credentials and fill in the deployment target (datacenter, datastore, network, and optionally a cluster or host)
+4. Enter a unique VM name and click **Deploy & Register VM**
 
-**Default credentials for the OVA:**
-
-| Field | Value |
-|-------|-------|
-| Username | `root` |
-| Password | `password` |
+vJailbreak will import the pre-configured OVA into vCenter, power the VM on, generate and inject an SSH key pair automatically, and register the Proxy VM — no manual key setup required. The VM appears in the list with status **Deploying** and transitions to **Ready** once verification completes (typically 3–5 minutes).
 
 :::caution
-Change the default password immediately after deployment in production environments.
+The OVA image uses default credentials (`root` / `password`) for the initial SSH key injection step. Change the root password on the VM after deployment in production environments.
 :::
 
-### Option B: Use a Custom Linux VM
+### Option B: Register an Existing Linux VM
 
 Any Linux VM can serve as the Proxy VM provided it meets the requirements. Install the necessary utilities:
 
@@ -108,27 +100,49 @@ This setting is required for vJailbreak to match attached disks to their block d
 
 ## SSH Key Configuration
 
-vJailbreak SSHes into the Proxy VM using a key pair you provide. The setup is straightforward:
+:::note
+This section applies to **Option B** (registering an existing VM). When using Option A (UI-based OVA deploy), SSH keys are generated and injected automatically — no manual key steps are needed.
+:::
 
-1. Generate a key pair **anywhere** — your workstation, a jump host, or the Proxy VM itself
-2. Place the **public key** in the Proxy VM's `authorized_keys` file
-3. Paste the **private key** into the vJailbreak UI when registering the Proxy VM
+When registering an existing VM, vJailbreak needs SSH access to the Proxy VM. The UI offers two ways to provide the key pair:
 
-vJailbreak stores the private key as a Kubernetes secret and uses it during verification and migration.
+### Sub-option 1: Let vJailbreak Generate the Key Pair
 
-#### Step 1: Generate a Key Pair
+1. In the **Add Proxy VM** drawer, select **Register an existing VM**
+2. Select your VMware credentials and the VM
+3. Under **SSH Access**, choose **Generate Key Pair** and click **Generate**
+4. The UI displays the public key — copy it and add it to the Proxy VM's `authorized_keys`:
+   ```bash
+   # On the Proxy VM (as root)
+   echo "<paste public key here>" >> ~/.ssh/authorized_keys
+   chmod 600 ~/.ssh/authorized_keys
+   ```
+5. Click **Register**
 
-Run this on any machine you have access to:
+vJailbreak stores the generated private key as a Kubernetes secret automatically.
+
+### Sub-option 2: Upload Your Own Private Key
+
+If you have an existing key pair already configured on the VM:
+
+1. Under **SSH Access**, choose **Upload Private Key**
+2. Upload the private key file or paste its contents into the text area
+3. Confirm the corresponding public key is already in the VM's `authorized_keys`
+4. Click **Register**
+
+vJailbreak stores the uploaded private key as a Kubernetes secret and uses it during verification and migration.
+
+#### Generating a Key Pair Manually
+
+If you prefer to generate the key pair yourself outside of vJailbreak:
 
 ```bash
 ssh-keygen -t rsa -b 4096 -f proxy_vm_key -N ""
 ```
 
 This produces two files:
-- `proxy_vm_key` — private key (paste this into vJailbreak)
+- `proxy_vm_key` — private key (upload this into vJailbreak)
 - `proxy_vm_key.pub` — public key (add this to the Proxy VM)
-
-#### Step 2: Add the Public Key to the Proxy VM
 
 On the Proxy VM, append the public key to root's `authorized_keys`:
 
@@ -145,14 +159,6 @@ If you have temporary password SSH access, you can use `ssh-copy-id` from your w
 
 ```bash
 ssh-copy-id -i proxy_vm_key.pub root@<proxy-vm-ip>
-```
-
-#### Step 3: Keep the Private Key Ready
-
-You will paste the contents of `proxy_vm_key` into the vJailbreak UI in the next step. Display it with:
-
-```bash
-cat proxy_vm_key
 ```
 
 :::note
@@ -312,7 +318,7 @@ If the migration is stuck after taking the snapshot and the source VM remains po
 2. If the Proxy VM became unavailable, the migration will not auto-recover — clean up manually:
    ```bash
    # Remove the snapshot from vCenter
-   govc snapshot.remove -vm "<source-vm>" "vjailbreak-<migration-id>"
+   govc snapshot.remove -vm "<source-vm>" "vjailbreak-hotadd-snap"
    ```
 3. Detach any disks vJailbreak attached to the Proxy VM before retrying
 

--- a/docs/src/content/docs/concepts/migration-options.md
+++ b/docs/src/content/docs/concepts/migration-options.md
@@ -26,9 +26,16 @@ Determines the underlying mechanism used to transfer disk data.
   - ESXi SSH access configured
   - VMs must be powered off during copy (cold migration only)
 
+* **Hot-Add** - Attaches frozen snapshot disks directly to a Proxy VM running in vCenter and streams data over NBD to the destination. Works with any datastore type (NFS, VMFS, vSAN) and does not require a shared storage array. Requires:
+  - A registered Proxy VM in **Ready** state (Linux VM with `qemu-nbd` installed)
+  - SSH access from vJailbreak to the Proxy VM
+  - VMs must be powered off during copy (cold migration only)
+
 :::tip
 Storage-Accelerated Copy can be 10-100x faster than normal copy for large VMs. For a 1 TB disk, normal copy takes ~2.5 hours while Storage-Accelerated Copy can complete in 5-30 minutes.
 :::
+
+See [Hot-Add Proxy Migration](../hot-add-proxy/) for configuration instructions.
 
 See [Storage-Accelerated Copy](../storage-accelerated-copy/) for detailed configuration instructions.
 

--- a/docs/src/content/docs/introduction/prerequisites.md
+++ b/docs/src/content/docs/introduction/prerequisites.md
@@ -6,7 +6,10 @@ description: prerequisites for vJailbreak
 For frequently asked questions, see [FAQ](../faq/).
 
 ### What access do I need for my vCenter user to be able to perform this migration?
-Please refer to the following table for the required privileges:
+
+The required privileges depend on which features you use. The base set below is required for all migrations. Additional privileges are listed separately for Hot-Add Proxy and OVA-based Proxy VM deployment.
+
+#### Base Privileges (all migrations)
 
 | Privilege | Description |
 | --- | --- |
@@ -42,6 +45,29 @@ Please refer to the following table for the required privileges:
 | `Cryptographic` privileges: |     |
 | `Cryptographic.Decrypt` | Allows decryption of an encrypted virtual machine. |
 | `Cryptographic.Direct access` | Allows access to encrypted resources. |
+
+#### Additional Privileges: Hot-Add Proxy Migrations
+
+Required when using the **Hot-Add** storage copy method. vJailbreak attaches snapshot disks from the source VM to a Proxy VM and detaches them after the NBD copy completes. The controller also automatically enables `disk.EnableUUID` on the Proxy VM if it is not already set.
+
+| Privilege | Description |
+| --- | --- |
+| `Virtual machine.Config.AddExistingDisk` | Allows attaching an existing VMDK (snapshot disk) to another virtual machine — used to attach source disks to the Proxy VM. |
+| `Virtual machine.Config.RemoveDisk` | Allows removing a disk from a virtual machine — used to detach source disks from the Proxy VM after copy. |
+| `Virtual machine.Config.AdvancedConfig` | Allows modifying VM extra config parameters — used to set `disk.EnableUUID = TRUE` on the Proxy VM. |
+
+#### Additional Privileges: OVA-Based Proxy VM Deployment
+
+Required only when using the **Deploy a new vJailbreak Proxy VM** option in the UI. These privileges are not needed if you register an existing VM as the Proxy VM.
+
+| Privilege | Description |
+| --- | --- |
+| `vApp.Import` | Allows importing an OVF/OVA package into vCenter — used to deploy the pre-built Proxy VM appliance. |
+| `Datastore.AllocateSpace` | Allows allocating disk space on a datastore — used to create the Proxy VM disk files during OVA import. |
+| `Network.Assign` | Allows assigning a network to a virtual machine or vApp — used to connect the Proxy VM to the selected portgroup. |
+| `Resource.AssignVAppToPool` | Allows assigning a vApp to a resource pool — used to place the deployed Proxy VM in the target compute resource. |
+| `Virtual machine.Inventory.Create` | Allows creating a virtual machine in the vCenter inventory — used to register the Proxy VM after OVA import. |
+| `Virtual machine.Config.AdvancedConfig` | Allows modifying VM extra config parameters — used to set `disk.EnableUUID = TRUE` on the newly deployed Proxy VM. |
 
 ### Understanding VMware NFC Performance Limitations
 


### PR DESCRIPTION
Update hot-add proxy setup docs, fix snapshot name in troubleshooting, add Hot-Add as storage copy method, and add feature-specific vCenter permission tables.