### PR TITLE
[2079] Fix ProxyVM showing Ready status while SSH validation is failing

### DIFF
--- a/k8s/migration/internal/controller/proxyvm_controller.go
+++ b/k8s/migration/internal/controller/proxyvm_controller.go
@@ -136,11 +136,7 @@ func (r *ProxyVMReconciler) reconcileNormal(ctx context.Context, proxyVM *vjailb
 	connectCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	if connErr := sshClient.Connect(connectCtx, state.ip, "root", privateKey); connErr != nil {
-		proxyVM.Status.ValidationMessage = fmt.Sprintf("SSH connection to Proxy VM %s failed (retrying): %v", state.ip, connErr)
-		if updateErr := r.Status().Update(ctx, proxyVM); updateErr != nil && !apierrors.IsNotFound(updateErr) {
-			return ctrl.Result{}, updateErr
-		}
-		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+		return r.failVerification(ctx, proxyVM, fmt.Sprintf("SSH connection to Proxy VM %s failed: %v", state.ip, connErr))
 	}
 	defer func() {
 		if discErr := sshClient.Disconnect(); discErr != nil {


### PR DESCRIPTION
Fix ProxyVM controller to correctly update ValidationStatus to VerificationFailed when SSH re-validation fails, instead of leaving it as Ready.

Fixes: #2079


__Testing Done__

<img width="1439" height="802" alt="image" src="https://github.com/user-attachments/assets/4de511a7-d36b-470b-8517-50862d53e6a7" />


<img width="1440" height="772" alt="image" src="https://github.com/user-attachments/assets/01f45302-0359-434c-9b11-ecde8e6c10ff" />
