### PR TITLE
#2088: [UI] Windows VM should be blocked for selection as a proxy VM

### DIFF
--- a/ui/src/features/proxyvms/components/AddProxyVMDrawer.tsx
+++ b/ui/src/features/proxyvms/components/AddProxyVMDrawer.tsx
@@ -125,7 +125,8 @@ export default function AddProxyVMDrawer({ open, onClose }: AddProxyVMDrawerProp
             name: m.spec.vms.name,
             ipAddress: m.spec.vms.ipAddress || m.spec.vms.assignedIp,
             cpu: m.spec.vms.cpu,
-            powerState: m.status?.powerState ?? 'unknown'
+            powerState: m.status?.powerState ?? 'unknown',
+            osFamily: m.spec.vms.osFamily
           })
         )
     },

--- a/ui/src/features/proxyvms/components/VMAutocomplete.tsx
+++ b/ui/src/features/proxyvms/components/VMAutocomplete.tsx
@@ -116,8 +116,7 @@ export default function VMAutocomplete({
 
       {!value && credSelected && (
         <Typography variant="caption" color="text.secondary">
-          Only powered-on VMs in the selected vCenter are listed — pick one instead of typing a
-          name.
+          Only powered-on Linux VMs from the selected vCenter are listed.
         </Typography>
       )}
 

--- a/ui/src/features/proxyvms/components/VMAutocomplete.tsx
+++ b/ui/src/features/proxyvms/components/VMAutocomplete.tsx
@@ -43,7 +43,9 @@ export default function VMAutocomplete({
           onChange={(_, v) => onChange(v)}
           getOptionLabel={(o) => o.name}
           isOptionEqualToValue={(a, b) => a.name === b.name}
-          getOptionDisabled={(o) => registeredVMNames.has(o.name)}
+          getOptionDisabled={(o) =>
+            registeredVMNames.has(o.name) || o.osFamily !== 'linuxGuest'
+          }
           filterOptions={(opts, { inputValue }) => {
             const q = inputValue.toLowerCase()
             return opts.filter(
@@ -67,6 +69,8 @@ export default function VMAutocomplete({
           )}
           renderOption={(props, option) => {
             const isRegistered = registeredVMNames.has(option.name)
+            const isNonLinux = option.osFamily !== 'linuxGuest'
+            const isDisabled = isRegistered || isNonLinux
             return (
               <Box component="li" {...props} key={option.name}>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
@@ -74,7 +78,7 @@ export default function VMAutocomplete({
                     sx={{
                       fontSize: 10,
                       color:
-                        isRegistered
+                        isDisabled
                           ? 'text.disabled'
                           : option.powerState === 'running'
                             ? 'success.main'
@@ -84,11 +88,17 @@ export default function VMAutocomplete({
                   />
                   <Typography
                     variant="body2"
-                    sx={{ flex: 1, color: isRegistered ? 'text.disabled' : 'inherit' }}
+                    sx={{ flex: 1, color: isDisabled ? 'text.disabled' : 'inherit' }}
                   >
                     {option.name}
                   </Typography>
-                  {isRegistered ? (
+                  {isNonLinux ? (
+                    <Typography variant="caption" color="text.disabled" sx={{ flexShrink: 0 }}>
+                      {option.osFamily === 'windowsGuest'
+                        ? 'Windows not supported'
+                        : 'Requires Linux OS'}
+                    </Typography>
+                  ) : isRegistered ? (
                     <Typography variant="caption" color="text.disabled" sx={{ flexShrink: 0 }}>
                       Already registered
                     </Typography>

--- a/ui/src/features/proxyvms/components/types.ts
+++ b/ui/src/features/proxyvms/components/types.ts
@@ -6,6 +6,7 @@ export interface VMOption {
   ipAddress?: string
   cpu: number
   powerState: string
+  osFamily?: string
 }
 
 export interface SelectFormData {


### PR DESCRIPTION
## What this PR does / why we need it
- Disable non-Linux VMs in VMAutocomplete and update UI messages

## Which issue(s) this PR fixes
fixes #2088 

## Testing done
[Screencast from 01-07-26 05:44:35 PM IST.webm](https://github.com/user-attachments/assets/8f94f827-d36b-4ccc-b444-89820b9cea7c)

#### Updated the field helper text message. 
<img width="795" height="739" alt="image" src="https://github.com/user-attachments/assets/5141acb6-038f-4709-84de-8e4b407358f4" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/2089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->