### PR TITLE
Add docs for the virtio-blk limitation and how to use scsi

### DIFF
--- a/docs/src/content/docs/guides/Troubleshooting/troubleshooting.md
+++ b/docs/src/content/docs/guides/Troubleshooting/troubleshooting.md
@@ -116,3 +116,42 @@ kubectl get migrationplans,migrations,migrationtemplates,networkmappings,opensta
 
   - This is a known and documented `virt-v2v` issue. [See upstream documentation](https://libguestfs.org/virt-v2v.1.html#linux%3A-rename%3A-sysroot-etc-resolv.conf-failure).
   - If configuration management or security hardening marks `/etc/resolv.conf` immutable, ensure this is unset before conversion, or adjust your automation so VMs intended for conversion do not have `/etc/resolv.conf` marked immutable.
+
+---
+
+## Disk attach fails during migration: No more available PCI slots
+
+- **Symptom**
+
+  During a migration, attaching a target volume to the vJailbreak VM (or an agent VM) fails. The `nova-compute` log on the OpenStack side shows an error similar to:
+
+  ```text
+  TRACE nova.virt.libvirt.driver [instance: <uuid>] libvirt.libvirtError: internal error: No more available PCI slots
+  ```
+
+- **Cause**
+
+  During conversion, vJailbreak attaches the target Cinder volumes to the vJailbreak VM (or its agent VMs) to copy and convert the disk data. If the vJailbreak image was uploaded without a disk bus setting, OpenStack attaches these volumes using the default **virtio-blk** bus, where **every attached volume is a separate PCI device** and consumes its own PCI slot.
+
+  The virtual PCI bus has a limited number of slots, several of which are already used by essential devices (network interfaces, video, memory balloon, and so on). Migrating VMs with many disks — or running many migrations in parallel on one agent — exhausts the available PCI slots, and the volume attach fails with the error above.
+
+- **Resolution**
+
+  Configure the vJailbreak image to use the **virtio-scsi** disk bus. With virtio-scsi, all attached volumes share a single SCSI controller that consumes only one PCI slot and supports up to 256 devices.
+
+  1. Set the following properties on the vJailbreak image **before** creating the vJailbreak VM:
+
+     ```bash
+     openstack image set \
+       --property hw_disk_bus=scsi \
+       --property hw_scsi_model=virtio-scsi \
+       <vjailbreak-image-name-or-ID>
+     ```
+
+  2. Deploy the vJailbreak VM from the updated image, then re-run the migration.
+
+- **Notes**
+
+  - The disk bus is fixed when the VM is created. If your vJailbreak VM is already deployed, setting the properties on the image is not enough — you must recreate the vJailbreak VM from the updated image.
+  - Agent VMs created during [scale up](../../how-to/scaling/) use the same image, so set these properties before scaling up agents.
+  - See also: [Known Limitations](../../../reference/known-limitations/#pci-slot-exhaustion-when-attaching-disks-with-virtio-blk).

--- a/docs/src/content/docs/introduction/getting_started.mdx
+++ b/docs/src/content/docs/introduction/getting_started.mdx
@@ -56,6 +56,11 @@ These example instructions are for any version of [Private Cloud Director](https
 ```shell
 openstack image create --os-interface admin --insecure --container-format bare --disk-format qcow2 --file <vjailbreak-image-path> vjailbreak-image.qcow2
 ```
+- Set the disk bus to virtio-scsi on the uploaded image. During migrations, vJailbreak attaches the target volumes to itself for conversion; with the default virtio-blk bus each attached volume consumes a PCI slot, and migrating VMs with many disks can fail with a `No more available PCI slots` error. 
+With virtio-scsi, all volumes share a single controller. See [Known Limitations](../../reference/known-limitations/#pci-slot-exhaustion-when-attaching-disks-with-virtio-blk).
+```shell
+openstack image set --property hw_disk_bus=scsi --property hw_scsi_model=virtio-scsi vjailbreak-image.qcow2
+```
 
 ### Create vJailbreak VM
 - Deploy a new VM from the uploaded image, choosing the _m1.xlarge.vol_ flavor (use larger flavor for larger VM migration).

--- a/docs/src/content/docs/reference/known-limitations.md
+++ b/docs/src/content/docs/reference/known-limitations.md
@@ -137,6 +137,29 @@ To use hotplug after migration:
 Standard flavors without hotplug extra specs will not support live resize. The VM must be powered off for a cold resize in that case.
 :::
 
+## PCI Slot Exhaustion When Attaching Disks with virtio-blk
+
+During conversion, vJailbreak attaches the target volumes to the vJailbreak VM (or its agent VMs). If the vJailbreak image is uploaded without a disk bus setting, OpenStack uses the default **virtio-blk** bus, where every attached volume consumes its own PCI slot. Migrating VMs with many disks, or running many parallel migrations on one agent, Maximum 26 devices can be attached after which PCI slots will exhaust and volume attach fails with:
+
+```text
+libvirt.libvirtError: internal error: No more available PCI slots
+```
+
+**Workaround**: Set the disk bus to **virtio-scsi** on the vJailbreak image before creating the vJailbreak VM. All attached volumes then share a single SCSI controller (one PCI slot, up to 256 devices):
+
+```bash
+openstack image set \
+  --property hw_disk_bus=scsi \
+  --property hw_scsi_model=virtio-scsi \
+  <vjailbreak-image-name-or-ID>
+```
+
+:::note
+The disk bus is fixed when the VM is created. If the vJailbreak VM is already deployed, recreate it from the updated image. Agent VMs created during scale up use the same image, so set these properties before scaling up.
+:::
+
+See the full troubleshooting entry: [Disk attach fails during migration: No more available PCI slots](../../guides/troubleshooting/troubleshooting/#disk-attach-fails-during-migration-no-more-available-pci-slots).
+
 ## Low Disk Space in the Source VM
 
 Before starting conversion, `virt-v2v` checks that each filesystem inside the **source VM** has sufficient free space. If any filesystem is too full, the conversion fails before it begins.


### PR DESCRIPTION
## What this PR does / why we need it
This PR adds the limitation of attaching 26disks on a vjailbreak VM which might cause failures when attaching multiple disks. hence to avoid this we are using virtio-scsi which uses a single pci slot to attach and 256 volumes can be attached at a time. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #2107 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/2104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->