### PR TITLE
#2067: Block/Grey out the already registered proxy vm, this could mismatch the secret

### DIFF
--- a/ui/docs/specs/proxyvms/proxyvms-feature.md
+++ b/ui/docs/specs/proxyvms/proxyvms-feature.md
@@ -493,7 +493,9 @@ useQuery (vCenter scoped resources)
   staleTime: 60_000
 ```
 
-**Cache invalidation**: After `postProxyVM`, `createProxyVMFromOVA`, or `deleteProxyVM`, invalidate `['proxyvms']`.
+**Cache invalidation**: After `postProxyVM`, `createProxyVMFromOVA`, `deleteProxyVM`, or `retryProxyVMVerification`, invalidate `['proxyvms']`.
+
+**`registeredVMNames`**: `useMemo(() => new Set(existingProxyVMs.map(vm => vm.spec.vmName)), [existingProxyVMs])` in `AddProxyVMDrawer`, built from `useProxyVMsQuery()` (enabled only while drawer `open`). Includes ProxyVMs in every status — `Deploying`/`Pending` included, not just `Ready` — so it also blocks re-registering/re-deploying a proxy VM name that hasn't finished provisioning yet. Passed to both `RegisterVMForm` (→ `VMAutocomplete`, disables the option) and `DeployVMForm` (→ blocks the name field's `validate` rule).
 
 ### Data Flow — Register Existing VM
 
@@ -538,10 +540,14 @@ ProxyVM is consumed in Step 3 (Network and Storage Mapping) of both standard and
 
 ### Storage Copy Method: `HotAdd`
 
-Added to `STORAGE_COPY_METHOD_OPTIONS` in `src/features/migration/constants.ts`:
+The internal enum value is still `'HotAdd'`, but the user-facing label is now **"vJailbreak Accelerated Copy"** (renamed from "Hot-Add via Proxy VM"). `STORAGE_COPY_METHOD_OPTIONS` in `src/features/migration/constants.ts`:
 
 ```ts
-{ value: 'HotAdd', label: 'Hot-Add via Proxy VM' }
+export const STORAGE_COPY_METHOD_OPTIONS = [
+  { value: 'normal', label: 'Standard Copy' },
+  { value: 'StorageAcceleratedCopy', label: 'Storage Accelerated Copy' },
+  { value: 'HotAdd', label: 'vJailbreak Accelerated Copy' }
+] as const
 ```
 
 **`StorageCopyMethod` type** (`src/features/migration/types.ts`):
@@ -552,26 +558,28 @@ type StorageCopyMethod = 'normal' | 'StorageAcceleratedCopy' | 'HotAdd'
 
 **Form params**: `proxyVMRef?: string` added to `FormValues` and `RollingFormParams`.
 
-**Beta chip**: `HotAdd` radio label shows `<Chip label="Beta" color="warning" variant="outlined" />`.
+**Beta chip**: both `StorageAcceleratedCopy` and `HotAdd` radio labels show `<Chip label="Beta" color="warning" variant="outlined" />` (not `HotAdd`-only).
+
+**Migration detail/list display**: `MigrationDetailsTab` labels `HotAdd` migrations as `"vJailbreak Accelerated Copy"` and shows an extra "vJailbreak Proxy VM" field with the proxy's name. `Phase.HotAddTransferInProgress` / `Phase.HotAddCleanup` are surfaced as distinct progress phases in `MigrationProgress`, `MigrationProgressWithPopover`, `MigrationsTable`, and `MigrationNextActionBanner`.
 
 ### NetworkAndStorageMappingStep Behavior (HotAdd)
 
 When `storageCopyMethod === 'HotAdd'`:
 
-- **Proxy VM selector** shown (with `FieldLabel` above):
-  - Source: `useProxyVMsQuery()` filtered to `status.validationStatus === 'Ready'`
+- **VMware Datastore → PCD Volume Type mapping table** shown first (same table as `normal` mode)
+- **Proxy VM selector** shown below it (with `FieldLabel` above):
+  - Source: `useProxyVMsQuery()` (enabled only while `storageCopyMethod === 'HotAdd'`) filtered to `status.validationStatus === 'Ready'`
   - Option label: `metadata.name (status.ipAddress)` or just `metadata.name`
-  - If no Ready VMs: warning Alert shown
-- **VMware Datastore → PCD Volume Type mapping table** also shown
+  - If no Ready VMs: warning Alert, select disabled
 - Switching away from HotAdd clears `proxyVMRef`
 
 ### MigrationOptionsAlt Behavior (HotAdd)
 
-When `storageCopyMethod === 'HotAdd'`:
+When `storageCopyMethod === 'HotAdd'` (`isHotAdd`):
 
-- `dataCopyMethod` forced to `'cold'` via useEffect
-- `hot` and `mock` options disabled
-- Helper text: "Hot-Add migration only supports Cold copy. Hot copy is disabled."
+- `dataCopyMethod` forced to `'cold'` **only if it isn't already `'cold'` or `'mock'`** — i.e. HotAdd allows **Cold or Mock** copy, not cold-only
+- Only the `hot` data-copy option is disabled in the dropdown (`disabled={isHotAdd && item.value !== 'cold' && item.value !== 'mock'}`)
+- Info alert: "vJailbreak Accelerated Copy requires Cold or Mock copy. Other data copy methods are not available."
 
 ### Validation
 

--- a/ui/docs/specs/proxyvms/proxyvms-feature.md
+++ b/ui/docs/specs/proxyvms/proxyvms-feature.md
@@ -22,7 +22,7 @@ ProxyVM is a Kubernetes CRD that represents a vCenter VM pre-configured to act a
 
 1. **Deploy new Proxy VM** → select method "Deploy a new vJailbreak Proxy VM" → enter VM name + pick VMware creds → pick datacenter/datastore/network → submit → controller deploys OVA, injects SSH keys, registers ProxyVM automatically → drawer shows progress and auto-closes once the VM appears in the list
 2. **Register existing VM** → select method "Register an existing VM" → pick VMware creds → pick VM from searchable dropdown (shows IP + vCPU; Windows VMs and already-registered VMs are greyed out/disabled) → generate key pair (copy public key to VM's `authorized_keys`) OR upload existing private key → submit → controller verifies prerequisites → VM becomes `Ready`
-3. **Monitor Proxy VM status** → page polls every 5s while any VM is `Deploying`, `Pending`, or `Verifying`; status filter + search available in table toolbar
+3. **Monitor Proxy VM status** → table's `useProxyVMsQuery()` polls every 5s while any VM is `Pending` or `Verifying` (a `Deploying` VM is tracked separately by the Add drawer's own deploy-poll, see §6); status filter + search available in table toolbar
 4. **Retry failed verification** → row in `VerificationFailed` status shows a retry icon → patches a `force-reconcile` annotation → controller re-verifies
 5. **Delete Proxy VM(s)** → single-row delete or multi-select "Delete Selected (n)" bulk delete → confirmation dialog → delete CRD(s) + SSH key Secret(s)
 6. **Use in migration** → Step 3 of migration form: select `vJailbreak Accelerated Copy` (Beta) → choose a `Ready` proxy VM from dropdown
@@ -40,7 +40,7 @@ src/api/proxyvms/
 └── index.ts        — barrel export
 
 src/hooks/api/
-└── useProxyVMsQuery.ts  — React Query hook, auto-polls while Pending/Verifying
+└── useProxyVMsQuery.ts  — React Query hook, auto-polls while any item is Pending/Verifying
 
 src/features/proxyvms/
 ├── pages/
@@ -521,7 +521,7 @@ User clicks "Add Proxy VM"
 ### Data Flow — Deploy New VM from OVA
 
 ```
-User selects "Deploy a new Proxy VM" method
+User selects "Deploy a new vJailbreak Proxy VM" method
   → DeployVMForm shown
   → Selects creds → fetches datacenters
   → Selects datacenter → fetches datastores + networks + clusters
@@ -597,21 +597,24 @@ HotAdd → createStorageMapping(params.storageMappings)
 
 ## 8. Validation Rules
 
-| Rule                     | Condition                                                     | Error                                                                                    |
-| ------------------------ | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| proxyVMRef required      | `storageCopyMethod === 'HotAdd'` and `!params.proxyVMRef`     | "Please select a Proxy VM to use for Hot-Add data copy"                                  |
-| storageMappings required | `storageCopyMethod === 'HotAdd'` and storage not fully mapped | Storage mapping required (same as `normal` mode)                                         |
-| VM required (register)   | Add drawer, select mode, submit                               | "VM is required"                                                                         |
-| vmwareCredsRef required  | Add drawer submit                                             | "VMware credentials are required"                                                        |
-| vmName required (deploy) | Add drawer, create mode, submit                               | "VM name is required"                                                                    |
-| vmName format (deploy)   | Must match `/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/`              | "Lowercase letters, numbers, and hyphens only. Cannot start or end with a hyphen."       |
-| vmName blank (deploy)    | Whitespace-only input                                         | "VM name cannot be blank"                                                                |
-| vmName length (deploy)   | > 63 characters                                               | "Must be 63 characters or fewer"                                                         |
-| sshPrivateKey required   | Add drawer, register mode, upload tab, submit                 | "SSH private key is required"                                                            |
-| sshPrivateKey format     | Must contain OpenSSH headers                                  | "Invalid key format. Expected OpenSSH private key (-----BEGIN OPENSSH PRIVATE KEY-----)" |
-| SSH key file size        | Upload > 1 MB                                                 | "File too large. SSH private key must be under 1 MB."                                    |
-| Generated key required   | Register mode, generate tab, no key generated yet             | "Generate a key pair first."                                                             |
-| authorizedKeysConfirmed  | Register mode; generate tab after key generated, OR upload tab after key pasted | "Required" (bold red FormHelperText below checkbox) |
+| Rule                          | Condition                                                                       | Error                                                                                       |
+| ----------------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| proxyVMRef required           | `storageCopyMethod === 'HotAdd'` and `!params.proxyVMRef`                       | "Please select a Proxy VM to use for Hot-Add data copy"                                      |
+| storageMappings required      | `storageCopyMethod === 'HotAdd'` and storage not fully mapped                   | Storage mapping required (same as `normal` mode)                                             |
+| VM required (register)        | Add drawer, select mode, submit                                                 | "VM is required"                                                                              |
+| vmwareCredsRef required       | Add drawer submit                                                               | "VMware credentials are required"                                                             |
+| vmName required (deploy)      | Add drawer, create mode, submit                                                 | "VM name is required"                                                                          |
+| vmName format (deploy)        | Must match `/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/`                                  | "Lowercase letters, numbers, and hyphens only. Cannot start or end with a hyphen."             |
+| vmName blank (deploy)         | Whitespace-only input                                                           | "VM name cannot be blank"                                                                      |
+| vmName length (deploy)        | > 63 characters                                                                 | "Must be 63 characters or fewer"                                                               |
+| vmName vCenter collision (deploy) | Name matches a VM already in the selected vCenter (`vmOptions`)             | "A VM with this name already exists in the selected vCenter."                                 |
+| vmName registered collision (deploy) | Name matches any existing ProxyVM CR, incl. `Deploying`/`Pending` ones (`registeredVMNames`) | "A vJailbreak Proxy VM with this name is already registered or deploying." |
+| VM option disabled (register) | vCenter VM already registered (`registeredVMNames`) or non-Linux (`osFamily !== 'linuxGuest'`) | Option unselectable in `VMAutocomplete`; caption shows why |
+| sshPrivateKey required        | Add drawer, register mode, upload tab, submit                                  | "SSH private key is required"                                                                  |
+| sshPrivateKey format          | Must pass `validateSshPrivateKey` (OpenSSH, RSA, EC, or PKCS#8 headers)         | Format-specific message from `validateSshPrivateKey`                                          |
+| SSH key file size             | Upload > 1 MB                                                                   | "File too large. SSH private key must be under 1 MB."                                          |
+| Generated key required        | Register mode, generate tab, no key generated yet                              | "Generate a key pair first."                                                                    |
+| authorizedKeysConfirmed       | Register mode; generate tab after key generated, OR upload tab after key pasted | "Required" (bold red FormHelperText below checkbox)                                            |
 
 ---
 
@@ -632,10 +635,12 @@ The VM must have these configured before registering it (documented externally �
 
 - ProxyVM must be in `migration-system` namespace — hardcoded via `VJAILBREAK_DEFAULT_NAMESPACE`
 - Only `Ready` proxy VMs appear in migration form dropdown
-- HotAdd forces cold copy; warm (hot) migration not supported with HotAdd
+- HotAdd (vJailbreak Accelerated Copy) allows Cold or Mock data copy only; warm (hot) migration not supported with HotAdd
 - SSH Secret name derived from `toK8sName(vmName)`. Collision possible if two VM names normalize to the same K8s-safe string.
-- `AddProxyVMDialog.tsx` — orphaned dead file; safe to delete
 - ProxyVM CRD is not session-scoped — persists across migrations and must be explicitly deleted
 - VM picker fetches from `/vmwaremachines?labelSelector=...` — requires VMware creds already validated and VMwareMachine CRs to exist
 - OVA deploy endpoint is at `/dev-api/sdk/vpw/v1/create-proxy-vm` — proxied through the API server
 - vCenter resources endpoint is at `/dev-api/sdk/vpw/v1/vcenter-resources` — scoped by `datacenter` param for second-level resources
+- Windows guest VMs (`osFamily === 'windowsGuest'`) and any non-`linuxGuest` VM cannot be selected as a proxy VM (GHI #2088) — enforced client-side only in `VMAutocomplete`, not by the controller
+- Duplicate-name guard (`registeredVMNames`, GHI #2067) is also client-side only — a race between two clients (or direct API/kubectl use) could still create two ProxyVM CRs whose `spec.vmName` collide; the controller itself does not reject this
+- Retry (`force-reconcile` annotation) only surfaces in the UI for `VerificationFailed` rows; `DeployFailed` rows have no retry action from the table

--- a/ui/docs/specs/proxyvms/proxyvms-feature.md
+++ b/ui/docs/specs/proxyvms/proxyvms-feature.md
@@ -4,9 +4,9 @@
 **API path**: `src/api/proxyvms/`  
 **Query hook**: `src/hooks/api/useProxyVMsQuery.ts`  
 **Generated**: 2026-05-27  
-**Last updated**: 2026-06-25  
-**GitHub Issue**: [#1971](https://github.com/platform9/vjailbreak/issues/1971)  
-**Related feature**: See `docs/specs/migration/migration-feature.md` — HotAdd storage copy method extension
+**Last updated**: 2026-07-07  
+**GitHub Issue**: [#1971](https://github.com/platform9/vjailbreak/issues/1971) (base feature), [#2067](https://github.com/platform9/vjailbreak/issues/2067) (dup-registration guard), [#2088](https://github.com/platform9/vjailbreak/issues/2088) (Windows VM block)  
+**Related feature**: See `docs/specs/migration/migration-feature.md` — HotAdd storage copy method extension (UI label: "vJailbreak Accelerated Copy")
 
 ---
 
@@ -20,11 +20,12 @@ ProxyVM is a Kubernetes CRD that represents a vCenter VM pre-configured to act a
 
 ### Key User Journeys
 
-1. **Deploy new Proxy VM** → select method "Deploy a new Proxy VM" → enter VM name + pick VMware creds → pick datacenter/datastore/network → submit → controller deploys OVA, injects SSH keys, registers ProxyVM automatically → VM appears in table
-2. **Register existing VM** → select method "Register an existing VM" → pick VMware creds → pick VM from searchable dropdown (shows IP + vCPU) → generate key pair (copy public key to VM's `authorized_keys`) OR upload existing private key → submit → controller verifies prerequisites → VM becomes `Ready`
-3. **Monitor Proxy VM status** → page polls every 5s while any VM is `Pending` or `Verifying`; status filter + search available in table toolbar
-4. **Delete Proxy VM** → confirmation dialog → delete CRD + SSH key Secret
-5. **Use in migration** → Step 3 of migration form: select `HotAdd via Proxy VM` (Beta) → choose a `Ready` proxy VM from dropdown
+1. **Deploy new Proxy VM** → select method "Deploy a new vJailbreak Proxy VM" → enter VM name + pick VMware creds → pick datacenter/datastore/network → submit → controller deploys OVA, injects SSH keys, registers ProxyVM automatically → drawer shows progress and auto-closes once the VM appears in the list
+2. **Register existing VM** → select method "Register an existing VM" → pick VMware creds → pick VM from searchable dropdown (shows IP + vCPU; Windows VMs and already-registered VMs are greyed out/disabled) → generate key pair (copy public key to VM's `authorized_keys`) OR upload existing private key → submit → controller verifies prerequisites → VM becomes `Ready`
+3. **Monitor Proxy VM status** → page polls every 5s while any VM is `Deploying`, `Pending`, or `Verifying`; status filter + search available in table toolbar
+4. **Retry failed verification** → row in `VerificationFailed` status shows a retry icon → patches a `force-reconcile` annotation → controller re-verifies
+5. **Delete Proxy VM(s)** → single-row delete or multi-select "Delete Selected (n)" bulk delete → confirmation dialog → delete CRD(s) + SSH key Secret(s)
+6. **Use in migration** → Step 3 of migration form: select `vJailbreak Accelerated Copy` (Beta) → choose a `Ready` proxy VM from dropdown
 
 ---
 
@@ -56,7 +57,6 @@ src/features/proxyvms/
     └── ProxyVMDetailDrawer.tsx  — Detail view drawer
 ```
 
-> `AddProxyVMDialog.tsx` is a dead file (orphaned). Not imported anywhere; safe to delete.
 
 ### Component Hierarchy
 
@@ -98,11 +98,11 @@ interface ProxyVMSpec {
 
 // status (controller-managed)
 interface ProxyVMStatus {
-  validationStatus: 'Pending' | 'Verifying' | 'Ready' | 'VerificationFailed'
+  validationStatus: 'Deploying' | 'DeployFailed' | 'Pending' | 'Verifying' | 'Ready' | 'VerificationFailed'
   validationMessage?: string
   ipAddress?: string
   attachedDiskCount?: number
-  componentsVerified?: string[]  // lsblk, nbdkit, qemu-nbd, sshd, disk.EnableUUID
+  componentsVerified?: { name: string; present: boolean; message?: string }[]
   lastValidationTime?: string    // RFC3339
 }
 ```
@@ -128,33 +128,43 @@ interface ProxyVMStatus {
 
 - `useProxyVMsQuery()` — data + loading + refetch
 - `addDrawerOpen` — controls `AddProxyVMDrawer`
-- `deleteTarget` — ProxyVM selected for deletion
-- `statusFilter` — active status filter (`'All' | 'Pending' | 'Verifying' | 'Ready' | 'VerificationFailed'`)
+- `deleteTarget` — single ProxyVM selected for row delete
+- `rowSelectionModel` / `bulkDeleteDialogOpen` — multi-select bulk delete
+- `retryingNames` — set of names currently retrying (spinner on retry icon)
+- `detailVM` / `detailOpen` — controls `ProxyVMDetailDrawer` (opened by clicking the Name cell)
+- `statusFilter` — active status filter (`'All' | 'Deploying' | 'DeployFailed' | 'Pending' | 'Verifying' | 'Ready' | 'VerificationFailed'`)
 
-**Toolbar**: `ListingToolbar` + `CustomSearchToolbar` (search by name/VM name, status filter dropdown, refresh) + "Add Proxy VM" button.
+**Toolbar**: `ListingToolbar` + `CustomSearchToolbar` (search by name/VM name, status filter dropdown, refresh) + "Add vJailbreak Proxy VM" button. When rows are selected, a "Delete Selected (n)" button appears next to the search bar.
 
 **Columns**:
 
-| Column         | Field                                     | Notes                                                         |
-| -------------- | ----------------------------------------- | ------------------------------------------------------------- |
-| Name           | `metadata.name`                           | Kubernetes resource name                                      |
-| VM Name        | `spec.vmName`                             | vCenter display name                                          |
-| Status         | `status.validationStatus`                 | Color-coded chip (`borderRadius: 4px`)                        |
-| Message        | `status.validationMessage`                | Truncated + tooltip; red on `VerificationFailed`              |
-| IP Address     | `status.ipAddress`                        | `-` if absent                                                 |
-| Attached Disks | `status.attachedDiskCount`                | `-` if absent                                                 |
-| Age            | derived from `metadata.creationTimestamp` | humanized (5m, 3h, 2d)                                        |
-| Last Validated | `status.lastValidationTime`               | `toLocaleString()`                                            |
-| Actions        | delete `IconButton`                       | `DeleteOutlined`, `stopPropagation`, opens ConfirmationDialog |
+| Column         | Field                                     | Notes                                                                 |
+| -------------- | ----------------------------------------- | ---------------------------------------------------------------------|
+| Name           | `metadata.name`                           | Kubernetes resource name; clickable, opens `ProxyVMDetailDrawer`     |
+| VM Name        | `spec.vmName`                             | vCenter display name                                                  |
+| Status         | `status.validationStatus`                 | Color-coded chip (`borderRadius: 4px`)                                |
+| IP Address     | `status.ipAddress`                        | `-` if absent                                                          |
+| Attached Disks | `status.attachedDiskCount`                | `-` if absent                                                          |
+| Age            | derived from `metadata.creationTimestamp` | humanized (5m, 3h, 2d)                                                 |
+| Last Validated | `status.lastValidationTime`               | `toLocaleString()`                                                     |
+| Actions        | retry (conditional) + delete `IconButton` | retry only on `VerificationFailed` rows; both `stopPropagation`        |
+
+> `checkboxSelection` is enabled on the grid for bulk delete; there is no separate "Message" column — `status.validationMessage` is only shown in the detail drawer's Status card.
 
 **Status chip colors**:
 
+- `Deploying` → blue (`info`)
+- `DeployFailed` → red (`error`)
 - `Pending` → grey (`default`)
 - `Verifying` → yellow (`warning`)
 - `Ready` → green (`success`)
 - `VerificationFailed` → red (`error`)
 
-**Delete flow**: ConfirmationDialog (`WarningIcon`, `actionVariant="outlined"`) → `deleteProxyVM(name)` + `deleteSecret(name)` (fire-and-forget) → invalidate `['proxyvms']` query cache.
+**Retry flow** (`VerificationFailed` rows only): retry `IconButton` (`Refresh`, spinner while in-flight) → `retryProxyVMVerification(name)` → 1s delay → invalidate `['proxyvms']` query cache.
+
+**Delete flow**: ConfirmationDialog (`WarningIcon`, `actionVariant="outlined"`) → `deleteProxyVM(name)`, tolerating 404 (already gone) → `deleteSecret(spec.sshKeySecretRef.name)` (fire-and-forget, manual-upload path only) → invalidate `['proxyvms']` query cache + `refetch()`.
+
+**Bulk delete flow**: select rows via checkboxes → "Delete Selected (n)" → ConfirmationDialog listing selected names → deletes all in parallel (`Promise.all`, tolerating 404 per item) → same secret cleanup + cache invalidation.
 
 ---
 
@@ -177,31 +187,33 @@ Both forms use `useForm` with `mode: 'onChange'`. Submit button disabled until f
 
 ```
 DrawerHeader
-  title: "Add Proxy VM"
+  title: "Add vJailbreak Proxy VM"
   subtitle: varies by formMode
 
 SurfaceCard
   [error Alert — dismissible]
 
   Method (overline label)
-    MethodCard: "Deploy a new Proxy VM" [RECOMMENDED]
+    MethodCard: "Deploy a new vJailbreak Proxy VM" [RECOMMENDED]
     MethodCard: "Register an existing VM"
 
   ─── divider ───
 
   [formMode === 'select'] → RegisterVMForm
   [formMode === 'create' && !deploymentStarted] → DeployVMForm
-  [formMode === 'create' && deploymentStarted] → deployment progress UI
+  [formMode === 'create' && deploymentStarted] → deployment progress UI (Alert + LinearProgress)
 
 DrawerFooter
-  Cancel | Register Proxy VM       (select mode)
-  Cancel | Deploy & Register VM    (create mode)
+  Cancel | Register vJailbreak Proxy VM   (select mode)
+  Done | Deploy & Register VM             (create mode, "Done" once deploymentStarted)
 ```
 
 **Subtitle**:
 
-- `select`: `"Register a powered-on VM you have already prepared as a Hot-Add proxy."`
-- `create`: `"A new Proxy VM is deployed from the OVA template and registered automatically."`
+- `select`: `"Register a powered-on VM you have already prepared as a vJailbreak Accelerated Copy proxy."`
+- `create`: `"A new vJailbreak Proxy VM is deployed from the OVA template and registered automatically."`
+
+**Deployment progress UI** (`formMode === 'create' && deploymentStarted`): success Alert naming the VM, `LinearProgress`, body text ("...typically takes 3–5 minutes"), and an info Alert noting the panel can be closed — the drawer auto-closes itself once the deployed VM name appears in the polled ProxyVM list (see §6).
 
 ---
 
@@ -239,6 +251,7 @@ interface VMOption {
   ipAddress?: string   // from spec.vms.ipAddress || spec.vms.assignedIp
   cpu: number          // from spec.vms.cpu
   powerState: string
+  osFamily?: string    // from spec.vms.osFamily; 'linuxGuest' | 'windowsGuest' | ...
 }
 ```
 
@@ -246,9 +259,13 @@ interface VMOption {
 - Disabled until VMware creds selected
 - Only powered-on VMs listed (`powerState === 'running'`)
 - Filter by name or IP
-- Each option shows: green/grey dot + name + IP + vCPU count
+- **Option disabling** (`getOptionDisabled`) — an option is disabled (greyed out, unselectable) when either:
+  - `registeredVMNames.has(option.name)` — already registered as a vJailbreak Proxy VM (GHI #2067; prevents secret mismatch on re-registration)
+  - `option.osFamily !== 'linuxGuest'` — non-Linux guest (GHI #2088; Windows VMs cannot be proxy VMs)
+  - Disabled options show a trailing caption instead of IP/vCPU: `"Windows not supported"` (Windows), `"Requires Linux OS"` (other non-Linux), or `"Already registered"`
+- Each enabled option shows: green/grey dot + name + IP + vCPU count
 - On creds change: clears selection and resets `vmName` form field
-- Helper text shown when no VM selected: "Only powered-on VMs in the selected vCenter are listed"
+- Helper text shown when no VM selected: "Only powered-on Linux VMs from the selected vCenter are listed."
 - Selected VM chip shows: green dot + name + IP + vCPU
 
 **Query**:
@@ -278,7 +295,7 @@ Uses `useFormContext` (must render inside `DesignSystemForm`).
 **Upload Private Key tab**:
 1. Info Alert ("Upload or paste your SSH private key…") when no key present. Warning Alert ("Before clicking Register, ensure public key is added to `authorized_keys`…") once key present (`hasPrivateKey`).
 2. "Upload key file" button — reads file text → `setValue('sshPrivateKey', text)`.
-3. Paste textarea `RHFTextField name="sshPrivateKey"`.
+3. Paste textarea `RHFTextField name="sshPrivateKey"` — validated via shared `validateSshPrivateKey` util (accepts OpenSSH, RSA, EC, PKCS#8 headers, not just OpenSSH).
 4. `{hasPrivateKey && <AuthorizedKeysConfirmation />}` — shown after key pasted/uploaded.
 
 **`AuthorizedKeysConfirmation`** (internal sub-component):
@@ -301,8 +318,8 @@ Rendered inside `DesignSystemForm id="create-proxy-vm-form"`. Sections:
 - VMware Credentials `RHFSelect`
 
 **New VM**
-- VM Name `RHFTextField` — validation: required, no blank/whitespace, lowercase alphanumeric + hyphens only (`/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/`), max 63 chars, no leading/trailing hyphens.
-- Caption: "Becomes both the vSphere VM name and the Proxy VM record. Must be unique."
+- VM Name `RHFTextField` — validation: required, no blank/whitespace, lowercase alphanumeric + hyphens only (`/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/`), max 63 chars, no leading/trailing hyphens, must not collide with an existing vCenter VM (`vmOptions`) **or** an already-registered/deploying ProxyVM (`registeredVMNames` — same guard as the Register form's dropdown; blocks entering the name of a proxy VM that is still `Deploying`/`Pending`, not just ones already `Ready`, see GHI #2067).
+- Caption: "Becomes both the vSphere VM name and the vJailbreak Proxy VM record. Must be unique."
 
 **Deployment Target** (2-column grid)
 - Datacenter `RHFSelect` — loaded from `getVCenterResources(creds)`
@@ -328,7 +345,9 @@ staleTime: 60_000
 
 ### ProxyVMDetailDrawer (`components/ProxyVMDetailDrawer.tsx`)
 
-Opens from row click in `ProxyVMsTable`. Width 760px.
+Opens from clicking the Name cell in `ProxyVMsTable`. Width 760px, `requireCloseConfirmation={false}`.
+
+**Status card**: `StatusChip` (filled) showing `validationStatus`, tone per `statusTone()` (`Ready`→success, `Deploying`→info, `Verifying`→warning, `DeployFailed`/`VerificationFailed`→error, else default). A spinner (`CircularProgress`) shows next to the chip while `Deploying` or `Verifying`. `status.validationMessage` shown below in red for `DeployFailed`/`VerificationFailed`, muted otherwise.
 
 **General section** — `KeyValueGrid` items:
 
@@ -339,22 +358,26 @@ Opens from row click in `ProxyVMsTable`. Width 760px.
 | IP address | `status.ipAddress` |
 | Attached disks | `status.attachedDiskCount` |
 | Last validated | `status.lastValidationTime` |
-| Components verified | `status.componentsVerified` joined (always shown, `—` if absent) |
+| Components verified | `status.componentsVerified` mapped to `name ✓/✗` joined (always shown, `—` if absent) |
 | Created | `metadata.creationTimestamp` |
 
-> Note: `vJailbreak Proxy VM name` (K8s metadata.name) is NOT shown — it is displayed as the drawer title. Only `VM name` (vCenter display name) is in the grid.
+> Note: `vJailbreak Proxy VM name` (K8s metadata.name) is NOT shown in the grid — it is displayed as the drawer title.
 
 **SSH Access section**:
 
 `isOVADeployed = !spec.sshKeyPairRef && !spec.sshKeySecretRef`
 
-| Condition | Subtitle | Content |
-|-----------|----------|---------|
-| `isOVADeployed` (still deploying or pending) | — | "SSH access is configured automatically during OVA deployment." |
-| `isOVADeployed` + `Ready` | — | "No SSH key configured" warning (should not occur in practice) |
-| `sshKeyPairRef` set | "SSH public key used by vJailbreak to access this Proxy VM." | Read-only public key `TextField` with copy button |
-| `sshKeySecretRef` set (manual upload) | "SSH public key used by vJailbreak to access this Proxy VM." | Info alert: manually uploaded key, no public key stored |
-| Key secret missing/unreadable | "SSH public key used by vJailbreak to access this Proxy VM." | Warning alert with secret name |
+| Condition | Content |
+|-----------|---------|
+| `isOVADeployed` | "SSH access is configured automatically during OVA deployment." |
+| `sshKeyPairRef` set, key loading | Spinner + "Loading public key…" |
+| `sshKeyPairRef` set, load error | Warning alert naming the secret |
+| `sshKeyPairRef` set, loaded | Read-only public key `TextField` with copy button |
+| `sshKeySecretRef` set (manual upload) | Info alert: manually uploaded key, no public key stored |
+| Not OVA-deployed, no key ref, `Ready` | Warning alert: "No SSH key configured for this vJailbreak Proxy VM." |
+| Not OVA-deployed, no key ref, not yet `Ready` | "SSH key will be available once the VM is ready." |
+
+Subtitle "SSH public key used by vJailbreak to access this Proxy VM." shown for all non-`isOVADeployed` cases.
 
 ---
 
@@ -427,7 +450,7 @@ Secret name = `${toK8sName(vmName)}-hot-add-ssh-key` (manual) or `${toK8sName(vm
 | ----------------------- | ---------------------------------------------- | -------------------------- |
 | List VMs for credential | `getVMwareMachines(namespace, vmwareCredName)` | Filtered by label selector |
 
-Returns `VMwareMachineList`. Drawer maps to `VMOption` (name + ipAddress + cpu + powerState). Only `powerState === 'running'` items displayed.
+Returns `VMwareMachineList`. Drawer maps to `VMOption` (name + ipAddress + cpu + powerState + osFamily). Only `powerState === 'running'` items are fetched into the option list; non-Linux and already-registered options remain in the list but are disabled/greyed out client-side (see §4 VMAutocomplete).
 
 ---
 

--- a/ui/src/features/proxyvms/components/AddProxyVMDrawer.tsx
+++ b/ui/src/features/proxyvms/components/AddProxyVMDrawer.tsx
@@ -480,6 +480,7 @@ export default function AddProxyVMDrawer({ open, onClose }: AddProxyVMDrawerProp
               scopedLoading={scopedLoading}
               isSubmitting={isSubmitting}
               vmOptions={vmOptions}
+              registeredVMNames={registeredVMNames}
             />
           )}
         </Box>

--- a/ui/src/features/proxyvms/components/DeployVMForm.tsx
+++ b/ui/src/features/proxyvms/components/DeployVMForm.tsx
@@ -29,6 +29,7 @@ interface DeployVMFormProps {
   scopedLoading: boolean
   isSubmitting: boolean
   vmOptions?: VMOption[]
+  registeredVMNames?: Set<string>
 }
 
 function toOptions(items: string[] | undefined) {
@@ -49,7 +50,8 @@ export default function DeployVMForm({
   dcLoading,
   scopedLoading,
   isSubmitting,
-  vmOptions = []
+  vmOptions = [],
+  registeredVMNames = new Set()
 }: DeployVMFormProps) {
   return (
     <DesignSystemForm
@@ -94,6 +96,8 @@ export default function DeployVMForm({
                   if (val.length > 63) return 'Must be 63 characters or fewer'
                   if (vmOptions.some((v) => v.name === val))
                     return 'A VM with this name already exists in the selected vCenter.'
+                  if (registeredVMNames.has(val))
+                    return 'A vJailbreak Proxy VM with this name is already registered or deploying.'
                   return true
                 }
               }}

--- a/ui/src/features/proxyvms/components/ProxyVMsTable.tsx
+++ b/ui/src/features/proxyvms/components/ProxyVMsTable.tsx
@@ -232,8 +232,9 @@ export default function ProxyVMsTable() {
           } catch (err: any) {
             if (err?.response?.status !== 404) throw err
           }
-          if (vm.spec.sshKeySecretRef?.name) {
-            deleteSecret(vm.spec.sshKeySecretRef.name, VJAILBREAK_DEFAULT_NAMESPACE).catch(() => {})
+          const secretName = vm.spec.sshKeySecretRef?.name || vm.spec.sshKeyPairRef?.name
+          if (secretName) {
+            deleteSecret(secretName, VJAILBREAK_DEFAULT_NAMESPACE).catch(() => {})
           }
         })
       )
@@ -263,8 +264,9 @@ export default function ProxyVMsTable() {
       }
       // 404 = already gone, proceed with cleanup
     }
-    if (deleteTarget.spec.sshKeySecretRef?.name) {
-      deleteSecret(deleteTarget.spec.sshKeySecretRef.name, VJAILBREAK_DEFAULT_NAMESPACE).catch(() => {})
+    const secretName = deleteTarget.spec.sshKeySecretRef?.name || deleteTarget.spec.sshKeyPairRef?.name
+    if (secretName) {
+      deleteSecret(secretName, VJAILBREAK_DEFAULT_NAMESPACE).catch(() => {})
     }
     queryClient.invalidateQueries({ queryKey: PROXY_VMS_QUERY_KEY })
     refetch()


### PR DESCRIPTION
## What this PR does / why we need it
-Added a validation check to prevent VM names that are already registered or in a deploying state.

## Which issue(s) this PR fixes
fixes #2067 

## Testing done
<img width="1528" height="745" alt="Screenshot from 2026-07-07 10-30-51" src="https://github.com/user-attachments/assets/d97567d3-8f2e-4d41-9151-23052b53276e" />
<img width="1528" height="745" alt="Screenshot from 2026-07-07 10-30-46" src="https://github.com/user-attachments/assets/c32755ca-51b1-49f2-bd2c-1082e379fa32" />
<img width="1528" height="745" alt="Screenshot from 2026-07-07 10-30-40" src="https://github.com/user-attachments/assets/f1478975-b217-4b50-9862-353ca0fc2f12" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/2105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->