### PR TITLE
[2085] Block Persist source network interfaces when mapped network subnet doesn't match VM IPs

### DIFF
--- a/ui/e2e/migration/edge-cases.spec.ts
+++ b/ui/e2e/migration/edge-cases.spec.ts
@@ -34,6 +34,8 @@ import {
   MOCK_RDM_DISKS_LIST,
   MOCK_SETTINGS_CONFIGMAP_NETWORK_PERSISTENCE_ON,
   MOCK_SETTINGS_CONFIGMAP_NETWORK_PERSISTENCE_OFF,
+  MOCK_SUBNET_COMPATIBILITY_INCOMPATIBLE,
+  MOCK_SUBNET_COMPATIBILITY_COMPATIBLE,
   NS,
 } from './helpers/migration.fixtures'
 
@@ -535,6 +537,9 @@ test.describe('MIG-036 — subnet compatibility warning', () => {
   })
 
   test('mapping to incompatible subnet shows warning per source network', async ({ page }) => {
+    // vpwned reports the mapped target subnet does not contain the VM IPs
+    await mockRoute(page, API.checkSubnetCompatibility, 'POST', MOCK_SUBNET_COMPATIBILITY_INCOMPATIBLE)
+
     const netTable = page.getByTestId('network-mapping-table')
     await expect(netTable).toBeVisible()
 
@@ -560,20 +565,21 @@ test.describe('MIG-036 — subnet compatibility warning', () => {
     await openOpts.first().click()
     await waitClosed()
 
-    // Warning may or may not appear — but no JS error should occur
-    const warningVisible = await page
-      .getByText(/subnet|compatible|cidr|ip.*not.*compatible|vm.*ip/i)
-      .isVisible()
-      .catch(() => false)
-    expect(typeof warningVisible).toBe('boolean')
+    // Deterministic mock → the per-network subnet warning must render
+    await expect(
+      page.getByText(/do not lie within the subnet of destination network/i).first()
+    ).toBeVisible({ timeout: 5000 })
   })
 
   test('remapping to compatible subnet clears subnet warning', async ({ page }) => {
+    // vpwned reports all VM IPs fit the mapped target subnet
+    await mockRoute(page, API.checkSubnetCompatibility, 'POST', MOCK_SUBNET_COMPATIBILITY_COMPATIBLE)
+
     // Map all network rows using proven pattern, then verify no subnet warning
     await mapAllTableRows(page, 'network-mapping-table')
 
     await page.waitForTimeout(400)
-    await expect(page.getByText(/subnet.*warning|incompatible.*subnet/i)).not.toBeVisible()
+    await expect(page.getByText(/do not lie within the subnet/i)).not.toBeVisible()
   })
 })
 
@@ -734,7 +740,7 @@ test.describe('MIG-039 — global default network persistence seeds migration fo
     await openMigrationDrawer(page)
     await selectClustersAndWaitForVMs(page)
     // Navigate to the migration options step (section 5)
-    await page.getByTestId('section-nav-item-5').click()
+    await page.getByTestId('section-nav-item-options').click()
   })
 
   test('checkbox is pre-checked when global default is ON', async ({ page }) => {
@@ -744,9 +750,13 @@ test.describe('MIG-039 — global default network persistence seeds migration fo
   })
 
   test('user can uncheck the pre-checked checkbox', async ({ page }) => {
-    const checkbox = page.getByTestId('migration-option-network-persistence')
+    // MUI Checkbox: data-testid lands on the root span; direct input clicks don't
+    // toggle MUI controlled inputs reliably — click the FormControlLabel instead
+    const checkbox = page
+      .getByTestId('migration-option-network-persistence')
+      .locator('input[type="checkbox"]')
     await expect(checkbox).toBeChecked({ timeout: 10_000 })
-    await checkbox.click()
+    await page.locator('label').filter({ hasText: /persist source network interfaces/i }).click()
     await expect(checkbox).not.toBeChecked()
   })
 })
@@ -762,7 +772,7 @@ test.describe('MIG-040 — global default OFF leaves network persistence uncheck
     await goToMigrations(page)
     await openMigrationDrawer(page)
     await selectClustersAndWaitForVMs(page)
-    await page.getByTestId('section-nav-item-5').click()
+    await page.getByTestId('section-nav-item-options').click()
   })
 
   test('checkbox is unchecked when global default is OFF', async ({ page }) => {
@@ -772,9 +782,13 @@ test.describe('MIG-040 — global default OFF leaves network persistence uncheck
   })
 
   test('user can manually check the unchecked checkbox', async ({ page }) => {
-    const checkbox = page.getByTestId('migration-option-network-persistence')
+    // MUI Checkbox: data-testid lands on the root span; direct input clicks don't
+    // toggle MUI controlled inputs reliably — click the FormControlLabel instead
+    const checkbox = page
+      .getByTestId('migration-option-network-persistence')
+      .locator('input[type="checkbox"]')
     await expect(checkbox).not.toBeChecked({ timeout: 10_000 })
-    await checkbox.click()
+    await page.locator('label').filter({ hasText: /persist source network interfaces/i }).click()
     await expect(checkbox).toBeChecked()
   })
 })
@@ -801,5 +815,64 @@ test.describe('MIG-041 — global settings DEFAULT_NETWORK_PERSISTENCE toggle', 
     await expect(checkbox).not.toBeChecked()
     await toggle.click()
     await expect(checkbox).toBeChecked()
+  })
+})
+
+// ─── MIG-042: Persist IP blocked when mapped network subnet mismatches (#2085) ─
+
+test.describe('MIG-042 — persist IP mutually exclusive with different-subnet mapping', () => {
+  // Persist IP is seeded ON from the global default so the incompatible case also
+  // proves the auto-uncheck behavior, not just the disabled state.
+  async function setupWithSubnetMock(page: Page, subnetMock: Record<string, unknown>) {
+    await mockRoute(page, API.settingsConfigMap, 'GET', MOCK_SETTINGS_CONFIGMAP_NETWORK_PERSISTENCE_ON)
+    await mockStandardFormApis(page)
+    await mockRoute(page, API.migrations, 'GET', MOCK_MIGRATIONS_LIST_EMPTY)
+    await mockRoute(page, API.migrationPlans, 'GET', MOCK_MIGRATION_PLANS_LIST_EMPTY)
+    await mockRoute(page, API.checkSubnetCompatibility, 'POST', subnetMock)
+    await goToMigrations(page)
+    await openMigrationDrawer(page)
+    await selectClustersAndWaitForVMs(page)
+
+    // Select VM with known IP so the subnet check fires on mapping
+    const grid = page.getByTestId('vms-datagrid')
+    await grid.locator('[role="row"]').nth(1).getByRole('checkbox').click({ force: true })
+
+    // Map all networks — this triggers the subnet compatibility check
+    await page.getByTestId('section-nav-item-map-resources').click()
+    const subnetCheckResponse = page.waitForResponse((response) =>
+      response.url().includes('check_network_subnet_compatibility')
+    )
+    await mapAllTableRows(page, 'network-mapping-table')
+    await subnetCheckResponse
+
+    await page.getByTestId('section-nav-item-options').click()
+  }
+
+  // MUI Checkbox renders data-testid on the root span; checked/disabled live on the inner input
+  const persistCheckboxInput = (page: Page) =>
+    page.getByTestId('migration-option-network-persistence').locator('input[type="checkbox"]')
+
+  test('subnet mismatch disables and unchecks persist source network interfaces', async ({ page }) => {
+    await setupWithSubnetMock(page, MOCK_SUBNET_COMPATIBILITY_INCOMPATIBLE)
+
+    const checkbox = persistCheckboxInput(page)
+    await expect(checkbox).toBeVisible({ timeout: 10_000 })
+    // Global default seeded it checked — mismatch must auto-uncheck and disable it
+    await expect(checkbox).toBeDisabled({ timeout: 10_000 })
+    await expect(checkbox).not.toBeChecked()
+
+    await expect(page.getByTestId('network-persistence-subnet-alert')).toBeVisible()
+  })
+
+  test('compatible subnet keeps persist source network interfaces available', async ({ page }) => {
+    await setupWithSubnetMock(page, MOCK_SUBNET_COMPATIBILITY_COMPATIBLE)
+
+    const checkbox = persistCheckboxInput(page)
+    await expect(checkbox).toBeVisible({ timeout: 10_000 })
+    await expect(checkbox).toBeEnabled()
+    // Seeded ON by global default and no mismatch → stays checked
+    await expect(checkbox).toBeChecked()
+
+    await expect(page.getByTestId('network-persistence-subnet-alert')).not.toBeVisible()
   })
 })

--- a/ui/e2e/migration/edge-cases.spec.ts
+++ b/ui/e2e/migration/edge-cases.spec.ts
@@ -569,6 +569,14 @@ test.describe('MIG-036 — subnet compatibility warning', () => {
     await expect(
       page.getByText(/do not lie within the subnet of destination network/i).first()
     ).toBeVisible({ timeout: 5000 })
+
+    // Warning includes a "Show more" docs link to the network mapping concepts page
+    const showMoreLink = page.getByRole('link', { name: /show more/i }).first()
+    await expect(showMoreLink).toBeVisible()
+    await expect(showMoreLink).toHaveAttribute(
+      'href',
+      'https://platform9.github.io/vjailbreak/concepts/network-storage-mapping/#network-mapping'
+    )
   })
 
   test('remapping to compatible subnet clears subnet warning', async ({ page }) => {
@@ -862,6 +870,11 @@ test.describe('MIG-042 — persist IP mutually exclusive with different-subnet m
     await expect(checkbox).not.toBeChecked()
 
     await expect(page.getByTestId('network-persistence-subnet-alert')).toBeVisible()
+
+    // Helper text switches from the default description to the disabled reason
+    await expect(
+      page.getByText(/disabled because some vm ip addresses do not lie within the subnet/i)
+    ).toBeVisible()
   })
 
   test('compatible subnet keeps persist source network interfaces available', async ({ page }) => {

--- a/ui/e2e/migration/helpers/migration.fixtures.ts
+++ b/ui/e2e/migration/helpers/migration.fixtures.ts
@@ -496,6 +496,22 @@ export const MOCK_IP_VALIDATION_CONFLICT = {
   conflicts: ['192.168.1.101'],
 }
 
+// ─── Subnet compatibility responses (vpwned check_network_subnet_compatibility) ─
+
+export const MOCK_SUBNET_COMPATIBILITY_INCOMPATIBLE = {
+  results: [
+    { ip: '192.168.1.101', is_compatible: false, reason: 'IP not within subnet CIDR' },
+  ],
+  subnet_cidrs: ['10.20.0.0/24'],
+  all_compatible: false,
+}
+
+export const MOCK_SUBNET_COMPATIBILITY_COMPATIBLE = {
+  results: [{ ip: '192.168.1.101', is_compatible: true, reason: '' }],
+  subnet_cidrs: ['192.168.1.0/24'],
+  all_compatible: true,
+}
+
 // ─── VMware clusters (for cluster selection dropdown) ─────────────────────────
 
 export const MOCK_VMWARE_CLUSTER_1 = {

--- a/ui/e2e/migration/helpers/migration.helpers.ts
+++ b/ui/e2e/migration/helpers/migration.helpers.ts
@@ -31,6 +31,7 @@ export const API = {
   rdmDisks: `**${V1A1}/rdmdisks`,
   volumeImageProfiles: `**${V1A1}/volumeimageprofiles**`,
   validateIPs: `**/validate_openstack_ip`,
+  checkSubnetCompatibility: `**/check_network_subnet_compatibility`,
   podLogs: (namespace: string, podName: string) =>
     `**/namespaces/${namespace}/pods/${podName}/log*`,
   rollingMigrationPlans: `**${V1A1}/rollingmigrationplans`,

--- a/ui/src/features/migration/pages/MigrationForm.tsx
+++ b/ui/src/features/migration/pages/MigrationForm.tsx
@@ -35,6 +35,9 @@ import type {
   MigrationFormDrawerProps
 } from '../types'
 import { useSectionTracking } from '../hooks/useSectionTracking'
+import { useNetworkIPsMap } from '../hooks/useNetworkIPsMap'
+import { useNetworkSubnetCompatibility } from '../hooks/useNetworkSubnetCompatibility'
+import { hasAnySubnetMismatch } from '../utils/subnetMismatch'
 import { useFormSync } from '../hooks/useFormSync'
 import { useCredentialFetching } from '../hooks/useCredentialFetching'
 import { useMigrationFormSubmit } from '../hooks/useMigrationFormSubmit'
@@ -239,6 +242,19 @@ export default function MigrationFormDrawer({
     openstackCredentials,
     touchedSections
   })
+
+  // Subnet compatibility between selected VM IPs and mapped target networks.
+  // Shared by the mapping step (per-network warnings) and the options step
+  // (persist IP is blocked while any mismatch exists).
+  const networkIPsMap = useNetworkIPsMap(params.vms || [])
+  const subnetWarnings = useNetworkSubnetCompatibility({
+    networkMappings: params.networkMappings,
+    openstackCredentials,
+    selectedVMs: params.vms || [],
+    networkIPsMap,
+    openstackNetworks: sortedOpenstackNetworks
+  })
+  const hasSubnetMismatch = hasAnySubnetMismatch(subnetWarnings)
 
   const { submitting, handleSubmit, handleClose } = useMigrationFormSubmit({
     params,
@@ -578,8 +594,7 @@ export default function MigrationFormDrawer({
                   networkMappingError={fieldErrors['networksMapping']}
                   storageMappingError={fieldErrors['storageMapping']}
                   showHeader={false}
-                  selectedVMs={params.vms}
-                  openstackCredentials={openstackCredentials}
+                  subnetWarnings={subnetWarnings}
                 />
               </SurfaceCard>
             </Box>
@@ -630,6 +645,7 @@ export default function MigrationFormDrawer({
                   getErrorsUpdater={getFieldErrorsUpdater}
                   stepNumber="5"
                   showHeader={false}
+                  hasSubnetMismatch={hasSubnetMismatch}
                 />
               </SurfaceCard>
             </Box>

--- a/ui/src/features/migration/pages/RollingMigrationForm.tsx
+++ b/ui/src/features/migration/pages/RollingMigrationForm.tsx
@@ -29,6 +29,9 @@ import { useClusterData } from '../hooks/useClusterData'
 import { useErrorHandler } from 'src/hooks/useErrorHandler'
 import { useHostConfigHandlers } from '../hooks/useHostConfigHandlers'
 import { useRollingFormData } from '../hooks/useRollingFormData'
+import { useNetworkIPsMap } from '../hooks/useNetworkIPsMap'
+import { useNetworkSubnetCompatibility } from '../hooks/useNetworkSubnetCompatibility'
+import { hasAnySubnetMismatch } from '../utils/subnetMismatch'
 import { useRollingFormValidation } from '../hooks/useRollingFormValidation'
 import { useRollingFormSubmit } from '../hooks/useRollingFormSubmit'
 import { useSectionTracking } from '../hooks/useSectionTracking'
@@ -49,6 +52,7 @@ import type {
   FieldErrors,
   RollingFormParams
 } from '../types'
+import type { VmData } from '../api/migration-templates/model'
 
 // RollingMigration includes osFamily which the shared SelectedMigrationOptionsType does not
 export interface SelectedMigrationOptionsType extends Record<string, unknown> {
@@ -390,6 +394,30 @@ export default function RollingMigrationFormDrawer({
     const volumeTypes = openstackCredData?.status?.openstack?.volumeTypes || []
     return volumeTypes.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
   }, [openstackCredData])
+
+  // Subnet compatibility between VM IPs and mapped target networks — shared by
+  // the mapping step (warnings) and migration options (persist IP block).
+  const subnetCheckVMs = useMemo<VmData[]>(
+    () =>
+      vmsWithAssignments.map((vm) => ({
+        id: vm.id,
+        name: vm.name,
+        datastores: vm.datastores || [],
+        networks: vm.networks,
+        ipAddress: vm.ip,
+        networkInterfaces: vm.networkInterfaces
+      })),
+    [vmsWithAssignments]
+  )
+  const networkIPsMap = useNetworkIPsMap(subnetCheckVMs)
+  const subnetWarnings = useNetworkSubnetCompatibility({
+    networkMappings: params.networkMappings,
+    openstackCredentials: openstackCredData || undefined,
+    selectedVMs: subnetCheckVMs,
+    networkIPsMap,
+    openstackNetworks
+  })
+  const hasSubnetMismatch = hasAnySubnetMismatch(subnetWarnings)
 
   // Update ESXi host config names when OpenStack host configs become available
   useEffect(() => {
@@ -888,8 +916,7 @@ export default function RollingMigrationFormDrawer({
                       storageMappingError={storageMappingError}
                       loading={loadingOpenstackDetails}
                       showHeader={false}
-                      selectedVMs={vmsWithAssignments as any}
-                      openstackCredentials={openstackCredData || undefined}
+                      subnetWarnings={subnetWarnings}
                     />
                   ) : (
                     <Typography variant="body2" color="text.secondary">
@@ -947,6 +974,7 @@ export default function RollingMigrationFormDrawer({
                     errors={fieldErrors}
                     getErrorsUpdater={getFieldErrorsUpdater}
                     showHeader={false}
+                    hasSubnetMismatch={hasSubnetMismatch}
                   />
                 </SurfaceCard>
               </Box>

--- a/ui/src/features/migration/steps/MigrationOptionsAlt.tsx
+++ b/ui/src/features/migration/steps/MigrationOptionsAlt.tsx
@@ -709,7 +709,9 @@ export default function MigrationOptionsAlt({
                 }
               />
               <OptionHelp variant="caption">
-                Retain the source VM's network interface names
+                {hasSubnetMismatch
+                  ? 'Disabled because some VM IP addresses do not lie within the subnet of the mapped destination network(s). Map to a network with a matching subnet to enable this option.'
+                  : "Retain the source VM's network interface names"}
               </OptionHelp>
             </OptionLeft>
             <Box />

--- a/ui/src/features/migration/steps/MigrationOptionsAlt.tsx
+++ b/ui/src/features/migration/steps/MigrationOptionsAlt.tsx
@@ -646,14 +646,6 @@ export default function MigrationOptionsAlt({
             </Alert>
           )}
 
-          {hasSubnetMismatch && (
-            <Alert severity="info" sx={{ mt: 1 }} data-testid="network-persistence-subnet-alert">
-              Persist source network interfaces is not available because some VM IP addresses do
-              not lie within the subnet of the selected destination network(s). Map to a network
-              with a matching subnet to enable this option.
-            </Alert>
-          )}
-
           <OptionRow>
             <OptionLeft>
               <FormControlLabel
@@ -709,13 +701,19 @@ export default function MigrationOptionsAlt({
                 }
               />
               <OptionHelp variant="caption">
-                {hasSubnetMismatch
-                  ? 'Disabled because some VM IP addresses do not lie within the subnet of the mapped destination network(s). Map to a network with a matching subnet to enable this option.'
-                  : "Retain the source VM's network interface names"}
+                Retain the source VM's network interface names
               </OptionHelp>
             </OptionLeft>
             <Box />
           </OptionRow>
+
+          {hasSubnetMismatch && (
+            <Alert severity="info" sx={{ mt: 1 }} data-testid="network-persistence-subnet-alert">
+              Persist source network interfaces is not available because some VM IP addresses do
+              not lie within the subnet of the selected destination network(s). Map to a network
+              with a matching subnet to enable this option.
+            </Alert>
+          )}
         </SectionBlock>
 
         {isPCD ? (

--- a/ui/src/features/migration/steps/MigrationOptionsAlt.tsx
+++ b/ui/src/features/migration/steps/MigrationOptionsAlt.tsx
@@ -85,7 +85,8 @@ export default function MigrationOptionsAlt({
   errors,
   getErrorsUpdater,
   stepNumber,
-  showHeader = true
+  showHeader = true,
+  hasSubnetMismatch = false
 }: MigrationOptionsPropsInterface) {
   const { setValue } = useFormContext()
   const { data: globalConfigMap } = useSettingsConfigMapQuery()
@@ -239,6 +240,14 @@ export default function MigrationOptionsAlt({
     const now = dayjs()
     return computedMin.isAfter(now) ? computedMin : now
   }, [params, selectedMigrationOptions])
+
+  // Persist IP is mutually exclusive with mapping to a network whose subnet
+  // does not contain the source VM IPs — auto-uncheck when a mismatch appears
+  useEffect(() => {
+    if (hasSubnetMismatch && params?.networkPersistence) {
+      onChange('networkPersistence')(false)
+    }
+  }, [hasSubnetMismatch, params?.networkPersistence, onChange])
 
   const isPCD = openstackCredentials?.metadata?.labels?.['vjailbreak.k8s.pf9.io/is-pcd'] === 'true'
   const hasL2Network = hasSelectedLayer2Network(
@@ -637,6 +646,14 @@ export default function MigrationOptionsAlt({
             </Alert>
           )}
 
+          {hasSubnetMismatch && (
+            <Alert severity="info" sx={{ mt: 1 }} data-testid="network-persistence-subnet-alert">
+              Persist source network interfaces is not available because some VM IP addresses do
+              not lie within the subnet of the selected destination network(s). Map to a network
+              with a matching subnet to enable this option.
+            </Alert>
+          )}
+
           <OptionRow>
             <OptionLeft>
               <FormControlLabel
@@ -684,6 +701,7 @@ export default function MigrationOptionsAlt({
                   <Checkbox
                     data-testid="migration-option-network-persistence"
                     checked={params?.networkPersistence || false}
+                    disabled={hasSubnetMismatch}
                     onChange={(e) => {
                       onChange('networkPersistence')(e.target.checked)
                     }}

--- a/ui/src/features/migration/steps/NetworkAndStorageMappingStep.tsx
+++ b/ui/src/features/migration/steps/NetworkAndStorageMappingStep.tsx
@@ -1,6 +1,7 @@
 import {
   FormControl,
   FormHelperText,
+  Link,
   MenuItem,
   Select,
   styled,
@@ -12,6 +13,7 @@ import {
   Alert,
   Chip
 } from '@mui/material'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import { useMemo } from 'react'
 import { useFilteredMappings } from '../hooks/useFilteredMappings'
 import { ResourceMappingTableNew as ResourceMappingTable } from '../components'
@@ -23,6 +25,9 @@ import type { NetworkAndStorageMappingStepProps } from '../types'
 import { STORAGE_COPY_METHOD_OPTIONS } from '../constants'
 
 export type { ResourceMap, StorageCopyMethod } from '../types'
+
+const NETWORK_MAPPING_DOCS_URL =
+  'https://platform9.github.io/vjailbreak/concepts/network-storage-mapping/#network-mapping'
 
 const VmsSelectionStepContainer = styled('div')(({ theme }) => ({
   display: 'grid',
@@ -174,7 +179,17 @@ export default function NetworkAndStorageMappingStep({
                   />
                   {Object.entries(subnetWarnings).map(([sourceNetwork, warning]) => (
                     <Alert key={sourceNetwork} severity="warning" sx={{ mt: 1 }}>
-                      <strong>{sourceNetwork}:</strong> {warning}
+                      <strong>{sourceNetwork}:</strong> {warning}{' '}
+                      <Link
+                        href={NETWORK_MAPPING_DOCS_URL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        underline="always"
+                        sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.25 }}
+                      >
+                        Show more
+                        <OpenInNewIcon fontSize="inherit" />
+                      </Link>
                     </Alert>
                   ))}
                 </>

--- a/ui/src/features/migration/steps/NetworkAndStorageMappingStep.tsx
+++ b/ui/src/features/migration/steps/NetworkAndStorageMappingStep.tsx
@@ -13,9 +13,7 @@ import {
   Chip
 } from '@mui/material'
 import { useMemo } from 'react'
-import { useNetworkIPsMap } from '../hooks/useNetworkIPsMap'
 import { useFilteredMappings } from '../hooks/useFilteredMappings'
-import { useNetworkSubnetCompatibility } from '../hooks/useNetworkSubnetCompatibility'
 import { ResourceMappingTableNew as ResourceMappingTable } from '../components'
 import { Step } from 'src/shared/components/forms'
 import { FieldLabel } from 'src/components'
@@ -48,8 +46,7 @@ export default function NetworkAndStorageMappingStep({
   stepNumber = '3',
   loading = false,
   showHeader = true,
-  selectedVMs = [],
-  openstackCredentials
+  subnetWarnings = {}
 }: NetworkAndStorageMappingStepProps) {
   const storageCopyMethod = params.storageCopyMethod || 'normal'
 
@@ -97,16 +94,6 @@ export default function NetworkAndStorageMappingStep({
     storageCopyMethod,
     validatedArrayCreds,
     onChange
-  })
-
-  const networkIPsMap = useNetworkIPsMap(selectedVMs)
-
-  const subnetWarnings = useNetworkSubnetCompatibility({
-    networkMappings: params.networkMappings,
-    openstackCredentials,
-    selectedVMs,
-    networkIPsMap,
-    openstackNetworks
   })
 
   // Calculate unmapped networks and storage

--- a/ui/src/features/migration/types.ts
+++ b/ui/src/features/migration/types.ts
@@ -169,8 +169,7 @@ export interface NetworkAndStorageMappingStepProps {
   stepNumber?: string
   loading?: boolean
   showHeader?: boolean
-  selectedVMs?: VmData[]
-  openstackCredentials?: OpenstackCreds
+  subnetWarnings?: Record<string, string>
 }
 
 // ---------------------------------------------------------------------------
@@ -351,6 +350,7 @@ export interface MigrationOptionsPropsInterface {
   getErrorsUpdater: (key: string | number) => (value: string) => void
   stepNumber: string
   showHeader?: boolean
+  hasSubnetMismatch?: boolean
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/src/features/migration/utils/subnetMismatch.test.ts
+++ b/ui/src/features/migration/utils/subnetMismatch.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { hasAnySubnetMismatch } from './subnetMismatch'
+
+describe('hasAnySubnetMismatch', () => {
+  it('returns false for undefined warnings', () => {
+    expect(hasAnySubnetMismatch(undefined)).toBe(false)
+  })
+
+  it('returns false for empty warnings (no mismatch detected → do not block)', () => {
+    expect(hasAnySubnetMismatch({})).toBe(false)
+  })
+
+  it('returns false when warning values are empty strings', () => {
+    expect(hasAnySubnetMismatch({ 'VM Network': '', Mgmt: '   ' })).toBe(false)
+  })
+
+  it('returns true when a single network has a mismatch warning', () => {
+    expect(
+      hasAnySubnetMismatch({
+        'VM Network': '2 VM IP address(es) do not lie within the subnet of destination network'
+      })
+    ).toBe(true)
+  })
+
+  it('returns true when only one of several networks has a mismatch', () => {
+    expect(
+      hasAnySubnetMismatch({
+        'VM Network': '',
+        Mgmt: '1 VM IP address(es) do not lie within the subnet of destination network'
+      })
+    ).toBe(true)
+  })
+})

--- a/ui/src/features/migration/utils/subnetMismatch.ts
+++ b/ui/src/features/migration/utils/subnetMismatch.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns true when any source network has a subnet-compatibility warning,
+ * i.e. at least one selected VM IP does not lie within the subnet of its
+ * mapped destination network. Used to block the "Persist source network
+ * interfaces" option, which would pin IPs that are invalid on the target.
+ */
+export function hasAnySubnetMismatch(subnetWarnings: Record<string, string> | undefined): boolean {
+  if (!subnetWarnings) return false
+  return Object.values(subnetWarnings).some((warning) => Boolean(warning && warning.trim()))
+}


### PR DESCRIPTION
## What this PR does / why we need it
The "Persist source network interfaces" option pins the source VM's MAC→IP mapping and NIC names inside the guest after migration. This makes no sense when the user maps a VMware network to a PCD network whose subnet does not contain the VM's IPs — the persisted IPs would be invalid on the target and the VM would lose connectivity. These two options are now mutually exclusive in the UI.


## Which issue(s) this PR fixes
fixes #2085 


## Testing done

https://github.com/user-attachments/assets/0328474d-de74-4eae-9430-7e446862a915
<img width="1440" height="814" alt="image" src="https://github.com/user-attachments/assets/c5f1bdb3-355a-456b-80c9-b171c3839cf0" />
<img width="1440" height="809" alt="image" src="https://github.com/user-attachments/assets/12598110-c49c-4c7f-a80a-44456800d76f" />

