### PR TITLE
[2106] Fix wrong stage shown for Hot-Add proxy migrations

### DIFF
--- a/k8s/migration/internal/controller/migration_controller.go
+++ b/k8s/migration/internal/controller/migration_controller.go
@@ -488,7 +488,13 @@ loop:
 			scope.Migration.Status.Phase = vjailbreakv1alpha1.VMMigrationPhaseFailed
 			break loop
 		case slices.Contains(IgnoredPhases, scope.Migration.Status.Phase):
-			break loop
+			// Still in a pre-started phase (Pending/Validating/ValidationFailed) and this event
+			// isn't a recognized progress signal. Keep scanning older events instead of bailing:
+			// events are newest-first, and for Hot-Add the long-running nbdcopy is often preceded
+			// by non-matching detail messages ("Disk attached...", "Removing pre-existing snapshot...")
+			// that would otherwise stop us before reaching the actual progress event and leave the
+			// migration stuck showing "Validating".
+			continue
 		default:
 			continue
 		}

--- a/ui/src/features/migration/components/detail/MigrationPhaseDetail.tsx
+++ b/ui/src/features/migration/components/detail/MigrationPhaseDetail.tsx
@@ -396,6 +396,12 @@ export default function MigrationPhaseDetail({
     case Phase.CopyingBlocks:
     case Phase.CopyingChangedBlocks:
     case Phase.AwaitingDataCopyStart:
+    // Hot-Add proxy copy phases all render as the "Copying Blocks" stage.
+    case Phase.SnapshottingSourceVM:
+    case Phase.AttachingDisksToProxy:
+    case Phase.IdentifyingBlockDevices:
+    case Phase.HotAddTransferInProgress:
+    case Phase.HotAddCleanup:
       return <CopyingPhaseDetail migration={migration} />
 
     case Phase.ConvertingDisk:


### PR DESCRIPTION
Map the Hot-Add proxy phases (Snapshotting, Attaching, Identifying, Transferring, Cleanup) to the "Copying Blocks" stage in the migration details UI. Fix the controller phase loop so it no longer stays stuck on "Validating" while nbdcopy is running.

fixes: #2106

## Testing Notes

<img width="1423" height="773" alt="image" src="https://github.com/user-attachments/assets/cfdaf6ee-ef61-447e-a273-7852a3d8d2c2" />
