### PR TITLE
[2113] Improved subnet mismatch warning and Persist IP disabled warning

### DIFF
--- a/ui/e2e/migration/edge-cases.spec.ts
+++ b/ui/e2e/migration/edge-cases.spec.ts
@@ -873,7 +873,7 @@ test.describe('MIG-042 — persist IP mutually exclusive with different-subnet m
 
     // Helper text switches from the default description to the disabled reason
     await expect(
-      page.getByText(/disabled because some vm ip addresses do not lie within the subnet/i)
+      page.getByText(/disabled because some ip addresses of the selected vms do not lie within the subnet/i)
     ).toBeVisible()
   })
 

--- a/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.ts
+++ b/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.ts
@@ -86,7 +86,7 @@ export function useNetworkSubnetCompatibility({
               const cidrList =
                 result.subnet_cidrs?.length > 0 ? ` (${result.subnet_cidrs.join(', ')})` : ''
               nextWarnings[mapping.source] =
-                `${incompatibleIPs.length} VM IP address(es) [${incompatibleIPs.join(', ')}] do not lie within the subnet of destination network ${mapping.target} ${cidrList}. ` +
+                `${incompatibleIPs.length} IP address(es) of the selected VMs [${incompatibleIPs.join(', ')}] do not lie within the subnet of destination network ${mapping.target} ${cidrList}. ` +
                 `Ensure fallback to DHCP is enabled, otherwise it may lead to migration failures`
             }
           } catch {

--- a/ui/src/features/migration/steps/MigrationOptionsAlt.tsx
+++ b/ui/src/features/migration/steps/MigrationOptionsAlt.tsx
@@ -709,9 +709,9 @@ export default function MigrationOptionsAlt({
 
           {hasSubnetMismatch && (
             <Alert severity="info" sx={{ mt: 1 }} data-testid="network-persistence-subnet-alert">
-              Persist source network interfaces is not available because some VM IP addresses do
-              not lie within the subnet of the selected destination network(s). Map to a network
-              with a matching subnet to enable this option.
+              Persist source network interfaces is not available because some IP addresses of the
+              selected VMs do not lie within the subnet of the selected destination network(s). Map
+              to a network with a matching subnet to enable this option.
             </Alert>
           )}
         </SectionBlock>

--- a/ui/src/features/migration/utils/subnetMismatch.test.ts
+++ b/ui/src/features/migration/utils/subnetMismatch.test.ts
@@ -17,7 +17,7 @@ describe('hasAnySubnetMismatch', () => {
   it('returns true when a single network has a mismatch warning', () => {
     expect(
       hasAnySubnetMismatch({
-        'VM Network': '2 VM IP address(es) do not lie within the subnet of destination network'
+        'VM Network': '2 IP address(es) of the selected VMs do not lie within the subnet of destination network'
       })
     ).toBe(true)
   })
@@ -26,7 +26,7 @@ describe('hasAnySubnetMismatch', () => {
     expect(
       hasAnySubnetMismatch({
         'VM Network': '',
-        Mgmt: '1 VM IP address(es) do not lie within the subnet of destination network'
+        Mgmt: '1 IP address(es) of the selected VMs do not lie within the subnet of destination network'
       })
     ).toBe(true)
   })


### PR DESCRIPTION
## What this PR does / why we need it
Improve subnet mismatch warning and Persist IP disabled warning

## Which issue(s) this PR fixes
fixes #2113 

## Testing done
 Before:
<img width="1436" height="804" alt="image" src="https://github.com/user-attachments/assets/4a1e40e7-ca51-4c37-b7b2-d983a1f9a7a0" />

After:
<img width="1440" height="812" alt="image" src="https://github.com/user-attachments/assets/cc122170-92bc-458e-8787-c11e92ba979b" />
<img width="1440" height="809" alt="image" src="https://github.com/user-attachments/assets/607c2ad9-05fd-4996-a6e8-5a13929b41bc" />
<img width="2880" height="1636" alt="image" src="https://github.com/user-attachments/assets/873fa906-4ef3-42d6-8ed6-4d5744eff7ce" />
<img width="2438" height="176" alt="image" src="https://github.com/user-attachments/assets/c2ff9695-6086-42af-9db0-a57a833e3c7b" />
