### PR TITLE
[2012] Fix SUSE GRUB Legacy device references post-migration

### DIFF
--- a/scripts/generate-mount-persistence.sh
+++ b/scripts/generate-mount-persistence.sh
@@ -94,19 +94,8 @@ get_fstab_id() {
   fi
 }
 
-# detect_bootloader <root_prefix>
-#
-# Prints "legacy", "grub2", or "unknown" for the guest rooted at
-# <root_prefix> (pass "" when not running inside a guestfish appliance, or
-# "/sysroot" when the guest is mounted there).
-#
-# Signal order, most to least authoritative:
-#   1. SUSE's /etc/sysconfig/bootloader LOADER_TYPE= — YaST's own record of
-#      which bootloader is actually installed (grub == legacy, grub2* == grub2).
-#   2. Presence of /boot/grub2 or a grub.cfg file (Debian/Ubuntu keep GRUB2's
-#      config under /boot/grub/grub.cfg, so filename beats directory name).
-#   3. Presence of /boot/grub/menu.lst or /boot/grub/grub.conf with no
-#      grub.cfg alongside it — the classic GRUB Legacy layout.
+# detect_bootloader <root_prefix>: echo legacy|grub2|unknown, preferring SUSE's LOADER_TYPE=,
+# then a grub.cfg / /boot/grub2 dir (grub2), then menu.lst / grub.conf (GRUB Legacy).
 detect_bootloader() {
   _prefix="$1"
 
@@ -131,14 +120,8 @@ detect_bootloader() {
   echo "unknown"
 }
 
-# fix_grub_cmdline <root_prefix>
-#
-# Rewrites root=/resume= kernel cmdline device references to UUID= form in
-# GRUB Legacy's menu.lst/grub.conf, GRUB2's /etc/default/grub, and SUSE's
-# /etc/sysconfig/bootloader. Deliberately never touches device.map — this is
-# the safe half of the old fix_grub_config, callable on its own (see
-# --os-family=suse in print_help) without risking the GRUB stage1 "Error 21"
-# regression that rewriting device.map before virt-v2v runs can cause.
+# fix_grub_cmdline <root_prefix>: rewrite root=/resume= device refs to UUID= in menu.lst/grub.conf,
+# /etc/default/grub, and sysconfig/bootloader. Never touches device.map, so it's safe pre-virt-v2v.
 fix_grub_cmdline() {
   _prefix="$1"
   echo "Fixing GRUB kernel cmdline (root=/resume=) references..."
@@ -189,14 +172,8 @@ fix_grub_cmdline() {
   echo " -> GRUB cmdline fixed. Backups created with .bak.* extension. device.map untouched."
 }
 
-# fix_grub_device_map <root_prefix>
-#
-# Rewrites /boot/grub/device.map entries from /dev/sdX to /dev/vdX. This is
-# the unsafe half of the old fix_grub_config: on SUSE GRUB Legacy guests,
-# doing this BEFORE virt-v2v runs makes virt-v2v's own appliance (where
-# disks are still /dev/sdX) reinstall GRUB stage1 with incorrect embedded
-# drive references, causing GRUB Error 21 at boot. Only ever call this from
-# fix_grub_config (--force-uuid), never from the --os-family=suse safe path.
+# fix_grub_device_map <root_prefix>: rewrite device.map /dev/sdX -> /dev/vdX. Unsafe pre-virt-v2v on
+# SUSE GRUB Legacy (stage1 reinstalled with wrong drives -> Error 21); only call via --force-uuid.
 fix_grub_device_map() {
   _prefix="$1"
   if [ -f "${_prefix}/boot/grub/device.map" ]; then
@@ -404,9 +381,8 @@ if $APPLY; then
 
   echo " -> Done. Backups created in /etc/udev/rules.d and /etc/fstab.bak.*"
   
-  # Fix grub configuration if --force-uuid was specified. Otherwise, for
-  # SUSE guests only (--os-family=suse), safely fix a detected GRUB Legacy
-  # cmdline without ever touching device.map (see print_help for why).
+  # --force-uuid runs the full grub fix; --os-family=suse only fixes a detected
+  # GRUB Legacy cmdline, never device.map (see print_help for why).
   if $FORCE_UUID; then
     fix_grub_config
   elif [ "$OS_FAMILY" = "suse" ]; then

--- a/scripts/generate-mount-persistence.sh
+++ b/scripts/generate-mount-persistence.sh
@@ -21,6 +21,7 @@ SKIP_DEVICES_REGEX="^/dev/(ram|loop|fd|sr|zram|nbd|md|pmem)[0-9]"
 APPLY=false
 REPLACE_FSTAB=false
 FORCE_UUID=false
+OS_FAMILY=""
 
 print_help() {
   cat <<EOF
@@ -36,7 +37,15 @@ Options:
   --force-uuid      Same as --replace-fstab, but converts all device references to
                     UUID=, LABEL=, or PARTUUID= format for consistent naming.
                     Also fixes grub configuration (GRUB Legacy, GRUB2, YaST2) to use
-                    UUID-based root device references. Creates backups of all modified files.
+                    UUID-based root device references, including device.map.
+                    Creates backups of all modified files.
+  --os-family=NAME  Hints the guest OS family (e.g. "suse"). When set to "suse" and
+                    --force-uuid was not also given, GRUB Legacy is detected on the
+                    guest and, if found, only the root=/resume= kernel cmdline
+                    references are rewritten to UUID= form. device.map is never
+                    touched by this path, so it cannot reintroduce the GRUB stage1
+                    "Error 21" regression that --force-uuid's device.map rewrite can
+                    cause when run before virt-v2v on SUSE GRUB Legacy guests.
   --help            Show this help message and exit.
 
 Examples:
@@ -45,17 +54,22 @@ Examples:
   $0 --replace-fstab
                    # Apply rules, deduplicate existing entries in /etc/fstab
   $0 --force-uuid  # Apply rules, deduplicate, convert all entries to UUID= format
+  $0 --replace-fstab --os-family=suse
+                   # Apply + dedup, and safely fix a SUSE GRUB Legacy cmdline if detected
 
 EOF
   exit 0
 }
 
-case "${1:-}" in
-  --apply) APPLY=true ;;
-  --replace-fstab) APPLY=true; REPLACE_FSTAB=true ;;
-  --force-uuid) APPLY=true; REPLACE_FSTAB=true; FORCE_UUID=true ;;
-  --help|-h) print_help ;;
-esac
+for arg in "$@"; do
+  case "$arg" in
+    --apply) APPLY=true ;;
+    --replace-fstab) APPLY=true; REPLACE_FSTAB=true ;;
+    --force-uuid) APPLY=true; REPLACE_FSTAB=true; FORCE_UUID=true ;;
+    --os-family=*) OS_FAMILY="${arg#--os-family=}" ;;
+    --help|-h) print_help ;;
+  esac
+done
 
 UDEV_RULES_FILE=$(mktemp)
 FSTAB_LINES_FILE=$(mktemp)
@@ -80,66 +94,131 @@ get_fstab_id() {
   fi
 }
 
+# detect_bootloader <root_prefix>
+#
+# Prints "legacy", "grub2", or "unknown" for the guest rooted at
+# <root_prefix> (pass "" when not running inside a guestfish appliance, or
+# "/sysroot" when the guest is mounted there).
+#
+# Signal order, most to least authoritative:
+#   1. SUSE's /etc/sysconfig/bootloader LOADER_TYPE= — YaST's own record of
+#      which bootloader is actually installed (grub == legacy, grub2* == grub2).
+#   2. Presence of /boot/grub2 or a grub.cfg file (Debian/Ubuntu keep GRUB2's
+#      config under /boot/grub/grub.cfg, so filename beats directory name).
+#   3. Presence of /boot/grub/menu.lst or /boot/grub/grub.conf with no
+#      grub.cfg alongside it — the classic GRUB Legacy layout.
+detect_bootloader() {
+  _prefix="$1"
+
+  if [ -f "${_prefix}/etc/sysconfig/bootloader" ]; then
+    _loader_type=$(grep -E '^LOADER_TYPE=' "${_prefix}/etc/sysconfig/bootloader" 2>/dev/null | cut -d= -f2 | tr -d '"')
+    case "$_loader_type" in
+      grub) echo "legacy"; return ;;
+      grub2*) echo "grub2"; return ;;
+    esac
+  fi
+
+  if [ -d "${_prefix}/boot/grub2" ] || [ -f "${_prefix}/boot/grub2/grub.cfg" ] || [ -f "${_prefix}/boot/grub/grub.cfg" ]; then
+    echo "grub2"
+    return
+  fi
+
+  if [ -f "${_prefix}/boot/grub/menu.lst" ] || [ -f "${_prefix}/boot/grub/grub.conf" ]; then
+    echo "legacy"
+    return
+  fi
+
+  echo "unknown"
+}
+
+# fix_grub_cmdline <root_prefix>
+#
+# Rewrites root=/resume= kernel cmdline device references to UUID= form in
+# GRUB Legacy's menu.lst/grub.conf, GRUB2's /etc/default/grub, and SUSE's
+# /etc/sysconfig/bootloader. Deliberately never touches device.map — this is
+# the safe half of the old fix_grub_config, callable on its own (see
+# --os-family=suse in print_help) without risking the GRUB stage1 "Error 21"
+# regression that rewriting device.map before virt-v2v runs can cause.
+fix_grub_cmdline() {
+  _prefix="$1"
+  echo "Fixing GRUB kernel cmdline (root=/resume=) references..."
+
+  _device_uuid_map=$(mktemp)
+  for _dev in /dev/vd[a-z]* /dev/sd[a-z]* /dev/hd[a-z]* /dev/xvd[a-z]*; do
+    [ -b "$_dev" ] || continue
+    _uuid=$(blkid -s UUID -o value "$_dev" 2>/dev/null || true)
+    [ -n "$_uuid" ] && echo "$_dev UUID=$_uuid" >> "$_device_uuid_map"
+  done
+
+  # Fix GRUB Legacy (menu.lst or grub.conf)
+  for _grub_cfg in "${_prefix}/boot/grub/menu.lst" "${_prefix}/boot/grub/grub.conf"; do
+    if [ -f "$_grub_cfg" ]; then
+      echo " -> Fixing GRUB Legacy config: $_grub_cfg"
+      cp "$_grub_cfg" "$_grub_cfg.bak.$(date +%s)"
+
+      while read -r _dev _uuid; do
+        sed -i "s|root=${_dev}|root=${_uuid}|g" "$_grub_cfg"
+        sed -i "s|resume=${_dev}|resume=${_uuid}|g" "$_grub_cfg"
+      done < "$_device_uuid_map"
+    fi
+  done
+
+  # Fix GRUB2 /etc/default/grub
+  if [ -f "${_prefix}/etc/default/grub" ]; then
+    echo " -> Fixing /etc/default/grub"
+    cp "${_prefix}/etc/default/grub" "${_prefix}/etc/default/grub.bak.$(date +%s)"
+
+    while read -r _dev _uuid; do
+      sed -i "s|root=${_dev}|root=${_uuid}|g" "${_prefix}/etc/default/grub"
+      sed -i "s|resume=${_dev}|resume=${_uuid}|g" "${_prefix}/etc/default/grub"
+    done < "$_device_uuid_map"
+  fi
+
+  # Fix SUSE YaST2 bootloader config
+  if [ -f "${_prefix}/etc/sysconfig/bootloader" ]; then
+    echo " -> Fixing SUSE /etc/sysconfig/bootloader"
+    cp "${_prefix}/etc/sysconfig/bootloader" "${_prefix}/etc/sysconfig/bootloader.bak.$(date +%s)"
+
+    while read -r _dev _uuid; do
+      sed -i "s|root=${_dev}|root=${_uuid}|g" "${_prefix}/etc/sysconfig/bootloader"
+      sed -i "s|resume=${_dev}|resume=${_uuid}|g" "${_prefix}/etc/sysconfig/bootloader"
+    done < "$_device_uuid_map"
+  fi
+
+  rm -f "$_device_uuid_map"
+  echo " -> GRUB cmdline fixed. Backups created with .bak.* extension. device.map untouched."
+}
+
+# fix_grub_device_map <root_prefix>
+#
+# Rewrites /boot/grub/device.map entries from /dev/sdX to /dev/vdX. This is
+# the unsafe half of the old fix_grub_config: on SUSE GRUB Legacy guests,
+# doing this BEFORE virt-v2v runs makes virt-v2v's own appliance (where
+# disks are still /dev/sdX) reinstall GRUB stage1 with incorrect embedded
+# drive references, causing GRUB Error 21 at boot. Only ever call this from
+# fix_grub_config (--force-uuid), never from the --os-family=suse safe path.
+fix_grub_device_map() {
+  _prefix="$1"
+  if [ -f "${_prefix}/boot/grub/device.map" ]; then
+    echo " -> Fixing device.map: ${_prefix}/boot/grub/device.map"
+    cp "${_prefix}/boot/grub/device.map" "${_prefix}/boot/grub/device.map.bak.$(date +%s)"
+    sed -i 's|/dev/sd\([a-z]\)|/dev/vd\1|g' "${_prefix}/boot/grub/device.map"
+  fi
+}
+
 fix_grub_config() {
   echo "Fixing grub configuration..."
-  
+
   # Detect if running in guestfish appliance (mountpoints under /sysroot)
   if mount | grep -q '/sysroot'; then
     ROOT_PREFIX="/sysroot"
   else
     ROOT_PREFIX=""
   fi
-  
-  # Build device-to-UUID mapping for all block devices
-  DEVICE_UUID_MAP=$(mktemp)
-  for dev in /dev/vd[a-z]* /dev/sd[a-z]* /dev/hd[a-z]* /dev/xvd[a-z]*; do
-    [ -b "$dev" ] || continue
-    UUID=$(blkid -s UUID -o value "$dev" 2>/dev/null || true)
-    [ -n "$UUID" ] && echo "$dev UUID=$UUID" >> "$DEVICE_UUID_MAP"
-  done
-  
-  # Fix GRUB Legacy (menu.lst or grub.conf)
-  for grub_cfg in "${ROOT_PREFIX}/boot/grub/menu.lst" "${ROOT_PREFIX}/boot/grub/grub.conf"; do
-    if [ -f "$grub_cfg" ]; then
-      echo " -> Fixing GRUB Legacy config: $grub_cfg"
-      cp "$grub_cfg" "$grub_cfg.bak.$(date +%s)"
-      
-      # Replace root=/dev/sdXN and root=/dev/vdXN with UUID
-      while read -r dev uuid; do
-        sed -i "s|root=${dev}|root=${uuid}|g" "$grub_cfg"
-        sed -i "s|resume=${dev}|resume=${uuid}|g" "$grub_cfg"
-      done < "$DEVICE_UUID_MAP"
-      
-      # Update device.map if it exists
-      if [ -f "${ROOT_PREFIX}/boot/grub/device.map" ]; then
-        cp "${ROOT_PREFIX}/boot/grub/device.map" "${ROOT_PREFIX}/boot/grub/device.map.bak.$(date +%s)"
-        sed -i 's|/dev/sd\([a-z]\)|/dev/vd\1|g' "${ROOT_PREFIX}/boot/grub/device.map"
-      fi
-    fi
-  done
-  
-  # Fix GRUB2 /etc/default/grub
-  if [ -f "${ROOT_PREFIX}/etc/default/grub" ]; then
-    echo " -> Fixing /etc/default/grub"
-    cp "${ROOT_PREFIX}/etc/default/grub" "${ROOT_PREFIX}/etc/default/grub.bak.$(date +%s)"
-    
-    while read -r dev uuid; do
-      sed -i "s|root=${dev}|root=${uuid}|g" "${ROOT_PREFIX}/etc/default/grub"
-      sed -i "s|resume=${dev}|resume=${uuid}|g" "${ROOT_PREFIX}/etc/default/grub"
-    done < "$DEVICE_UUID_MAP"
-  fi
-  
-  # Fix SUSE YaST2 bootloader config
-  if [ -f "${ROOT_PREFIX}/etc/sysconfig/bootloader" ]; then
-    echo " -> Fixing SUSE /etc/sysconfig/bootloader"
-    cp "${ROOT_PREFIX}/etc/sysconfig/bootloader" "${ROOT_PREFIX}/etc/sysconfig/bootloader.bak.$(date +%s)"
-    
-    while read -r dev uuid; do
-      sed -i "s|root=${dev}|root=${uuid}|g" "${ROOT_PREFIX}/etc/sysconfig/bootloader"
-      sed -i "s|resume=${dev}|resume=${uuid}|g" "${ROOT_PREFIX}/etc/sysconfig/bootloader"
-    done < "$DEVICE_UUID_MAP"
-  fi
-  
+
+  fix_grub_cmdline "$ROOT_PREFIX"
+  fix_grub_device_map "$ROOT_PREFIX"
+
   # Regenerate GRUB2 config if not in guestfish
   if [ -z "$ROOT_PREFIX" ]; then
     if command -v grub2-mkconfig >/dev/null 2>&1; then
@@ -170,8 +249,7 @@ fix_grub_config() {
       pbl --install 2>/dev/null || true
     fi
   fi
-  
-  rm -f "$DEVICE_UUID_MAP"
+
   echo " -> Grub configuration fixed. Backups created with .bak.* extension"
 }
 
@@ -326,9 +404,24 @@ if $APPLY; then
 
   echo " -> Done. Backups created in /etc/udev/rules.d and /etc/fstab.bak.*"
   
-  # Fix grub configuration if --force-uuid was specified
+  # Fix grub configuration if --force-uuid was specified. Otherwise, for
+  # SUSE guests only (--os-family=suse), safely fix a detected GRUB Legacy
+  # cmdline without ever touching device.map (see print_help for why).
   if $FORCE_UUID; then
     fix_grub_config
+  elif [ "$OS_FAMILY" = "suse" ]; then
+    if mount | grep -q '/sysroot'; then
+      _suse_root_prefix="/sysroot"
+    else
+      _suse_root_prefix=""
+    fi
+    _suse_bootloader=$(detect_bootloader "$_suse_root_prefix")
+    if [ "$_suse_bootloader" = "legacy" ]; then
+      echo "SUSE guest with GRUB Legacy detected -> applying safe root=/resume= UUID fix"
+      fix_grub_cmdline "$_suse_root_prefix"
+    else
+      echo "SUSE guest, bootloader=$_suse_bootloader -> no GRUB Legacy cmdline fix needed"
+    fi
   fi
 else
   echo "# === UDEV RULES (save to /etc/udev/rules.d/99-by-mountpoint.rules) ==="

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -271,6 +271,22 @@ func IsSUSEFamily(osRelease string) bool {
 		strings.Contains(lowerRelease, "opensuse")
 }
 
+// MountPersistenceScriptArgs returns the argument string RunMountPersistenceScript
+// passes to generate-mount-persistence.sh for a given guest osRelease.
+//
+// Non-SUSE guests get the full --force-uuid conversion (fstab + grub config,
+// including device.map). SUSE guests get --replace-fstab plus --os-family=suse:
+// the script itself then detects whether the guest is GRUB Legacy and, only if
+// so, safely rewrites the root=/resume= kernel cmdline without touching
+// device.map — avoiding the GRUB Error 21 regression that rewriting device.map
+// before virt-v2v runs can cause on SUSE GRUB Legacy guests.
+func MountPersistenceScriptArgs(osRelease string) string {
+	if IsSUSEFamily(osRelease) {
+		return "--replace-fstab --os-family=suse"
+	}
+	return "--force-uuid"
+}
+
 func GetPartitions(disk string) ([]string, error) {
 	// Execute lsblk command to get partition information
 	cmd := exec.Command("lsblk", "-no", "NAME", disk)
@@ -989,17 +1005,18 @@ func RunMountPersistenceScript(disks []vm.VMDisk, diskPath string, osRelease str
 		return fmt.Errorf("generate-mount-persistence.sh script not found at %s", scriptPath)
 	}
 
-	// Choose the script flag based on OS family.
+	// Choose the script args based on OS family.
 	// SUSE GRUB Legacy guests must not have device.map rewritten before virt-v2v
 	// runs, so we use --replace-fstab (which skips fix_grub_config) instead of
-	// --force-uuid.
-	scriptFlag := "--force-uuid"
+	// --force-uuid, and additionally pass --os-family=suse so the script can
+	// safely fix a detected GRUB Legacy root=/resume= cmdline on its own
+	// (device.map is never touched by that path — see generate-mount-persistence.sh).
+	scriptArgs := MountPersistenceScriptArgs(osRelease)
 	if IsSUSEFamily(osRelease) {
-		scriptFlag = "--replace-fstab"
-		log.Printf("SUSE guest detected: using --replace-fstab (skipping fix_grub_config) to avoid corrupting device.map before virt-v2v")
+		log.Printf("SUSE guest detected: using --replace-fstab --os-family=suse (script will safely fix GRUB Legacy cmdline if detected, without touching device.map)")
 	}
 
-	log.Printf("Running generate-mount-persistence.sh with %s option", scriptFlag)
+	log.Printf("Running generate-mount-persistence.sh with %s option(s)", scriptArgs)
 
 	// Upload the script to the guest VM
 	var uploadErr error
@@ -1032,7 +1049,7 @@ func RunMountPersistenceScript(disks []vm.VMDisk, diskPath string, osRelease str
 	var runOutput string
 
 	command = "sh"
-	runOutput, runErr = RunCommandInGuestAllVolumes(disks, command, true, "/tmp/generate-mount-persistence.sh "+scriptFlag)
+	runOutput, runErr = RunCommandInGuestAllVolumes(disks, command, true, "/tmp/generate-mount-persistence.sh "+scriptArgs)
 
 	if runErr != nil {
 		log.Printf("Warning: generate-mount-persistence.sh execution failed: %v: %s", runErr, strings.TrimSpace(runOutput))
@@ -1040,7 +1057,7 @@ func RunMountPersistenceScript(disks []vm.VMDisk, diskPath string, osRelease str
 		return nil
 	}
 
-	log.Printf("Successfully executed generate-mount-persistence.sh with %s", scriptFlag)
+	log.Printf("Successfully executed generate-mount-persistence.sh with %s", scriptArgs)
 	log.Printf("Script output: %s", strings.TrimSpace(runOutput))
 
 	return nil

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -271,15 +271,8 @@ func IsSUSEFamily(osRelease string) bool {
 		strings.Contains(lowerRelease, "opensuse")
 }
 
-// MountPersistenceScriptArgs returns the argument string RunMountPersistenceScript
-// passes to generate-mount-persistence.sh for a given guest osRelease.
-//
-// Non-SUSE guests get the full --force-uuid conversion (fstab + grub config,
-// including device.map). SUSE guests get --replace-fstab plus --os-family=suse:
-// the script itself then detects whether the guest is GRUB Legacy and, only if
-// so, safely rewrites the root=/resume= kernel cmdline without touching
-// device.map — avoiding the GRUB Error 21 regression that rewriting device.map
-// before virt-v2v runs can cause on SUSE GRUB Legacy guests.
+// MountPersistenceScriptArgs picks generate-mount-persistence.sh flags per OS: non-SUSE uses
+// --force-uuid; SUSE uses --replace-fstab --os-family=suse to skip the device.map rewrite that breaks GRUB (Error 21).
 func MountPersistenceScriptArgs(osRelease string) string {
 	if IsSUSEFamily(osRelease) {
 		return "--replace-fstab --os-family=suse"
@@ -1005,12 +998,8 @@ func RunMountPersistenceScript(disks []vm.VMDisk, diskPath string, osRelease str
 		return fmt.Errorf("generate-mount-persistence.sh script not found at %s", scriptPath)
 	}
 
-	// Choose the script args based on OS family.
-	// SUSE GRUB Legacy guests must not have device.map rewritten before virt-v2v
-	// runs, so we use --replace-fstab (which skips fix_grub_config) instead of
-	// --force-uuid, and additionally pass --os-family=suse so the script can
-	// safely fix a detected GRUB Legacy root=/resume= cmdline on its own
-	// (device.map is never touched by that path — see generate-mount-persistence.sh).
+	// Pick script args by OS family: SUSE uses --replace-fstab --os-family=suse instead of
+	// --force-uuid, skipping the pre-virt-v2v device.map rewrite that breaks SUSE GRUB Legacy.
 	scriptArgs := MountPersistenceScriptArgs(osRelease)
 	if IsSUSEFamily(osRelease) {
 		log.Printf("SUSE guest detected: using --replace-fstab --os-family=suse (script will safely fix GRUB Legacy cmdline if detected, without touching device.map)")


### PR DESCRIPTION
fixed: #2012

Rewrite SUSE GRUB Legacy `root=`/`resume=` cmdline device references to UUID= without touching `device.map`, so migrated SUSE 11 SP4 guests boot instead of dropping to a ramfs shell.

__Testing done__
### VM booting successfully post migration

<img width="1028" height="761" alt="image" src="https://github.com/user-attachments/assets/b1d69a71-7599-4919-ac19-4d6b3c7b9189" />
