### PR TITLE
[2128] Show assigned flavor and disk size for VMs selected for migration

### DIFF
--- a/ui/src/api/migration-templates/model.ts
+++ b/ui/src/api/migration-templates/model.ts
@@ -1,3 +1,4 @@
+import type { VMwareDiskEntry } from 'src/api/vmware-machines/model'
 export interface GetMigrationTemplatesList {
   apiVersion: string
   items: MigrationTemplate[]
@@ -74,7 +75,7 @@ export interface VmData {
   esxHost?: string
   ipAddress?: string
   targetFlavorId?: string
-  disks?: string[]
+  disks?: VMwareDiskEntry[]
   labels?: { [key: string]: string }
   vmWareMachineName?: string
   networkInterfaces?: VmNetworkInterface[]

--- a/ui/src/api/migrations/migrations.ts
+++ b/ui/src/api/migrations/migrations.ts
@@ -17,6 +17,18 @@ export const getMigrations = async (
   return data?.items
 }
 
+export interface MigrationConfigMap {
+  data?: Record<string, string>
+}
+
+export const getMigrationConfigMap = async (
+  vmwareMachineName: string,
+  namespace = VJAILBREAK_DEFAULT_NAMESPACE
+): Promise<MigrationConfigMap> => {
+  const endpoint = `${K8S_PROXY_BASE_PATH}/namespaces/${namespace}/configmaps/migration-config-${vmwareMachineName}`
+  return axios.get<MigrationConfigMap>({ endpoint })
+}
+
 export const getMigration = async (migrationName, namespace = VJAILBREAK_DEFAULT_NAMESPACE) => {
   const endpoint = `${VJAILBREAK_API_BASE_PATH}/namespaces/${namespace}/migrations/${migrationName}`
   const response = await axios.get<Migration>({

--- a/ui/src/api/vmware-machines/model.ts
+++ b/ui/src/api/vmware-machines/model.ts
@@ -1,7 +1,16 @@
+export interface VMwareDisk {
+  name?: string
+  capacityGB?: number
+  datastore?: string
+  datastoreId?: string
+}
+
+export type VMwareDiskEntry = string | VMwareDisk
+
 export interface VMwareVM {
   cpu: number
   datastores: string[]
-  disks: string[]
+  disks: VMwareDiskEntry[]
   memory: number
   name: string
   vmid?: string

--- a/ui/src/features/migration/api/migration-templates/model.ts
+++ b/ui/src/features/migration/api/migration-templates/model.ts
@@ -1,3 +1,4 @@
+import type { VMwareDiskEntry } from 'src/api/vmware-machines/model'
 export interface GetMigrationTemplatesList {
   apiVersion: string
   items: MigrationTemplate[]
@@ -78,7 +79,7 @@ export interface VmData {
   esxHost?: string
   ipAddress?: string
   targetFlavorId?: string
-  disks?: string[]
+  disks?: VMwareDiskEntry[]
   labels?: { [key: string]: string }
   vmWareMachineName?: string
   networkInterfaces?: VmNetworkInterface[]

--- a/ui/src/features/migration/components/detail/MigrationDetailsTab.tsx
+++ b/ui/src/features/migration/components/detail/MigrationDetailsTab.tsx
@@ -34,6 +34,7 @@ import {
 } from 'src/components/migrations/migrationDetailConstants'
 import { FieldLabel, KeyValueGrid, SurfaceCard } from 'src/components'
 import { formatDateTime, formatDiskSize } from 'src/utils'
+import { normalizeVmDisks, resolveFlavorDisplay } from '../../utils/migrationDetailFields'
 import { Migration } from '../../api/migrations'
 
 const enabledOrNA = (value: unknown) => (value === true ? 'Enabled' : 'N/A')
@@ -213,6 +214,20 @@ export default function MigrationDetailsTab({ migration }: MigrationDetailsTabPr
     if (Array.isArray(disks)) return String(disks.length)
     return 'N/A'
   }, [vmSpec?.disks])
+
+  const selectedFlavorId = data?.vmwareMachine?.spec?.targetFlavorId || ''
+  const configFlavorId = data?.migrationConfigMap?.TARGET_FLAVOR_ID || ''
+  const flavorDisplay = useMemo(
+    () =>
+      resolveFlavorDisplay({
+        configFlavorId,
+        selectedFlavorId,
+        flavors: data?.openstackCreds?.spec?.flavors,
+      }),
+    [configFlavorId, data?.openstackCreds, selectedFlavorId]
+  )
+
+  const vmDisks = useMemo(() => normalizeVmDisks(vmSpec?.disks), [vmSpec?.disks])
 
   const networkAdapterCount = useMemo(() => {
     const ifaces = vmSpec?.networkInterfaces
@@ -473,12 +488,13 @@ export default function MigrationDetailsTab({ migration }: MigrationDetailsTabPr
       { label: 'Guest OS', value: guestOS },
       { label: 'CPU', value: cpu },
       { label: 'Memory', value: memory },
+      { label: 'Flavor', value: flavorDisplay },
       { label: 'Total Disks', value: diskCount },
       { label: 'Network Adapters', value: networkAdapterCount },
       { label: 'vJailbreak Agent', value: (migrationStatus?.agentName as string) || 'N/A' },
       { label: 'RDM Disks', value: rdmDisksSummary },
     ],
-    [cpu, createdAt, dataCopyMethodLabel, diskCount, displayVmName, guestOS, isHotAdd, memory, migrationStatus?.agentName, migrationType, networkAdapterCount, proxyVMName, rdmDisksSummary]
+    [cpu, createdAt, dataCopyMethodLabel, diskCount, displayVmName, flavorDisplay, guestOS, isHotAdd, memory, migrationStatus?.agentName, migrationType, networkAdapterCount, proxyVMName, rdmDisksSummary]
   )
 
   const migrationEnvironmentValues = useMemo(
@@ -703,33 +719,73 @@ export default function MigrationDetailsTab({ migration }: MigrationDetailsTabPr
           </Box>
         ) : null}
 
+        {vmDisks.length ? (
+          <Box sx={{ mt: 2 }}>
+            <Divider sx={{ mb: 2 }} />
+            <Box sx={{ display: 'grid', gap: 1 }}>
+              <FieldLabel label="Disks" />
+              <TableContainer component={Paper} variant="outlined">
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Disk</TableCell>
+                      <TableCell>Size</TableCell>
+                      <TableCell>Datastore</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {vmDisks.map((d, idx) => (
+                      <TableRow key={`${d.name}-${idx}`}>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ wordBreak: 'break-word' }}>
+                            {d.name}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>{d.size}</TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ wordBreak: 'break-word' }}>
+                            {d.datastore}
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </Box>
+          </Box>
+        ) : null}
+
         {data?.rdmDisks?.length ? (
           <Box sx={{ mt: 2 }}>
             <Divider sx={{ mb: 2 }} />
-            <TableContainer component={Paper} variant="outlined">
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Disk</TableCell>
-                    <TableCell>Size</TableCell>
-                    <TableCell>Phase</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {data.rdmDisks.map((d) => (
-                    <TableRow key={d.metadata.name}>
-                      <TableCell>
-                        <Typography variant="body2" sx={{ wordBreak: 'break-word' }}>
-                          {d.spec.displayName || d.spec.diskName || d.metadata.name}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>{formatDiskSize(d.spec.diskSize)}</TableCell>
-                      <TableCell>{d.status?.phase || 'N/A'}</TableCell>
+            <Box sx={{ display: 'grid', gap: 1 }}>
+              <FieldLabel label="RDM Disks" />
+              <TableContainer component={Paper} variant="outlined">
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Disk</TableCell>
+                      <TableCell>Size</TableCell>
+                      <TableCell>Phase</TableCell>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
+                  </TableHead>
+                  <TableBody>
+                    {data.rdmDisks.map((d) => (
+                      <TableRow key={d.metadata.name}>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ wordBreak: 'break-word' }}>
+                            {d.spec.displayName || d.spec.diskName || d.metadata.name}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>{formatDiskSize(d.spec.diskSize)}</TableCell>
+                        <TableCell>{d.status?.phase || 'N/A'}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </Box>
           </Box>
         ) : null}
       </SurfaceCard>

--- a/ui/src/features/migration/types.ts
+++ b/ui/src/features/migration/types.ts
@@ -2,6 +2,7 @@ import type { Dispatch, SetStateAction } from 'react'
 import { VmData } from './api/migration-templates/model'
 import type { RetryMigrationConfig } from './context/MigrationFormContext'
 import { OpenStackFlavor, OpenstackCreds, PCDNetworkInfo } from 'src/api/openstack-creds/model'
+import type { VMwareDiskEntry } from 'src/api/vmware-machines/model'
 import { Migration } from './api/migrations'
 import { RefetchOptions, QueryObserverResult } from '@tanstack/react-query'
 import type { GridRowSelectionModel, GridToolbarProps } from '@mui/x-data-grid'
@@ -285,7 +286,7 @@ export interface CanonicalVM {
   vmKey?: string
   vmid?: string
   labels?: Record<string, string>
-  disks?: string[]
+  disks?: VMwareDiskEntry[]
   vmWareMachineName?: string
 }
 

--- a/ui/src/features/migration/utils/migrationDetailFields.test.ts
+++ b/ui/src/features/migration/utils/migrationDetailFields.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeVmDisks, resolveFlavorDisplay } from './migrationDetailFields'
+
+const flavors = [
+  { id: 'flavor-1', name: 'm1.small' },
+  { id: 'flavor-2', name: 'm1.large' },
+]
+
+describe('resolveFlavorDisplay', () => {
+  it('shows Auto-assign when no flavor is selected or resolved yet', () => {
+    expect(resolveFlavorDisplay({ flavors })).toBe('Auto-assign')
+    expect(resolveFlavorDisplay({ configFlavorId: '', selectedFlavorId: '', flavors })).toBe(
+      'Auto-assign'
+    )
+  })
+
+  it('shows the user-selected flavor name resolved from the flavor list', () => {
+    expect(resolveFlavorDisplay({ selectedFlavorId: 'flavor-1', flavors })).toBe('m1.small')
+  })
+
+  it('prefers the flavor recorded in the migration ConfigMap', () => {
+    expect(
+      resolveFlavorDisplay({
+        configFlavorId: 'flavor-2',
+        selectedFlavorId: 'flavor-1',
+        flavors,
+      })
+    ).toBe('m1.large')
+  })
+
+  it('marks auto-assigned flavors resolved by the controller', () => {
+    expect(resolveFlavorDisplay({ configFlavorId: 'flavor-2', flavors })).toBe(
+      'm1.large (auto-assigned)'
+    )
+  })
+
+  it('falls back to the flavor ID when no name can be resolved', () => {
+    expect(resolveFlavorDisplay({ selectedFlavorId: 'flavor-404', flavors })).toBe('flavor-404')
+    expect(resolveFlavorDisplay({ configFlavorId: 'flavor-404' })).toBe(
+      'flavor-404 (auto-assigned)'
+    )
+  })
+})
+
+describe('normalizeVmDisks', () => {
+  it('returns empty for missing or non-array disks', () => {
+    expect(normalizeVmDisks(undefined)).toEqual([])
+    expect(normalizeVmDisks('disk-1')).toEqual([])
+  })
+
+  it('maps disk objects to rows with formatted sizes', () => {
+    expect(
+      normalizeVmDisks([
+        { name: 'Hard disk 1', capacityGB: 33, datastore: 'datastore-nfs' },
+        { name: 'Hard disk 2', capacityGB: 2048, datastore: 'ds-2' },
+      ])
+    ).toEqual([
+      { name: 'Hard disk 1', size: '33 GB', datastore: 'datastore-nfs' },
+      { name: 'Hard disk 2', size: '2 TB', datastore: 'ds-2' },
+    ])
+  })
+
+  it('handles legacy string disks without sizes', () => {
+    expect(normalizeVmDisks(['Hard disk 1'])).toEqual([
+      { name: 'Hard disk 1', size: 'N/A', datastore: 'N/A' },
+    ])
+  })
+
+  it('fills placeholder names and sizes for incomplete entries', () => {
+    expect(normalizeVmDisks([{ capacityGB: 0 }, ''])).toEqual([
+      { name: 'Disk 1', size: 'N/A', datastore: 'N/A' },
+      { name: 'Disk 2', size: 'N/A', datastore: 'N/A' },
+    ])
+  })
+})

--- a/ui/src/features/migration/utils/migrationDetailFields.ts
+++ b/ui/src/features/migration/utils/migrationDetailFields.ts
@@ -1,0 +1,55 @@
+import { formatDiskSize } from 'src/utils'
+import type { VMwareDiskEntry } from 'src/api/vmware-machines/model'
+import type { OpenStackFlavor } from 'src/api/openstack-creds/model'
+
+/**
+ * Resolves the flavor label shown on the migration details page.
+ *
+ * Precedence: TARGET_FLAVOR_ID from the migration's ConfigMap (set by the controller for
+ * both user-selected and auto-assigned flavors), falling back to the user-selected flavor
+ * on the VMwareMachine spec. The ID is mapped to a display name via the OpenstackCreds
+ * flavor list. When no flavor is resolvable yet, the flavor will be auto-assigned at
+ * migration time.
+ */
+export function resolveFlavorDisplay({
+  configFlavorId,
+  selectedFlavorId,
+  flavors,
+}: {
+  configFlavorId?: string
+  selectedFlavorId?: string
+  flavors?: Pick<OpenStackFlavor, 'id' | 'name'>[]
+}): string {
+  const resolvedId = configFlavorId || selectedFlavorId || ''
+  if (!resolvedId) return 'Auto-assign'
+  const resolvedName = (flavors || []).find((f) => f?.id === resolvedId)?.name || resolvedId
+  return selectedFlavorId ? resolvedName : `${resolvedName} (auto-assigned)`
+}
+
+export interface VmDiskRow {
+  name: string
+  size: string
+  datastore: string
+}
+
+/**
+ * Normalizes VMwareMachine.spec.vms.disks entries into display rows.
+ * Handles both the current object shape ({ name, capacityGB, datastore }) and
+ * the legacy plain-string shape from older VMwareMachine CRs.
+ */
+export function normalizeVmDisks(disks: unknown): VmDiskRow[] {
+  if (!Array.isArray(disks)) return []
+  return (disks as VMwareDiskEntry[]).map((d, idx) => {
+    if (typeof d === 'string') {
+      return { name: d || `Disk ${idx + 1}`, size: 'N/A', datastore: 'N/A' }
+    }
+    return {
+      name: d?.name || `Disk ${idx + 1}`,
+      size:
+        typeof d?.capacityGB === 'number' && d.capacityGB > 0
+          ? formatDiskSize(d.capacityGB * 1024 ** 3)
+          : 'N/A',
+      datastore: d?.datastore || 'N/A',
+    }
+  })
+}

--- a/ui/src/hooks/api/useMigrationDetailResourcesQuery.ts
+++ b/ui/src/hooks/api/useMigrationDetailResourcesQuery.ts
@@ -21,6 +21,7 @@ import { getVMwareMachine } from 'src/api/vmware-machines/vmwareMachines'
 import type { PCDCluster, PCDClusterList } from 'src/api/pcd-clusters/model'
 import { getPCDClusters } from 'src/api/pcd-clusters/pcdClusters'
 import type { Migration } from 'src/features/migration/api/migrations'
+import { getMigrationConfigMap } from 'src/api/migrations/migrations'
 
 export interface MigrationDetailResources {
   migrationPlan: MigrationPlan | null
@@ -40,6 +41,7 @@ export interface MigrationDetailResources {
   arrayCredsMapping: ArrayCredsMapping | null
   vmwareMachine: VMwareMachine | null
   rdmDisks: RdmDisk[]
+  migrationConfigMap: Record<string, string> | null
 }
 
 export const useMigrationDetailResourcesQuery = ({
@@ -73,7 +75,8 @@ export const useMigrationDetailResourcesQuery = ({
           storageMapping: null,
           arrayCredsMapping: null,
           vmwareMachine: null,
-          rdmDisks: []
+          rdmDisks: [],
+          migrationConfigMap: null
         }
       }
 
@@ -172,6 +175,10 @@ export const useMigrationDetailResourcesQuery = ({
         ? await safeGet(() => getVMwareMachine(vmwareMachineName, namespace))
         : null
 
+      const migrationConfigMap = vmwareMachineName
+        ? (await safeGet(() => getMigrationConfigMap(vmwareMachineName, namespace)))?.data || null
+        : null
+
       const rdmDiskNames = ((vmwareMachine?.spec as any)?.vms?.rdmDisks as string[]) || []
       const effectiveVmName = vmName || ((vmwareMachine?.spec as any)?.vms?.name as string) || ''
       const allRdmDisks = effectiveVmName ? await safeGet(() => getRdmDisksList(namespace)) : null
@@ -203,7 +210,8 @@ export const useMigrationDetailResourcesQuery = ({
         storageMapping,
         arrayCredsMapping,
         vmwareMachine,
-        rdmDisks
+        rdmDisks,
+        migrationConfigMap
       }
     }
   })


### PR DESCRIPTION
## What this PR does / why we need it
Show assigned flavor and disk size for VMs selected for migration

## Which issue(s) this PR fixes
fixes #2128 

## Testing done
<img width="1440" height="818" alt="image" src="https://github.com/user-attachments/assets/d7365410-4595-4518-a21f-41530f33b9d6" />
<img width="1439" height="818" alt="image" src="https://github.com/user-attachments/assets/661ac874-ac35-44df-8761-1a5b22d1e5c4" />
<img width="1434" height="813" alt="image" src="https://github.com/user-attachments/assets/2de29816-cc5d-4c09-b7f1-f46487fc74c7" />