### PR TITLE
[2143] unique port names for multi-NIC VMs using network+subnet+vmname

### DIFF
--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -17,6 +17,11 @@ import (
 // - VCenterLoginRetryLimit: Using k8s/migration value (5) - more resilient
 // ============================================================================
 
+// OpenStack Neutron constraints
+const (
+	NeutronMaxPortNameLen = 255
+)
+
 // OS Family Constants
 // These values match VMware's VirtualMachineGuestOsFamily types
 const (

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -2362,6 +2362,12 @@ func (migobj *Migrate) createPortsForNetworks(ctx context.Context, vminfo *vm.VM
 	portids := []string{}
 	ipaddresses := []string{}
 
+	// subnetPortIndex is shared across every NIC of this VM: it's how
+	// distinct port names get assigned when two or more NICs land on the same
+	// subnet (see GetCreateOpts/buildPortName), so it must persist across the
+	// whole loop, not be recreated per NIC.
+	subnetPortIndex := make(map[string]int)
+
 	for idx, networkname := range migobj.Networknames {
 		network, err := migobj.Openstackclients.GetNetwork(ctx, networkname)
 		if err != nil {
@@ -2388,7 +2394,7 @@ func (migobj *Migrate) createPortsForNetworks(ctx context.Context, vminfo *vm.VM
 		mac = applyPreserveMACOverride(vminfo, idx, mac, override.preserveMAC)
 		utils.PrintLog(fmt.Sprintf("Using IPs for MAC %s: %v", vminfo.Mac[idx], loggedIPs))
 
-		port, err := migobj.createPort(ctx, network, mac, vminfo, securityGroupIDs)
+		port, err := migobj.createPort(ctx, network, mac, vminfo, securityGroupIDs, subnetPortIndex)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -2406,8 +2412,10 @@ func (migobj *Migrate) createPortsForNetworks(ctx context.Context, vminfo *vm.VM
 
 // createPort creates a single OpenStack port on network for the given
 // (possibly overridden) MAC, using vminfo.IPperMac to determine fixed IPs.
-func (migobj *Migrate) createPort(ctx context.Context, network *networks.Network, mac string, vminfo *vm.VMInfo, securityGroupIDs []string) (*ports.Port, error) {
-	port, err := migobj.Openstackclients.ValidateAndCreatePort(ctx, network, mac, vminfo.IPperMac, vminfo.Name, securityGroupIDs, migobj.FallbackToDHCP, vminfo.GatewayIP)
+// subnetPortIndex must be the same map across every NIC of this VM (see
+// createPortsForNetworks) so NICs sharing a subnet get distinct port names.
+func (migobj *Migrate) createPort(ctx context.Context, network *networks.Network, mac string, vminfo *vm.VMInfo, securityGroupIDs []string, subnetPortIndex map[string]int) (*ports.Port, error) {
+	port, err := migobj.Openstackclients.ValidateAndCreatePort(ctx, network, mac, vminfo.IPperMac, vminfo.Name, securityGroupIDs, migobj.FallbackToDHCP, vminfo.GatewayIP, subnetPortIndex)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create port group")
 	}

--- a/v2v-helper/openstack/openstackops.go
+++ b/v2v-helper/openstack/openstackops.go
@@ -43,7 +43,7 @@ type OpenstackOperations interface {
 	GetFlavor(ctx context.Context, flavorId string) (*flavors.Flavor, error)
 	GetNetwork(ctx context.Context, networkname string) (*networks.Network, error)
 	GetPort(ctx context.Context, portID string) (*ports.Port, error)
-	ValidateAndCreatePort(ctx context.Context, networkid *networks.Network, mac string, ipPerMac map[string][]vm.IpEntry, vmname string, securityGroups []string, fallbackToDHCP bool, gatewayIP map[string]string) (*ports.Port, error)
+	ValidateAndCreatePort(ctx context.Context, networkid *networks.Network, mac string, ipPerMac map[string][]vm.IpEntry, vmname string, securityGroups []string, fallbackToDHCP bool, gatewayIP map[string]string, subnetPortIndex map[string]int) (*ports.Port, error)
 	DeletePort(ctx context.Context, portID string) error
 	GetSubnet(ctx context.Context, network []string, ip string) (*subnets.Subnet, error)
 	CreatePort(ctx context.Context, networkid *networks.Network, mac string, ip []string, vmname string, securityGroups []string, fallbackToDHCP bool, gatewayIP map[string]string) (*ports.Port, error)

--- a/v2v-helper/openstack/openstackops_mock.go
+++ b/v2v-helper/openstack/openstackops_mock.go
@@ -394,18 +394,18 @@ func (mr *MockOpenstackOperationsMockRecorder) SetVolumeUEFI(ctx, volume interfa
 }
 
 // ValidateAndCreatePort mocks base method.
-func (m *MockOpenstackOperations) ValidateAndCreatePort(ctx context.Context, networkid *networks.Network, mac string, ipPerMac map[string][]vm.IpEntry, vmname string, securityGroups []string, fallbackToDHCP bool, gatewayIP map[string]string) (*ports.Port, error) {
+func (m *MockOpenstackOperations) ValidateAndCreatePort(ctx context.Context, networkid *networks.Network, mac string, ipPerMac map[string][]vm.IpEntry, vmname string, securityGroups []string, fallbackToDHCP bool, gatewayIP map[string]string, subnetPortIndex map[string]int) (*ports.Port, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateAndCreatePort", ctx, networkid, mac, ipPerMac, vmname, securityGroups, fallbackToDHCP, gatewayIP)
+	ret := m.ctrl.Call(m, "ValidateAndCreatePort", ctx, networkid, mac, ipPerMac, vmname, securityGroups, fallbackToDHCP, gatewayIP, subnetPortIndex)
 	ret0, _ := ret[0].(*ports.Port)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ValidateAndCreatePort indicates an expected call of ValidateAndCreatePort.
-func (mr *MockOpenstackOperationsMockRecorder) ValidateAndCreatePort(ctx, networkid, mac, ipPerMac, vmname, securityGroups, fallbackToDHCP, gatewayIP interface{}) *gomock.Call {
+func (mr *MockOpenstackOperationsMockRecorder) ValidateAndCreatePort(ctx, networkid, mac, ipPerMac, vmname, securityGroups, fallbackToDHCP, gatewayIP, subnetPortIndex interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAndCreatePort", reflect.TypeOf((*MockOpenstackOperations)(nil).ValidateAndCreatePort), ctx, networkid, mac, ipPerMac, vmname, securityGroups, fallbackToDHCP, gatewayIP)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAndCreatePort", reflect.TypeOf((*MockOpenstackOperations)(nil).ValidateAndCreatePort), ctx, networkid, mac, ipPerMac, vmname, securityGroups, fallbackToDHCP, gatewayIP, subnetPortIndex)
 }
 
 // WaitForVolume mocks base method.

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -694,10 +694,31 @@ func (osclient *OpenStackClients) CheckIfPortExists(ctx context.Context, ipEntri
 
 }
 
+// buildPortName constructs a unique, human-readable port name for OpenStack.
+// Format: port-<networkName>-<subnetName>-<vmname> (or port-<networkName>-<vmname> for L2).
+// The vmname segment is truncated to fit within the Neutron 255-character limit.
+func buildPortName(networkName, subnetName, vmname string) string {
+	var prefix string
+	if subnetName != "" {
+		prefix = fmt.Sprintf("port-%s-%s-", networkName, subnetName)
+	} else {
+		prefix = fmt.Sprintf("port-%s-", networkName)
+	}
+	remaining := constants.NeutronMaxPortNameLen - len(prefix)
+	if remaining <= 0 {
+		return (prefix + vmname)[:constants.NeutronMaxPortNameLen]
+	}
+	if len(vmname) > remaining {
+		return prefix + vmname[:remaining]
+	}
+	return prefix + vmname
+}
+
 func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *networks.Network, mac string, ipEntries []vm.IpEntry, vmname string, securityGroups []string, gatewayIP map[string]string) (ports.CreateOpts, error) {
 
+	// Default: network-only name (L2 networks have no subnets). Overridden below when subnet is available.
 	createOpts := ports.CreateOpts{
-		Name:           "port-" + vmname,
+		Name:           buildPortName(network.Name, "", vmname),
 		NetworkID:      network.ID,
 		SecurityGroups: &securityGroups,
 	}
@@ -721,11 +742,16 @@ func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *ne
 
 	if len(localDeepCopyIpEntries) > 0 {
 		fixedIPs := make([]ports.IP, 0)
+		nameSet := false
 		for _, ipEntry := range localDeepCopyIpEntries {
 			subnetId, err := osclient.GetSubnet(ctx, network.Subnets, ipEntry.IP)
 			if err != nil {
 				return createOpts, fmt.Errorf("subnet not found for IP %s", ipEntry.IP)
 			} else {
+				if !nameSet {
+					createOpts.Name = buildPortName(network.Name, subnetId.Name, vmname)
+					nameSet = true
+				}
 				gatewayIP[mac] = subnetId.GatewayIP
 				PrintLog(fmt.Sprintf("IP %s is in subnet %s", ipEntry.IP, subnetId.ID))
 				fixedIPs = append(fixedIPs, ports.IP{
@@ -739,6 +765,13 @@ func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *ne
 		// empty non-nil slice: user explicitly wants a port with no fixed IPs (preserveIP=false, no custom IP)
 		PrintLog("Creating port with no fixed IPs for mac " + mac)
 		createOpts.FixedIPs = []ports.IP{}
+		// Non-L2 networks have subnets; look up the first one for a meaningful port name.
+		if !isL2Network && len(network.Subnets) > 0 {
+			subnetID, err := subnets.Get(ctx, osclient.NetworkingClient, network.Subnets[0]).Extract()
+			if err == nil {
+				createOpts.Name = buildPortName(network.Name, subnetID.Name, vmname)
+			}
+		}
 	} else if len(network.Subnets) > 0 {
 		// nil: original VM had no IPs on this NIC — let OpenStack DHCP assign
 		PrintLog("Empty port on vcentre detected for mac " + mac)
@@ -747,6 +780,7 @@ func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *ne
 			return createOpts, fmt.Errorf("subnet not found for network %s", network.ID)
 		}
 		gatewayIP[mac] = subnetID.GatewayIP
+		createOpts.Name = buildPortName(network.Name, subnetID.Name, vmname)
 	} else {
 		// nil ipEntries but the network has no subnets at all (e.g. an L2-only
 		// network that legitimately has zero subnets). There's no subnet to

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -695,30 +695,31 @@ func (osclient *OpenStackClients) CheckIfPortExists(ctx context.Context, ipEntri
 }
 
 // buildPortName constructs a unique, human-readable port name for OpenStack.
-// Format: port-<networkName>-<subnetName>-<vmname> (or port-<networkName>-<vmname> for L2).
-// The vmname segment is truncated to fit within the Neutron 255-character limit.
-func buildPortName(networkName, subnetName, vmname string) string {
-	var prefix string
+// Format: port-<vmname>-<subnetName> (or port-<vmname> for L2 networks, which have no subnet).
+// The vmname segment is truncated as needed to fit within the Neutron 255-character limit;
+// the subnet-name suffix (the part relied on for uniqueness) is always preserved intact.
+func buildPortName(vmname, subnetName string) string {
+	const prefix = "port-"
+	suffix := ""
 	if subnetName != "" {
-		prefix = fmt.Sprintf("port-%s-%s-", networkName, subnetName)
-	} else {
-		prefix = fmt.Sprintf("port-%s-", networkName)
+		suffix = "-" + subnetName
 	}
-	remaining := constants.NeutronMaxPortNameLen - len(prefix)
-	if remaining <= 0 {
-		return (prefix + vmname)[:constants.NeutronMaxPortNameLen]
+	maxVMNameLen := constants.NeutronMaxPortNameLen - len(prefix) - len(suffix)
+	if maxVMNameLen <= 0 {
+		// prefix + suffix alone exceed the limit; truncate the whole result as a last resort.
+		return (prefix + vmname + suffix)[:constants.NeutronMaxPortNameLen]
 	}
-	if len(vmname) > remaining {
-		return prefix + vmname[:remaining]
+	if len(vmname) > maxVMNameLen {
+		vmname = vmname[:maxVMNameLen]
 	}
-	return prefix + vmname
+	return prefix + vmname + suffix
 }
 
 func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *networks.Network, mac string, ipEntries []vm.IpEntry, vmname string, securityGroups []string, gatewayIP map[string]string) (ports.CreateOpts, error) {
 
-	// Default: network-only name (L2 networks have no subnets). Overridden below when subnet is available.
+	// Default: vmname-only name (L2 networks have no subnets). Overridden below when subnet is available.
 	createOpts := ports.CreateOpts{
-		Name:           buildPortName(network.Name, "", vmname),
+		Name:           buildPortName(vmname, ""),
 		NetworkID:      network.ID,
 		SecurityGroups: &securityGroups,
 	}
@@ -749,7 +750,7 @@ func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *ne
 				return createOpts, fmt.Errorf("subnet not found for IP %s", ipEntry.IP)
 			} else {
 				if !nameSet {
-					createOpts.Name = buildPortName(network.Name, subnetId.Name, vmname)
+					createOpts.Name = buildPortName(vmname, subnetId.Name)
 					nameSet = true
 				}
 				gatewayIP[mac] = subnetId.GatewayIP
@@ -769,7 +770,7 @@ func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *ne
 		if !isL2Network && len(network.Subnets) > 0 {
 			subnetID, err := subnets.Get(ctx, osclient.NetworkingClient, network.Subnets[0]).Extract()
 			if err == nil {
-				createOpts.Name = buildPortName(network.Name, subnetID.Name, vmname)
+				createOpts.Name = buildPortName(vmname, subnetID.Name)
 			}
 		}
 	} else if len(network.Subnets) > 0 {
@@ -780,7 +781,7 @@ func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *ne
 			return createOpts, fmt.Errorf("subnet not found for network %s", network.ID)
 		}
 		gatewayIP[mac] = subnetID.GatewayIP
-		createOpts.Name = buildPortName(network.Name, subnetID.Name, vmname)
+		createOpts.Name = buildPortName(vmname, subnetID.Name)
 	} else {
 		// nil ipEntries but the network has no subnets at all (e.g. an L2-only
 		// network that legitimately has zero subnets). There's no subnet to

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -695,14 +695,22 @@ func (osclient *OpenStackClients) CheckIfPortExists(ctx context.Context, ipEntri
 }
 
 // buildPortName constructs a unique, human-readable port name for OpenStack.
-// Format: port-<vmname>-<subnetName> (or port-<vmname> for L2 networks, which have no subnet).
-// The vmname segment is truncated as needed to fit within the Neutron 255-character limit;
-// the subnet-name suffix (the part relied on for uniqueness) is always preserved intact.
-func buildPortName(vmname, subnetName string) string {
+// Format: port-<vmname>-<subnetName>-<index> (or port-<vmname>-<index> for L2
+// networks, which have no subnet). index is a 1-based counter, scoped to
+// "this subnet (or no-subnet bucket) on this VM", supplied by the caller via
+// GetCreateOpts's subnetPortIndex map: the first NIC placed on a given subnet
+// gets index 1, a second NIC landing on that same subnet gets index 2, and so
+// on. This keeps port names unique even when a VM has multiple NICs on the
+// same subnet, which port-<vmname>-<subnetName> alone cannot distinguish.
+// The vmname segment is truncated as needed to fit within the Neutron
+// 255-character limit; the subnet-name/index suffix (relied on for
+// uniqueness) is always preserved intact except in the extreme case where it
+// alone exceeds the limit.
+func buildPortName(vmname, subnetName string, index int) string {
 	const prefix = "port-"
-	suffix := ""
+	suffix := fmt.Sprintf("-%d", index)
 	if subnetName != "" {
-		suffix = "-" + subnetName
+		suffix = "-" + subnetName + suffix
 	}
 	maxVMNameLen := constants.NeutronMaxPortNameLen - len(prefix) - len(suffix)
 	if maxVMNameLen <= 0 {
@@ -715,17 +723,34 @@ func buildPortName(vmname, subnetName string) string {
 	return prefix + vmname + suffix
 }
 
-func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *networks.Network, mac string, ipEntries []vm.IpEntry, vmname string, securityGroups []string, gatewayIP map[string]string) (ports.CreateOpts, error) {
+// GetCreateOpts builds the ports.CreateOpts for a single NIC. subnetPortIndex
+// is a per-VM counter map (subnet name -> next index, "" for the no-subnet/L2
+// bucket) shared across all of a VM's NICs by the caller, so that multiple
+// NICs landing on the same subnet still get distinct, incrementing port
+// names instead of colliding. Pass the same map across every NIC of one VM;
+// a nil map is accepted (each call then gets its own single-use counter).
+func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *networks.Network, mac string, ipEntries []vm.IpEntry, vmname string, securityGroups []string, gatewayIP map[string]string, subnetPortIndex map[string]int) (ports.CreateOpts, error) {
+	if subnetPortIndex == nil {
+		subnetPortIndex = make(map[string]int)
+	}
 
-	// Default: vmname-only name (L2 networks have no subnets). Overridden below when subnet is available.
 	createOpts := ports.CreateOpts{
-		Name:           buildPortName(vmname, ""),
 		NetworkID:      network.ID,
 		SecurityGroups: &securityGroups,
 	}
 	if mac != "" {
 		createOpts.MACAddress = mac
 	}
+
+	// setName assigns createOpts.Name using a 1-based counter scoped to
+	// subnetName ("" covers L2 networks / unresolved-subnet fallbacks), and is
+	// called exactly once per GetCreateOpts invocation (one NIC == one port),
+	// on whichever branch below ends up handling this NIC.
+	setName := func(subnetName string) {
+		subnetPortIndex[subnetName]++
+		createOpts.Name = buildPortName(vmname, subnetName, subnetPortIndex[subnetName])
+	}
+
 	var localDeepCopyIpEntries []vm.IpEntry
 
 	// If the target network is L2 network pass empty ip address
@@ -747,10 +772,13 @@ func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *ne
 		for _, ipEntry := range localDeepCopyIpEntries {
 			subnetId, err := osclient.GetSubnet(ctx, network.Subnets, ipEntry.IP)
 			if err != nil {
+				// Fall back to the no-subnet bucket so a DHCP-fallback retry
+				// (if the caller allows one) still gets a sensible name.
+				setName("")
 				return createOpts, fmt.Errorf("subnet not found for IP %s", ipEntry.IP)
 			} else {
 				if !nameSet {
-					createOpts.Name = buildPortName(vmname, subnetId.Name)
+					setName(subnetId.Name)
 					nameSet = true
 				}
 				gatewayIP[mac] = subnetId.GatewayIP
@@ -767,31 +795,39 @@ func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *ne
 		PrintLog("Creating port with no fixed IPs for mac " + mac)
 		createOpts.FixedIPs = []ports.IP{}
 		// Non-L2 networks have subnets; look up the first one for a meaningful port name.
+		subnetName := ""
 		if !isL2Network && len(network.Subnets) > 0 {
 			subnetID, err := subnets.Get(ctx, osclient.NetworkingClient, network.Subnets[0]).Extract()
 			if err == nil {
-				createOpts.Name = buildPortName(vmname, subnetID.Name)
+				subnetName = subnetID.Name
 			}
 		}
+		setName(subnetName)
 	} else if len(network.Subnets) > 0 {
 		// nil: original VM had no IPs on this NIC — let OpenStack DHCP assign
 		PrintLog("Empty port on vcentre detected for mac " + mac)
 		subnetID, err := subnets.Get(ctx, osclient.NetworkingClient, network.Subnets[0]).Extract()
 		if err != nil {
+			setName("")
 			return createOpts, fmt.Errorf("subnet not found for network %s", network.ID)
 		}
 		gatewayIP[mac] = subnetID.GatewayIP
-		createOpts.Name = buildPortName(vmname, subnetID.Name)
+		setName(subnetID.Name)
 	} else {
 		// nil ipEntries but the network has no subnets at all (e.g. an L2-only
 		// network that legitimately has zero subnets). There's no subnet to
 		// query or gateway to record, so just leave FixedIPs/gatewayIP unset.
 		PrintLog("Empty port with no subnets on network " + network.ID + " for mac " + mac)
+		setName("")
 	}
 	return createOpts, nil
 }
 
-func (osclient *OpenStackClients) ValidateAndCreatePort(ctx context.Context, network *networks.Network, mac string, ipPerMac map[string][]vm.IpEntry, vmname string, securityGroups []string, fallbackToDHCP bool, gatewayIP map[string]string) (*ports.Port, error) {
+// ValidateAndCreatePort creates a port for one NIC. subnetPortIndex should be
+// a single map shared across all NICs of the same VM (see GetCreateOpts) so
+// that multiple NICs on the same subnet get distinct port names; pass nil if
+// that guarantee isn't needed (e.g. a one-off, non-VM-scoped port creation).
+func (osclient *OpenStackClients) ValidateAndCreatePort(ctx context.Context, network *networks.Network, mac string, ipPerMac map[string][]vm.IpEntry, vmname string, securityGroups []string, fallbackToDHCP bool, gatewayIP map[string]string, subnetPortIndex map[string]int) (*ports.Port, error) {
 	PrintLog(fmt.Sprintf("OPENSTACK API: Creating port for network %s, authurl %s, tenant %s with MAC address %s and IP addresses %v", network.ID, osclient.AuthURL, osclient.Tenant, mac, ipPerMac[mac]))
 	Existingport, err := osclient.CheckIfPortExists(ctx, ipPerMac[mac], mac, network, gatewayIP)
 	if err != nil {
@@ -813,7 +849,7 @@ func (osclient *OpenStackClients) ValidateAndCreatePort(ctx context.Context, net
 
 	// if currentInstanceID is not nill that means this is an L2 network, we should continue
 
-	createOpts, err := osclient.GetCreateOpts(ctx, network, mac, ipPerMac[mac], vmname, securityGroups, gatewayIP)
+	createOpts, err := osclient.GetCreateOpts(ctx, network, mac, ipPerMac[mac], vmname, securityGroups, gatewayIP, subnetPortIndex)
 	if err != nil {
 		if !fallbackToDHCP {
 			return nil, errors.Wrapf(err, "failed to create port options with static IP %v, and fallback to DHCP is disabled", ipPerMac[mac])
@@ -873,7 +909,9 @@ func (osclient *OpenStackClients) CreatePort(ctx context.Context, networkid *net
 		ipEntries[i] = vm.IpEntry{IP: ipAddr}
 	}
 
-	createOpts, err := osclient.GetCreateOpts(ctx, networkid, mac, ipEntries, vmname, securityGroups, gatewayIP)
+	// One-off port creation, not part of a per-VM NIC loop, so there's no
+	// cross-call counter to share; each call gets its own single-use one.
+	createOpts, err := osclient.GetCreateOpts(ctx, networkid, mac, ipEntries, vmname, securityGroups, gatewayIP, nil)
 	if err != nil {
 		if !fallbackToDHCP {
 			return nil, errors.Wrapf(err, "failed to create port options with static IP %v, and fallback to DHCP is disabled", ip)

--- a/v2v-helper/pkg/utils/openstackopsutils_test.go
+++ b/v2v-helper/pkg/utils/openstackopsutils_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
+	"github.com/platform9/vjailbreak/pkg/common/constants"
 	"github.com/platform9/vjailbreak/v2v-helper/vm"
 )
 
@@ -474,5 +475,73 @@ func TestSetVolumeBootable_ErrorButNotBootableReturnsError(t *testing.T) {
 	err := client.SetVolumeBootable(t.Context(), vol)
 	if err == nil {
 		t.Fatal("expected error when GetVolume confirms not bootable, got nil")
+	}
+}
+
+func TestBuildPortName(t *testing.T) {
+	tests := []struct {
+		name        string
+		networkName string
+		subnetName  string
+		vmname      string
+		want        string
+		wantLen     int
+	}{
+		{
+			name:        "normal case with subnet",
+			networkName: "prod-net",
+			subnetName:  "prod-subnet",
+			vmname:      "my-vm",
+			want:        "port-prod-net-prod-subnet-my-vm",
+		},
+		{
+			name:        "L2 network no subnet",
+			networkName: "l2-net",
+			subnetName:  "",
+			vmname:      "my-vm",
+			want:        "port-l2-net-my-vm",
+		},
+		{
+			name:        "vmname truncated to fit 255 limit",
+			networkName: "net",
+			subnetName:  "sub",
+			vmname:      strings.Repeat("a", 300),
+			wantLen:     constants.NeutronMaxPortNameLen,
+		},
+		{
+			name:        "long network+subnet forces vmname truncation",
+			networkName: strings.Repeat("n", 100),
+			subnetName:  strings.Repeat("s", 100),
+			vmname:      strings.Repeat("v", 100),
+			wantLen:     constants.NeutronMaxPortNameLen,
+		},
+		{
+			name:        "extremely long network+subnet exceeds prefix budget",
+			networkName: strings.Repeat("n", 200),
+			subnetName:  strings.Repeat("s", 100),
+			vmname:      "vm",
+			wantLen:     constants.NeutronMaxPortNameLen,
+		},
+		{
+			name:        "all short names fit without truncation",
+			networkName: "net",
+			subnetName:  "sub",
+			vmname:      "vm",
+			want:        "port-net-sub-vm",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildPortName(tt.networkName, tt.subnetName, tt.vmname)
+			if tt.want != "" && got != tt.want {
+				t.Errorf("buildPortName(%q, %q, %q) = %q, want %q", tt.networkName, tt.subnetName, tt.vmname, got, tt.want)
+			}
+			if tt.wantLen > 0 && len(got) != tt.wantLen {
+				t.Errorf("buildPortName(%q, %q, %q) len=%d, want %d", tt.networkName, tt.subnetName, tt.vmname, len(got), tt.wantLen)
+			}
+			if len(got) > constants.NeutronMaxPortNameLen {
+				t.Errorf("buildPortName result len=%d exceeds %d: %q", len(got), constants.NeutronMaxPortNameLen, got)
+			}
+		})
 	}
 }

--- a/v2v-helper/pkg/utils/openstackopsutils_test.go
+++ b/v2v-helper/pkg/utils/openstackopsutils_test.go
@@ -480,67 +480,70 @@ func TestSetVolumeBootable_ErrorButNotBootableReturnsError(t *testing.T) {
 
 func TestBuildPortName(t *testing.T) {
 	tests := []struct {
-		name        string
-		networkName string
-		subnetName  string
-		vmname      string
-		want        string
-		wantLen     int
+		name             string
+		vmname           string
+		subnetName       string
+		want             string
+		wantLen          int
+		wantSuffixIntact bool // whether the "-<subnetName>" suffix must survive untruncated
 	}{
 		{
-			name:        "normal case with subnet",
-			networkName: "prod-net",
-			subnetName:  "prod-subnet",
-			vmname:      "my-vm",
-			want:        "port-prod-net-prod-subnet-my-vm",
+			name:             "normal case with subnet",
+			vmname:           "my-vm",
+			subnetName:       "prod-subnet",
+			want:             "port-my-vm-prod-subnet",
+			wantSuffixIntact: true,
 		},
 		{
-			name:        "L2 network no subnet",
-			networkName: "l2-net",
-			subnetName:  "",
-			vmname:      "my-vm",
-			want:        "port-l2-net-my-vm",
+			name:       "L2 network no subnet",
+			vmname:     "my-vm",
+			subnetName: "",
+			want:       "port-my-vm",
 		},
 		{
-			name:        "vmname truncated to fit 255 limit",
-			networkName: "net",
-			subnetName:  "sub",
-			vmname:      strings.Repeat("a", 300),
-			wantLen:     constants.NeutronMaxPortNameLen,
+			name:             "vmname truncated to fit 255 limit",
+			vmname:           strings.Repeat("a", 300),
+			subnetName:       "sub",
+			wantLen:          constants.NeutronMaxPortNameLen,
+			wantSuffixIntact: true,
 		},
 		{
-			name:        "long network+subnet forces vmname truncation",
-			networkName: strings.Repeat("n", 100),
-			subnetName:  strings.Repeat("s", 100),
-			vmname:      strings.Repeat("v", 100),
-			wantLen:     constants.NeutronMaxPortNameLen,
+			name:       "vmname truncated, L2 (no subnet)",
+			vmname:     strings.Repeat("a", 300),
+			subnetName: "",
+			wantLen:    constants.NeutronMaxPortNameLen,
 		},
 		{
-			name:        "extremely long network+subnet exceeds prefix budget",
-			networkName: strings.Repeat("n", 200),
-			subnetName:  strings.Repeat("s", 100),
-			vmname:      "vm",
-			wantLen:     constants.NeutronMaxPortNameLen,
+			name:       "extremely long subnet name exceeds prefix budget",
+			vmname:     "vm",
+			subnetName: strings.Repeat("s", 300),
+			wantLen:    constants.NeutronMaxPortNameLen,
+			// subnet name itself doesn't fit even with an empty vmname, so the whole
+			// string is hard-truncated as a last resort and the suffix is not preserved.
+			wantSuffixIntact: false,
 		},
 		{
-			name:        "all short names fit without truncation",
-			networkName: "net",
-			subnetName:  "sub",
-			vmname:      "vm",
-			want:        "port-net-sub-vm",
+			name:             "all short names fit without truncation",
+			vmname:           "vm",
+			subnetName:       "sub",
+			want:             "port-vm-sub",
+			wantSuffixIntact: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildPortName(tt.networkName, tt.subnetName, tt.vmname)
+			got := buildPortName(tt.vmname, tt.subnetName)
 			if tt.want != "" && got != tt.want {
-				t.Errorf("buildPortName(%q, %q, %q) = %q, want %q", tt.networkName, tt.subnetName, tt.vmname, got, tt.want)
+				t.Errorf("buildPortName(%q, %q) = %q, want %q", tt.vmname, tt.subnetName, got, tt.want)
 			}
 			if tt.wantLen > 0 && len(got) != tt.wantLen {
-				t.Errorf("buildPortName(%q, %q, %q) len=%d, want %d", tt.networkName, tt.subnetName, tt.vmname, len(got), tt.wantLen)
+				t.Errorf("buildPortName(%q, %q) len=%d, want %d", tt.vmname, tt.subnetName, len(got), tt.wantLen)
 			}
 			if len(got) > constants.NeutronMaxPortNameLen {
 				t.Errorf("buildPortName result len=%d exceeds %d: %q", len(got), constants.NeutronMaxPortNameLen, got)
+			}
+			if tt.wantSuffixIntact && !strings.HasSuffix(got, "-"+tt.subnetName) {
+				t.Errorf("buildPortName(%q, %q) = %q, expected suffix %q to be preserved intact for uniqueness", tt.vmname, tt.subnetName, got, "-"+tt.subnetName)
 			}
 		})
 	}

--- a/v2v-helper/pkg/utils/openstackopsutils_test.go
+++ b/v2v-helper/pkg/utils/openstackopsutils_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -263,7 +264,7 @@ func TestGetCreateOpts_NilIPEntries_L2NetworkWithNoSubnets(t *testing.T) {
 		}
 	}()
 
-	createOpts, err := client.GetCreateOpts(t.Context(), network, "aa:bb:cc:dd:ee:ff", nil, "test-vm", nil, gatewayIP)
+	createOpts, err := client.GetCreateOpts(t.Context(), network, "aa:bb:cc:dd:ee:ff", nil, "test-vm", nil, gatewayIP, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -272,6 +273,9 @@ func TestGetCreateOpts_NilIPEntries_L2NetworkWithNoSubnets(t *testing.T) {
 	}
 	if _, ok := gatewayIP["aa:bb:cc:dd:ee:ff"]; ok {
 		t.Fatalf("expected no gateway to be recorded for a subnet-less L2 network, got: %v", gatewayIP)
+	}
+	if createOpts.Name != "port-test-vm-1" {
+		t.Errorf("expected fallback port name %q, got %q", "port-test-vm-1", createOpts.Name)
 	}
 }
 
@@ -483,40 +487,64 @@ func TestBuildPortName(t *testing.T) {
 		name             string
 		vmname           string
 		subnetName       string
+		index            int
 		want             string
 		wantLen          int
-		wantSuffixIntact bool // whether the "-<subnetName>" suffix must survive untruncated
+		wantSuffixIntact bool // whether the "-<subnetName>-<index>"/"-<index>" suffix must survive untruncated
 	}{
 		{
-			name:             "normal case with subnet",
+			name:             "normal case with subnet, first NIC",
 			vmname:           "my-vm",
 			subnetName:       "prod-subnet",
-			want:             "port-my-vm-prod-subnet",
+			index:            1,
+			want:             "port-my-vm-prod-subnet-1",
 			wantSuffixIntact: true,
 		},
 		{
-			name:       "L2 network no subnet",
-			vmname:     "my-vm",
-			subnetName: "",
-			want:       "port-my-vm",
+			name:             "normal case with subnet, second NIC on same subnet",
+			vmname:           "my-vm",
+			subnetName:       "prod-subnet",
+			index:            2,
+			want:             "port-my-vm-prod-subnet-2",
+			wantSuffixIntact: true,
+		},
+		{
+			name:             "L2 network no subnet, first NIC",
+			vmname:           "my-vm",
+			subnetName:       "",
+			index:            1,
+			want:             "port-my-vm-1",
+			wantSuffixIntact: true,
+		},
+		{
+			name:             "L2 network no subnet, second NIC",
+			vmname:           "my-vm",
+			subnetName:       "",
+			index:            2,
+			want:             "port-my-vm-2",
+			wantSuffixIntact: true,
 		},
 		{
 			name:             "vmname truncated to fit 255 limit",
 			vmname:           strings.Repeat("a", 300),
 			subnetName:       "sub",
+			index:            1,
 			wantLen:          constants.NeutronMaxPortNameLen,
 			wantSuffixIntact: true,
 		},
 		{
-			name:       "vmname truncated, L2 (no subnet)",
-			vmname:     strings.Repeat("a", 300),
-			subnetName: "",
-			wantLen:    constants.NeutronMaxPortNameLen,
+			name:             "vmname truncated, L2 (no subnet)",
+			vmname:           strings.Repeat("a", 300),
+			subnetName:       "",
+			index:            1,
+			wantLen:          constants.NeutronMaxPortNameLen,
+			wantSuffixIntact: true,
 		},
 		{
 			name:       "extremely long subnet name exceeds prefix budget",
 			vmname:     "vm",
 			subnetName: strings.Repeat("s", 300),
+			index:      1,
 			wantLen:    constants.NeutronMaxPortNameLen,
 			// subnet name itself doesn't fit even with an empty vmname, so the whole
 			// string is hard-truncated as a last resort and the suffix is not preserved.
@@ -526,25 +554,89 @@ func TestBuildPortName(t *testing.T) {
 			name:             "all short names fit without truncation",
 			vmname:           "vm",
 			subnetName:       "sub",
-			want:             "port-vm-sub",
+			index:            1,
+			want:             "port-vm-sub-1",
 			wantSuffixIntact: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildPortName(tt.vmname, tt.subnetName)
+			got := buildPortName(tt.vmname, tt.subnetName, tt.index)
 			if tt.want != "" && got != tt.want {
-				t.Errorf("buildPortName(%q, %q) = %q, want %q", tt.vmname, tt.subnetName, got, tt.want)
+				t.Errorf("buildPortName(%q, %q, %d) = %q, want %q", tt.vmname, tt.subnetName, tt.index, got, tt.want)
 			}
 			if tt.wantLen > 0 && len(got) != tt.wantLen {
-				t.Errorf("buildPortName(%q, %q) len=%d, want %d", tt.vmname, tt.subnetName, len(got), tt.wantLen)
+				t.Errorf("buildPortName(%q, %q, %d) len=%d, want %d", tt.vmname, tt.subnetName, tt.index, len(got), tt.wantLen)
 			}
 			if len(got) > constants.NeutronMaxPortNameLen {
 				t.Errorf("buildPortName result len=%d exceeds %d: %q", len(got), constants.NeutronMaxPortNameLen, got)
 			}
-			if tt.wantSuffixIntact && !strings.HasSuffix(got, "-"+tt.subnetName) {
-				t.Errorf("buildPortName(%q, %q) = %q, expected suffix %q to be preserved intact for uniqueness", tt.vmname, tt.subnetName, got, "-"+tt.subnetName)
+			wantSuffix := fmt.Sprintf("-%d", tt.index)
+			if tt.subnetName != "" {
+				wantSuffix = "-" + tt.subnetName + wantSuffix
+			}
+			if tt.wantSuffixIntact && !strings.HasSuffix(got, wantSuffix) {
+				t.Errorf("buildPortName(%q, %q, %d) = %q, expected suffix %q to be preserved intact for uniqueness", tt.vmname, tt.subnetName, tt.index, got, wantSuffix)
 			}
 		})
+	}
+}
+
+// TestGetCreateOpts_MultipleNICsSameSubnet_IndexIncrements verifies the fix
+// for the remaining collision case in #2143: a VM with two or more NICs that
+// land on the *same* subnet would still get identical port names under plain
+// port-<vmname>-<subnet-name> naming. Sharing one subnetPortIndex map across
+// the calls (as callers must, one per NIC) makes each subsequent NIC on that
+// subnet get a distinct, incrementing suffix instead.
+func TestGetCreateOpts_MultipleNICsSameSubnet_IndexIncrements(t *testing.T) {
+	const networkID = "net-shared"
+	const subnetID = "subnet-shared"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/networks/"+networkID):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"network": map[string]any{"id": networkID, "tags": []string{}},
+			})
+		case strings.Contains(r.URL.Path, "/subnets/"+subnetID):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"subnet": map[string]any{
+					"id":         subnetID,
+					"name":       "prod-subnet",
+					"cidr":       "10.0.0.0/24",
+					"gateway_ip": "10.0.0.1",
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := &OpenStackClients{NetworkingClient: newTestNetworkingClient(srv)}
+	network := &networks.Network{ID: networkID, Subnets: []string{subnetID}}
+	subnetPortIndex := map[string]int{}
+
+	// NIC 1 and NIC 2 both resolve to the same subnet (different IPs, same /24).
+	opts1, err := client.GetCreateOpts(t.Context(), network, "aa:bb:cc:dd:ee:01",
+		[]vm.IpEntry{{IP: "10.0.0.10", Prefix: 24}}, "test-vm", nil, map[string]string{}, subnetPortIndex)
+	if err != nil {
+		t.Fatalf("first GetCreateOpts call failed: %v", err)
+	}
+	opts2, err := client.GetCreateOpts(t.Context(), network, "aa:bb:cc:dd:ee:02",
+		[]vm.IpEntry{{IP: "10.0.0.20", Prefix: 24}}, "test-vm", nil, map[string]string{}, subnetPortIndex)
+	if err != nil {
+		t.Fatalf("second GetCreateOpts call failed: %v", err)
+	}
+
+	if want := "port-test-vm-prod-subnet-1"; opts1.Name != want {
+		t.Errorf("first NIC port name = %q, want %q", opts1.Name, want)
+	}
+	if want := "port-test-vm-prod-subnet-2"; opts2.Name != want {
+		t.Errorf("second NIC port name = %q, want %q", opts2.Name, want)
+	}
+	if opts1.Name == opts2.Name {
+		t.Fatalf("both NICs on the same subnet got identical port names: %q", opts1.Name)
 	}
 }


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2>
<p>Fixes #2143
When a VMware VM with multiple NICs is migrated, all OpenStack ports previously received identical names (<code>port-&lt;vmname&gt;</code>), making it impossible for operators and downstream automation to distinguish between them. A first pass fixed the cross-subnet case; a follow-up addresses the remaining case where two or more NICs land on the <em>same</em> subnet, which would still collide.</p>
<h2>Changes</h2>
<ul>
<li><strong>New <code>buildPortName</code> helper</strong> (<code>v2v-helper/pkg/utils/openstackopsutils.go</code>): constructs port names as <code>port-&lt;vmname&gt;-&lt;subnet&gt;-&lt;relative-index&gt;</code> (or <code>port-&lt;vmname&gt;-&lt;relative-index&gt;</code> for L2 networks, which have no subnet), enforcing the Neutron 255-char limit by truncating only the vmname segment. <code>relative-index</code> is a 1-based counter scoped to "this subnet (or no-subnet bucket) on this VM" — uniform, so even a VM's first NIC on a subnet gets <code>-1</code>, not a bare name.</li>
<li><strong>New <code>subnetPortIndex map[string]int</code> counter</strong>, threaded through <code>GetCreateOpts</code> and <code>ValidateAndCreatePort</code> (both signatures changed — <code>ValidateAndCreatePort</code> is an exported <code>OpenstackOperations</code> interface method, mock updated accordingly). <code>migrate.go</code>'s <code>createPortsForNetworks</code> creates one counter per VM and shares it across every NIC in that VM's port-creation loop, so a second NIC landing on the same subnet gets <code>-2</code> instead of colliding with the first.</li>
<li><strong>Updated <code>GetCreateOpts</code></strong> to resolve a subnet name (or fall back to the no-subnet bucket) and assign the indexed name across all four port-creation branches:
<ul>
<li>Normal (preserveIP=true, has IPs): uses first subnet matched to the VM's IP</li>
<li>No fixed IPs (preserveIP=false): performs an extra <code>network.Subnets[0]</code> lookup for subnet name</li>
<li>DHCP (nil IPs, network has subnets): performs a <code>network.Subnets[0]</code> lookup for subnet name (same mechanism as the no-fixed-IPs branch)</li>
<li>Nil IPs on an L2 network with zero subnets: no subnet to resolve, still gets an indexed no-subnet-bucket name; avoids indexing an empty subnet list</li>
</ul>
</li>
<li><strong>Unit tests</strong>: <code>TestBuildPortName</code> — 8 table-driven cases covering both subnet and L2 naming, first/second-NIC index increments, truncation edge cases, and the 255-char hard limit. New <code>TestGetCreateOpts_MultipleNICsSameSubnet_IndexIncrements</code> drives two <code>GetCreateOpts</code> calls sharing one counter map against a mock Neutron server and asserts distinct <code>-1</code>/<code>-2</code> port names for two NICs on the same subnet.</li>
</ul>
<h2>Port naming format</h2>

Case | Port name
-- | --
Normal / DHCP | port-\<vmname>-\<subnet-name>-\<relative-index>
L2 network | port-\<vmname>-\<relative-index>
vmname too long | port-\<vmname[:N]>-\<subnet-name>-\<relative-index> (truncated)

</body></html>

__Testing Done__


<img width="1127" height="441" alt="image" src="https://github.com/user-attachments/assets/22f68666-3b85-4b59-941b-158f22667417" />


<img width="1437" height="74" alt="image" src="https://github.com/user-attachments/assets/aa25d7db-208b-4847-aaf4-4202db96e68b" />

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/2147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->