### PR TITLE
feat(ai): remove admin key requirement from AI key setup

### DIFF
--- a/pkg/vpwned/server/ai_key_handler.go
+++ b/pkg/vpwned/server/ai_key_handler.go
@@ -28,8 +28,7 @@ type aiKeyHandler struct {
 }
 
 type aiKeyRequest struct {
-	APIKey   string `json:"api_key"`
-	AdminKey string `json:"admin_key"`
+	APIKey string `json:"api_key"`
 }
 
 type aiKeyResponse struct {
@@ -65,24 +64,12 @@ func (h *aiKeyHandler) saveKey(w http.ResponseWriter, r *http.Request) {
 
 	ctx := context.Background()
 
-	// Fetch existing secret to preserve admin-key if not provided.
-	var existing corev1.Secret
-	existingErr := h.k8sClient.Get(ctx, types.NamespacedName{Name: aiSecretName, Namespace: aiSecretNS}, &existing)
-
 	secretData := map[string][]byte{
 		"api-key": []byte(req.APIKey),
 	}
 
-	switch {
-	case req.AdminKey != "":
-		secretData["admin-key"] = []byte(req.AdminKey)
-	case existingErr == nil && len(existing.Data["admin-key"]) > 0:
-		// Preserve existing admin key when caller omits it.
-		secretData["admin-key"] = existing.Data["admin-key"]
-	default:
-		http.Error(w, "admin_key is required", http.StatusBadRequest)
-		return
-	}
+	var existing corev1.Secret
+	existingErr := h.k8sClient.Get(ctx, types.NamespacedName{Name: aiSecretName, Namespace: aiSecretNS}, &existing)
 
 	if k8serrors.IsNotFound(existingErr) {
 		newSecret := &corev1.Secret{

--- a/pkg/vpwned/server/ai_key_handler_test.go
+++ b/pkg/vpwned/server/ai_key_handler_test.go
@@ -55,7 +55,7 @@ func TestAIKeyHandler_GetPresent(t *testing.T) {
 
 func TestAIKeyHandler_PostCreates(t *testing.T) {
 	h := &aiKeyHandler{k8sClient: fakeK8sClientForKeyTest()}
-	body, _ := json.Marshal(aiKeyRequest{APIKey: "sk-ant-abc", AdminKey: "my-admin"})
+	body, _ := json.Marshal(aiKeyRequest{APIKey: "sk-ant-abc"})
 	req := httptest.NewRequest(http.MethodPost, "/vpw/v1/ai/key", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -73,10 +73,10 @@ func TestAIKeyHandler_PostCreates(t *testing.T) {
 func TestAIKeyHandler_PostUpdates(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: aiSecretName, Namespace: aiSecretNS},
-		Data:       map[string][]byte{"api-key": []byte("old"), "admin-key": []byte("old-admin")},
+		Data:       map[string][]byte{"api-key": []byte("old")},
 	}
 	h := &aiKeyHandler{k8sClient: fakeK8sClientForKeyTest(secret)}
-	body, _ := json.Marshal(aiKeyRequest{APIKey: "sk-ant-new", AdminKey: "new-admin"})
+	body, _ := json.Marshal(aiKeyRequest{APIKey: "sk-ant-new"})
 	req := httptest.NewRequest(http.MethodPost, "/vpw/v1/ai/key", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -94,42 +94,5 @@ func TestAIKeyHandler_PostMissingKey(t *testing.T) {
 	h.ServeHTTP(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", w.Code)
-	}
-}
-
-// TestAIKeyHandler_PostPreservesAdminKey verifies that when admin_key is omitted
-// but the secret already has one, the existing admin key is kept.
-func TestAIKeyHandler_PostPreservesAdminKey(t *testing.T) {
-	existingAdminKey := "boot-generated-admin-key"
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: aiSecretName, Namespace: aiSecretNS},
-		Data: map[string][]byte{
-			"api-key":   []byte("old-anthropic"),
-			"admin-key": []byte(existingAdminKey),
-		},
-	}
-	h := &aiKeyHandler{k8sClient: fakeK8sClientForKeyTest(secret)}
-	// Only supply new Anthropic key; omit admin_key.
-	body, _ := json.Marshal(aiKeyRequest{APIKey: "sk-ant-new"})
-	req := httptest.NewRequest(http.MethodPost, "/vpw/v1/ai/key", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
-}
-
-// TestAIKeyHandler_PostAdminKeyRequiredNoExisting verifies that admin_key is
-// required when no secret exists yet (first-time setup).
-func TestAIKeyHandler_PostAdminKeyRequiredNoExisting(t *testing.T) {
-	h := &aiKeyHandler{k8sClient: fakeK8sClientForKeyTest()}
-	body, _ := json.Marshal(aiKeyRequest{APIKey: "sk-ant-abc"}) // no admin_key
-	req := httptest.NewRequest(http.MethodPost, "/vpw/v1/ai/key", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected 400 when admin_key absent on first setup, got %d", w.Code)
 	}
 }

--- a/ui/src/api/ai/aiAnalysis.ts
+++ b/ui/src/api/ai/aiAnalysis.ts
@@ -9,6 +9,6 @@ export async function getAIKeyStatus(): Promise<{ configured: boolean }> {
   return api.get<{ configured: boolean }>({ endpoint: '/dev-api/sdk/vpw/v1/ai/key' })
 }
 
-export async function saveAIKey(apiKey: string, adminKey: string): Promise<void> {
-  await api.post<void>({ endpoint: '/dev-api/sdk/vpw/v1/ai/key', data: { api_key: apiKey, admin_key: adminKey } })
+export async function saveAIKey(apiKey: string): Promise<void> {
+  await api.post<void>({ endpoint: '/dev-api/sdk/vpw/v1/ai/key', data: { api_key: apiKey } })
 }

--- a/ui/src/features/globalSettings/components/GlobalSettingsPage.tsx
+++ b/ui/src/features/globalSettings/components/GlobalSettingsPage.tsx
@@ -968,12 +968,10 @@ export default function GlobalSettingsPage() {
 
   // AI key state
   const [aiKeyValue, setAIKeyValue] = useState('')
-  const [adminKeyValue, setAdminKeyValue] = useState('')
   const [aiKeyConfigured, setAIKeyConfigured] = useState(false)
   const [aiKeySaving, setAIKeySaving] = useState(false)
   const [aiKeyError, setAIKeyError] = useState<string | null>(null)
   const [aiKeySuccess, setAIKeySuccess] = useState(false)
-  const [adminKeyError, setAdminKeyError] = useState<string | null>(null)
 
   useEffect(() => {
     getAIKeyStatus().then((s) => setAIKeyConfigured(s.configured)).catch(() => {})
@@ -981,27 +979,20 @@ export default function GlobalSettingsPage() {
 
   const handleSaveAIKey = useCallback(async () => {
     if (!aiKeyValue.trim()) return
-    // Admin key required only when no existing key is configured
-    if (!aiKeyConfigured && !adminKeyValue.trim()) {
-      setAdminKeyError('Admin key is required for initial setup')
-      return
-    }
-    setAdminKeyError(null)
     setAIKeySaving(true)
     setAIKeyError(null)
     try {
-      await saveAIKey(aiKeyValue.trim(), adminKeyValue.trim())
+      await saveAIKey(aiKeyValue.trim())
       setAIKeyConfigured(true)
       setAIKeyValue('')
-      setAdminKeyValue('')
       setAIKeySuccess(true)
       setTimeout(() => setAIKeySuccess(false), 3000)
     } catch {
-      setAIKeyError('Failed to save API keys. Check vpwned logs.')
+      setAIKeyError('Failed to save API key. Check vpwned logs.')
     } finally {
       setAIKeySaving(false)
     }
-  }, [aiKeyValue, adminKeyValue, aiKeyConfigured])
+  }, [aiKeyValue])
 
   const [vddkFile, setVddkFile] = useState<File | null>(null)
   const [vddkStatus, setVddkStatus] = useState<VddkUploadStatus>('idle')
@@ -1686,10 +1677,10 @@ export default function GlobalSettingsPage() {
 
               {aiKeyConfigured && !aiKeySuccess && (
                 <Alert severity="success" sx={{ mb: 2 }}>
-                  API keys configured. Enter new values below to update them.
+                  API key configured. Enter a new value below to update it.
                 </Alert>
               )}
-              {aiKeySuccess && <Alert severity="success" sx={{ mb: 2 }}>API keys saved. The AI service is restarting to pick up the new key.</Alert>}
+              {aiKeySuccess && <Alert severity="success" sx={{ mb: 2 }}>API key saved. The AI service is restarting to pick up the new key.</Alert>}
               {aiKeyError && <Alert severity="error" sx={{ mb: 2 }}>{aiKeyError}</Alert>}
 
               <TextField
@@ -1709,30 +1700,12 @@ export default function GlobalSettingsPage() {
                 sx={{ mb: 2 }}
               />
 
-              <TextField
-                label="Admin API Key"
-                type="password"
-                fullWidth
-                required={!aiKeyConfigured}
-                value={adminKeyValue}
-                onChange={(e) => { setAdminKeyValue(e.target.value); setAdminKeyError(null) }}
-                placeholder={aiKeyConfigured ? '(leave blank to keep existing)' : 'Enter admin key'}
-                helperText={
-                  adminKeyError ||
-                  (aiKeyConfigured
-                    ? 'Leave blank to keep the existing admin key'
-                    : 'Auto-generated at boot — check install.sh output or your deployment notes')
-                }
-                error={!!adminKeyError}
-                sx={{ mb: 2 }}
-              />
-
               <Button
                 variant="contained"
                 onClick={handleSaveAIKey}
-                disabled={aiKeySaving || !aiKeyValue.trim() || (!aiKeyConfigured && !adminKeyValue.trim())}
+                disabled={aiKeySaving || !aiKeyValue.trim()}
               >
-                {aiKeySaving ? 'Saving...' : 'Save API Keys'}
+                {aiKeySaving ? 'Saving...' : 'Save API Key'}
               </Button>
             </Box>
           </TabPanel>


### PR DESCRIPTION
Closes #2103

## Summary

- Removes the Admin API Key field from AI settings — only Anthropic API key needed
- Backend no longer requires or stores `admin-key` in the k8s Secret
- Simplifies first-time setup (no more boot-generated admin key to hunt down)
- Also includes UI polish from the AI analysis feature:
  - Experimental chip color: `info` → `warning` (matches Beta tag yellow)
  - Experimental chip added to Settings → AI tab
  - `AIAnalysisTab` uses common components (`StatusChip`, `Banner`, `ActionButton`) instead of raw MUI

## Test plan

- [ ] Open Settings → AI tab, verify only "Anthropic API Key" field visible (no Admin API Key field)
- [ ] Enter API key and click "Save API Key", verify saves successfully and AI pod restarts
- [ ] Verify Experimental chip is yellow on AI Analysis tab (migration detail + logs drawer + settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/2151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->