### PR TITLE
When Ip is empty and fallback to dhcp true ask pcd to assign ip via dhcp

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -2349,7 +2349,7 @@ func (migobj *Migrate) createPortsForNetworks(ctx context.Context, vminfo *vm.VM
 
 		mac := vminfo.Mac[idx]
 		detectedIPs := logAndCollectDetectedIPs(vminfo, mac)
-		loggedIPs := applyPreserveIPOverride(vminfo, idx, mac, override, detectedIPs)
+		loggedIPs := applyPreserveIPOverride(vminfo, idx, mac, override, detectedIPs, migobj.FallbackToDHCP)
 		mac = applyPreserveMACOverride(vminfo, idx, mac, override.preserveMAC)
 		utils.PrintLog(fmt.Sprintf("Using IPs for MAC %s: %v", vminfo.Mac[idx], loggedIPs))
 
@@ -2439,7 +2439,9 @@ func logAndCollectDetectedIPs(vminfo *vm.VMInfo, mac string) []string {
 
 // applyPreserveIPOverride replaces vminfo.IPperMac[mac] with the user-assigned
 // IP, or clears it, when preserveIP is false; returns the IPs for logging.
-func applyPreserveIPOverride(vminfo *vm.VMInfo, idx int, mac string, override nicOverride, detectedIPs []string) []string {
+// If no custom IP is given, fallbackToDHCP picks nil (auto-allocate) vs an
+// empty slice (no fixed IPs) for GetCreateOpts.
+func applyPreserveIPOverride(vminfo *vm.VMInfo, idx int, mac string, override nicOverride, detectedIPs []string, fallbackToDHCP bool) []string {
 	if override.preserveIP {
 		return detectedIPs
 	}
@@ -2454,9 +2456,15 @@ func applyPreserveIPOverride(vminfo *vm.VMInfo, idx int, mac string, override ni
 		return override.userAssignedIP
 	}
 
-	utils.PrintLog(fmt.Sprintf("NIC[%d]: preserveIP=false, no custom IP for MAC %s — port will have no fixed IPs", idx, mac))
-	vminfo.IPperMac[mac] = []vm.IpEntry{} // empty non-nil signals "no fixed IPs" to GetCreateOpts
-	return detectedIPs                    // matches pre-refactor log wording, even though these IPs are discarded
+	if fallbackToDHCP {
+		utils.PrintLog(fmt.Sprintf("NIC[%d]: preserveIP=false, no custom IP for MAC %s, fallbackToDHCP=true — port will auto-allocate an IP", idx, mac))
+		vminfo.IPperMac[mac] = nil
+		return detectedIPs
+	}
+
+	utils.PrintLog(fmt.Sprintf("NIC[%d]: preserveIP=false, no custom IP for MAC %s, fallbackToDHCP=false — port will have no fixed IPs", idx, mac))
+	vminfo.IPperMac[mac] = []vm.IpEntry{}
+	return detectedIPs
 }
 
 // applyPreserveMACOverride copies mac's IPs to the "" key and returns "" so

--- a/v2v-helper/migrate/migrate_network_override_test.go
+++ b/v2v-helper/migrate/migrate_network_override_test.go
@@ -1,0 +1,112 @@
+// Copyright © 2024 The vjailbreak authors
+
+package migrate
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/platform9/vjailbreak/v2v-helper/vm"
+)
+
+// TestApplyPreserveIPOverride_FallbackToDHCP covers preserveIP=false with no
+// custom IP: fallbackToDHCP should pick nil (auto-allocate) vs an empty slice
+// (no fixed IPs).
+func TestApplyPreserveIPOverride_FallbackToDHCP(t *testing.T) {
+	const mac = "aa:bb:cc:dd:ee:ff"
+
+	tests := []struct {
+		name           string
+		override       nicOverride
+		fallbackToDHCP bool
+		detectedIPs    []string
+		wantIPperMac   []vm.IpEntry
+		wantIsNil      bool
+	}{
+		{
+			name:           "preserveIP=false, empty IP, dhcp=false",
+			override:       nicOverride{preserveIP: false},
+			fallbackToDHCP: false,
+			detectedIPs:    []string{"10.0.0.5"},
+			wantIPperMac:   []vm.IpEntry{},
+			wantIsNil:      false,
+		},
+		{
+			name:           "preserveIP=false, empty IP, dhcp=true",
+			override:       nicOverride{preserveIP: false},
+			fallbackToDHCP: true,
+			detectedIPs:    []string{"10.0.0.5"},
+			wantIPperMac:   nil,
+			wantIsNil:      true,
+		},
+		{
+			name:           "preserveIP=false, custom IP, dhcp=true",
+			override:       nicOverride{preserveIP: false, userAssignedIP: []string{"192.168.1.50"}},
+			fallbackToDHCP: true,
+			detectedIPs:    []string{"10.0.0.5"},
+			wantIPperMac:   []vm.IpEntry{{IP: "192.168.1.50", Prefix: 0}},
+			wantIsNil:      false,
+		},
+		{
+			name:           "preserveIP=false, custom IP, dhcp=false",
+			override:       nicOverride{preserveIP: false, userAssignedIP: []string{"192.168.1.50"}},
+			fallbackToDHCP: false,
+			detectedIPs:    []string{"10.0.0.5"},
+			wantIPperMac:   []vm.IpEntry{{IP: "192.168.1.50", Prefix: 0}},
+			wantIsNil:      false,
+		},
+		{
+			name:           "preserveIP=true: untouched",
+			override:       nicOverride{preserveIP: true},
+			fallbackToDHCP: true,
+			detectedIPs:    []string{"10.0.0.5"},
+			wantIPperMac:   []vm.IpEntry{{IP: "10.0.0.5", Prefix: 24}},
+			wantIsNil:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vminfo := &vm.VMInfo{
+				IPperMac: map[string][]vm.IpEntry{
+					mac: {{IP: "10.0.0.5", Prefix: 24}},
+				},
+			}
+
+			applyPreserveIPOverride(vminfo, 0, mac, tt.override, tt.detectedIPs, tt.fallbackToDHCP)
+
+			got := vminfo.IPperMac[mac]
+			if tt.wantIsNil && got != nil {
+				t.Fatalf("expected IPperMac[mac] to be nil, got %#v", got)
+			}
+			if !tt.wantIsNil && got == nil {
+				t.Fatalf("expected IPperMac[mac] to be non-nil, got nil")
+			}
+			if !reflect.DeepEqual(got, tt.wantIPperMac) {
+				t.Fatalf("IPperMac[mac] = %#v, want %#v", got, tt.wantIPperMac)
+			}
+		})
+	}
+}
+
+// TestApplyPreserveIPOverride_EmptySliceVsNilDistinctionMatters asserts nil
+// and an empty slice aren't treated as interchangeable, since GetCreateOpts
+// branches on that distinction.
+func TestApplyPreserveIPOverride_EmptySliceVsNilDistinctionMatters(t *testing.T) {
+	const mac = "11:22:33:44:55:66"
+
+	vminfoDHCPOff := &vm.VMInfo{IPperMac: map[string][]vm.IpEntry{mac: {{IP: "1.2.3.4"}}}}
+	applyPreserveIPOverride(vminfoDHCPOff, 0, mac, nicOverride{preserveIP: false}, nil, false)
+	if vminfoDHCPOff.IPperMac[mac] == nil {
+		t.Fatalf("fallbackToDHCP=false must produce a non-nil empty slice, got nil")
+	}
+	if len(vminfoDHCPOff.IPperMac[mac]) != 0 {
+		t.Fatalf("fallbackToDHCP=false must produce an empty slice, got %#v", vminfoDHCPOff.IPperMac[mac])
+	}
+
+	vminfoDHCPOn := &vm.VMInfo{IPperMac: map[string][]vm.IpEntry{mac: {{IP: "1.2.3.4"}}}}
+	applyPreserveIPOverride(vminfoDHCPOn, 0, mac, nicOverride{preserveIP: false}, nil, true)
+	if vminfoDHCPOn.IPperMac[mac] != nil {
+		t.Fatalf("fallbackToDHCP=true must produce a nil slice, got %#v", vminfoDHCPOn.IPperMac[mac])
+	}
+}

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -735,7 +735,7 @@ func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *ne
 		// empty non-nil slice: user explicitly wants a port with no fixed IPs (preserveIP=false, no custom IP)
 		PrintLog("Creating port with no fixed IPs for mac " + mac)
 		createOpts.FixedIPs = []ports.IP{}
-	} else {
+	} else if len(network.Subnets) > 0 {
 		// nil: original VM had no IPs on this NIC — let OpenStack DHCP assign
 		PrintLog("Empty port on vcentre detected for mac " + mac)
 		subnetID, err := subnets.Get(ctx, osclient.NetworkingClient, network.Subnets[0]).Extract()
@@ -743,6 +743,11 @@ func (osclient *OpenStackClients) GetCreateOpts(ctx context.Context, network *ne
 			return createOpts, fmt.Errorf("subnet not found for network %s", network.ID)
 		}
 		gatewayIP[mac] = subnetID.GatewayIP
+	} else {
+		// nil ipEntries but the network has no subnets at all (e.g. an L2-only
+		// network that legitimately has zero subnets). There's no subnet to
+		// query or gateway to record, so just leave FixedIPs/gatewayIP unset.
+		PrintLog("Empty port with no subnets on network " + network.ID + " for mac " + mac)
 	}
 	return createOpts, nil
 }

--- a/v2v-helper/pkg/utils/openstackopsutils_test.go
+++ b/v2v-helper/pkg/utils/openstackopsutils_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
 )
 
@@ -211,6 +212,64 @@ func newTestBlockStorageClient(srv *httptest.Server, httpClient *http.Client) *g
 	return &gophercloud.ServiceClient{
 		ProviderClient: provider,
 		ResourceBase:   srv.URL + "/",
+	}
+}
+
+// newTestNetworkingClient builds a gophercloud ServiceClient pointed at srv
+// for use as OpenStackClients.NetworkingClient.
+func newTestNetworkingClient(srv *httptest.Server) *gophercloud.ServiceClient {
+	return &gophercloud.ServiceClient{
+		ProviderClient: &gophercloud.ProviderClient{TokenID: "test-token", Throwaway: true},
+		ResourceBase:   srv.URL + "/v2.0/",
+	}
+}
+
+// TestGetCreateOpts_NilIPEntries_L2NetworkWithNoSubnets reproduces a panic:
+// when ipEntries is nil (e.g. preserveIP=false + fallbackToDHCP=true routes
+// here to let OpenStack auto-allocate an IP) and the target network is an
+// L2-only "simple_network" with zero subnets, GetCreateOpts's nil branch used
+// to unconditionally index network.Subnets[0] and crash the migration with an
+// index-out-of-range panic. L2 networks are explicitly allowed to have no
+// subnets (see the guard in ValidateAndCreatePort), so this is a reachable
+// case, not a hypothetical one.
+func TestGetCreateOpts_NilIPEntries_L2NetworkWithNoSubnets(t *testing.T) {
+	const networkID = "net-l2-no-subnets"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/networks/"+networkID) {
+			body := map[string]any{
+				"network": map[string]any{
+					"id":   networkID,
+					"tags": []string{"simple_network"},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(body)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	client := &OpenStackClients{NetworkingClient: newTestNetworkingClient(srv)}
+	network := &networks.Network{ID: networkID, Subnets: []string{}}
+	gatewayIP := map[string]string{}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("GetCreateOpts panicked on an L2 network with no subnets: %v", r)
+		}
+	}()
+
+	createOpts, err := client.GetCreateOpts(t.Context(), network, "aa:bb:cc:dd:ee:ff", nil, "test-vm", nil, gatewayIP)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if createOpts.FixedIPs != nil {
+		t.Fatalf("expected no FixedIPs to be set, got: %+v", createOpts.FixedIPs)
+	}
+	if _, ok := gatewayIP["aa:bb:cc:dd:ee:ff"]; ok {
+		t.Fatalf("expected no gateway to be recorded for a subnet-less L2 network, got: %v", gatewayIP)
 	}
 }
 


### PR DESCRIPTION
## What this PR does / why we need it
So when user unchecks preserve IP, mac and clears ip,mac and selects fallback to dhcp. IP/mac should be assigned by pcd via dhcp. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes # first part control plane fix of 2028, haven't fixed guest related change, Further pr's will follow. 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/2153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->