### PR TITLE
Make clean up both agents and vjb nodes to run as background and improve reliability

### DIFF
--- a/image_builder/configs/daemonset.yaml
+++ b/image_builder/configs/daemonset.yaml
@@ -59,21 +59,56 @@ spec:
             - |
               IS_MASTER=$(grep -E '^export IS_MASTER=' /etc/pf9/k3s.env | cut -d'=' -f2)
               MASTER_IP=$(grep -E '^export MASTER_IP=' /etc/pf9/k3s.env | cut -d'=' -f2)
+
+              # Migration considered idle if quiet for this long; only then is it eligible for cleanup.
+              ACTIVITY_WINDOW_MIN=60
+              # Delete threshold: older than 24h.
+              RETENTION_MTIME=+1
+
+              # Deletes migration-<vm>-<id>.log + migration-<vm>-<id>/ as one unit,
+              # skipping the pair if either was written to within ACTIVITY_WINDOW_MIN.
+              cleanup_dir() {
+                local base_dir="$1"
+                [ -d "$base_dir" ] || return 0
+
+                local names
+                names=$( { find "$base_dir" -maxdepth 1 -type f -name 'migration-*.log' -printf '%f\n' 2>/dev/null | sed 's/\.log$//'
+                           find "$base_dir" -mindepth 1 -maxdepth 1 -type d -name 'migration-*' -printf '%f\n' 2>/dev/null
+                         } | sort -u )
+
+                echo "$names" | while IFS= read -r name; do
+                  [ -n "$name" ] || continue
+                  local log_file="$base_dir/$name.log"
+                  local dir="$base_dir/$name"
+
+                  if find "$log_file" "$dir" -type f -mmin -"$ACTIVITY_WINDOW_MIN" 2>/dev/null | grep -q .; then
+                    echo "[cleanup] Skipping $name (active within last ${ACTIVITY_WINDOW_MIN}m)"
+                    continue
+                  fi
+
+                  [ -f "$log_file" ] && find "$log_file" -mtime "$RETENTION_MTIME" -delete 2>/dev/null
+                  if [ -d "$dir" ]; then
+                    find "$dir" -type f -mtime "$RETENTION_MTIME" -delete 2>/dev/null
+                    rmdir "$dir" 2>/dev/null || true
+                  fi
+                done
+
+                # Stray non-migration files: clean by age alone.
+                find "$base_dir" -maxdepth 1 -type f ! -name 'migration-*.log' -mtime "$RETENTION_MTIME" -delete 2>/dev/null || true
+              }
+
               if [ "$IS_MASTER" = "true" ]; then
                 echo "Master node detected. IP: $MASTER_IP"
-                
-                # Clean up logs older than 24 hours on master node
-                echo "Cleaning up logs older than 24 hours on master node"
-                # Note: Not restarting services to avoid disruption
-                # Instead, properly closing files in the v2v-helper code
-                # Clean master's own logs and force delete any stuck files
-                find /var/log/pf9 -type f -mtime +1 -delete 2>/dev/null || true
-                # Clean worker logs stored on master and force delete any stuck files
-                find /var/lib/rsync/worker-logs -type f -mtime +1 -delete 2>/dev/null || true
-                # Clear deleted but open files (useful when processes still hold file handles)
-                echo "Clearing deleted but open files..."
-                lsof +L1 | grep "/var/log/pf9\|/var/lib/rsync/worker-logs" | awk '{print $2}' | xargs -r kill -HUP 2>/dev/null || true
-                
+
+                master_cleanup_loop() {
+                  while true; do
+                    echo "Cleaning up logs older than 24 hours on master node ($(date))"
+                    cleanup_dir /var/log/pf9
+                    sleep 300
+                  done
+                }
+                master_cleanup_loop &
+
                 echo "Starting rsync daemon..."
                 rsync --daemon --config=/etc/pf9/rsyncd.conf --no-detach
                 if ps aux | grep rsync | grep -v grep; then
@@ -84,29 +119,24 @@ spec:
                 fi
               else
                 echo "Worker node detected. Syncing from Master..."
+
+                agent_cleanup_loop() {
+                  while true; do
+                    echo "Cleaning up logs older than 24 hours on worker node ($(date))"
+                    cleanup_dir /var/log/pf9
+                    sync
+                    echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true
+                    sleep 300
+                  done
+                }
+                agent_cleanup_loop &
+
                 while true; do
                   mkdir -p /home/ubuntu/vmware-vix-disklib-distrib/
-                  
-                  # Clean up logs older than 24 hours on worker node
-                  echo "Cleaning up logs older than 24 hours on worker node"
-                  # Note: Not restarting services to avoid disruption
-                  # Instead, properly closing files in the v2v-helper code
-                  # Force delete old log files
-                  find /var/log/pf9 -type f -mtime +1 -delete 2>/dev/null || true
-                  # Clear deleted but open files
-                  echo "Clearing deleted but open files..."
-                  lsof +L1 | grep "/var/log/pf9" | awk '{print $2}' | xargs -r kill -HUP 2>/dev/null || true
-                  # Free up disk space by clearing caches
-                  sync
-                  echo 3 > /proc/sys/vm/drop_caches 2>/dev/null || true
-                  
+
                   echo "Syncing from rsync://${MASTER_IP}"
                   rsync -avz rsync://${MASTER_IP}/vmwarelib/ /home/ubuntu/vmware-vix-disklib-distrib/
-
-                  # Sync logs from worker to master
                   rsync -avz  /var/log/pf9 rsync://${MASTER_IP}/worker-logs
-
-                  # Sync virtio-win drivers from master to worker
                   rsync -avz rsync://${MASTER_IP}/virtio-win /home/ubuntu/virtio-win
 
                   if [ $? -eq 0 ]; then


### PR DESCRIPTION
## What this PR does / why we need it
This PR fixes logs not getting cleared on vjailbreak node and agent nodes log deletion reliability.

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #2154 

## Special notes for your reviewer


## Testing done
Before running the fix on master:
```
var/log/pf9# ls -lrth
total 2.2M
drwxr-xr-x 2 root root 4.0K Jul 13 04:55 migration-rocky-9-automation-47-28a6c
-rw-r--r-- 1 root root  18K Jul 13 05:03 migration-ubuntu-config-bios-8126-5c860.log
-rw-r--r-- 1 root root  21K Jul 13 05:04 migration-rocky-9-automation-47-28a6c.log
drwxr-xr-x 2 root root 4.0K Jul 13 05:05 migration-rocky-dist-automation-7772-8db8d
-rw-r--r-- 1 root root  18K Jul 13 05:16 migration-rocky-dist-automation-7772-8db8d.log
drwxr-xr-x 2 root root 4.0K Jul 13 05:32 migration-rocky10-1-automation-7650-da37e
drwxr-xr-x 2 root root 4.0K Jul 13 05:32 migration-rocky8-10-automation-7649-b01c4
-rw-r--r-- 1 root root  18K Jul 13 05:43 migration-rocky8-10-automation-7649-b01c4.log
-rw-r--r-- 1 root root  19K Jul 13 05:43 migration-rocky10-1-automation-7650-da37e.log
drwxr-xr-x 2 root root 4.0K Jul 13 05:45 migration-centos-7-automation-34-892d8
drwxr-xr-x 2 root root 4.0K Jul 13 05:46 migration-rocky-9-automation-47-a8946
-rw-r--r-- 1 root root  20K Jul 13 05:55 migration-centos-7-automation-34-892d8.log
-rw-r--r-- 1 root root  21K Jul 13 05:55 migration-rocky-9-automation-47-a8946.log
drwxr-xr-x 2 root root 4.0K Jul 13 05:57 migration-ubuntu-config-bios-8126-a568d
drwxr-xr-x 2 root root 4.0K Jul 13 05:58 migration-rhel-9-automation-3703-e6ed0
-rw-r--r-- 1 root root  19K Jul 13 06:06 migration-rhel-9-automation-3703-e6ed0.log
-rw-r--r-- 1 root root  18K Jul 13 06:10 migration-ubuntu-config-bios-8126-a568d.log
drwxr-xr-x 2 root root 4.0K Jul 16 07:05 migration-ubuntu-22-xfs-7146-2e982
drwxr-xr-x 2 root root 4.0K Jul 16 07:06 migration-ubuntu-config-bios-8126-5c860
drwxr-xr-x 2 root root 4.0K Jul 16 09:01 migration-win2k25-automation-38-4738b
-rw-r--r-- 1 root root  19K Jul 16 09:32 migration-win2k25-automation-38-4738b.log
-rw-r--r-- 1 root root 1.9M Jul 16 12:07 migration-ubuntu-22-xfs-7146-2e982.log


After the fix:
/var/log/pf9# ls -lrth
total 1.9M
drwxr-xr-x 2 root root 4.0K Jul 16 07:05 migration-ubuntu-22-xfs-7146-2e982
drwxr-xr-x 2 root root 4.0K Jul 16 07:06 migration-ubuntu-config-bios-8126-5c860
drwxr-xr-x 2 root root 4.0K Jul 16 09:01 migration-win2k25-automation-38-4738b
-rw-r--r-- 1 root root  19K Jul 16 09:32 migration-win2k25-automation-38-4738b.log
-rw-r--r-- 1 root root 1.9M Jul 16 12:12 migration-ubuntu-22-xfs-7146-2e982.log
```

_please add testing details (logs, screenshots, etc.)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/2155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->