### PR TITLE
[2096] Default removeVMwareTools to true

### DIFF
--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -976,8 +976,10 @@ spec:
                       migration plan should be synced
                     type: string
                   removeVMwareTools:
-                    description: RemoveVMwareTools instructs the migration helper
-                      to remove VMware Tools post migration
+                    default: true
+                    description: |-
+                      RemoveVMwareTools instructs the migration helper to remove VMware Tools post migration.
+                      Defaults to true since most migrations require VMware Tools removal.
                     type: boolean
                 type: object
               customMetadata:
@@ -2426,8 +2428,10 @@ spec:
                       migration plan should be synced
                     type: string
                   removeVMwareTools:
-                    description: RemoveVMwareTools instructs the migration helper
-                      to remove VMware Tools post migration
+                    default: true
+                    description: |-
+                      RemoveVMwareTools instructs the migration helper to remove VMware Tools post migration.
+                      Defaults to true since most migrations require VMware Tools removal.
                     type: boolean
                 type: object
               bmConfigRef:

--- a/deploy/installer.yaml
+++ b/deploy/installer.yaml
@@ -976,8 +976,10 @@ spec:
                       migration plan should be synced
                     type: string
                   removeVMwareTools:
-                    description: RemoveVMwareTools instructs the migration helper
-                      to remove VMware Tools post migration
+                    default: true
+                    description: |-
+                      RemoveVMwareTools instructs the migration helper to remove VMware Tools post migration.
+                      Defaults to true since most migrations require VMware Tools removal.
                     type: boolean
                 type: object
               customMetadata:
@@ -2426,8 +2428,10 @@ spec:
                       migration plan should be synced
                     type: string
                   removeVMwareTools:
-                    description: RemoveVMwareTools instructs the migration helper
-                      to remove VMware Tools post migration
+                    default: true
+                    description: |-
+                      RemoveVMwareTools instructs the migration helper to remove VMware Tools post migration.
+                      Defaults to true since most migrations require VMware Tools removal.
                     type: boolean
                 type: object
               bmConfigRef:

--- a/k8s/migration/api/v1alpha1/migrationplan_types.go
+++ b/k8s/migration/api/v1alpha1/migrationplan_types.go
@@ -62,8 +62,10 @@ type AdvancedOptions struct {
 	PeriodicSyncEnabled bool `json:"periodicSyncEnabled,omitempty"`
 	// NetworkPersistence instructs the migration helper to persist the source networking configuration
 	NetworkPersistence bool `json:"networkPersistence,omitempty"`
-	// RemoveVMwareTools instructs the migration helper to remove VMware Tools post migration
-	RemoveVMwareTools bool `json:"removeVMwareTools,omitempty"`
+	// RemoveVMwareTools instructs the migration helper to remove VMware Tools post migration.
+	// Defaults to true since most migrations require VMware Tools removal.
+	// +kubebuilder:default=true
+	RemoveVMwareTools *bool `json:"removeVMwareTools,omitempty"`
 	// AcknowledgeNetworkConflictRisk indicates that the user acknowledges the risk of network conflicts when doing live migration
 	AcknowledgeNetworkConflictRisk bool `json:"acknowledgeNetworkConflictRisk,omitempty"`
 	// ImageProfiles is the ordered list of VolumeImageProfile names to apply to the migrated VM's boot volume.

--- a/k8s/migration/api/v1alpha1/zz_generated.deepcopy.go
+++ b/k8s/migration/api/v1alpha1/zz_generated.deepcopy.go
@@ -44,6 +44,11 @@ func (in *AdvancedOptions) DeepCopyInto(out *AdvancedOptions) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.RemoveVMwareTools != nil {
+		in, out := &in.RemoveVMwareTools, &out.RemoveVMwareTools
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ImageProfiles != nil {
 		in, out := &in.ImageProfiles, &out.ImageProfiles
 		*out = make([]string, len(*in))

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationplans.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_migrationplans.yaml
@@ -99,8 +99,10 @@ spec:
                       migration plan should be synced
                     type: string
                   removeVMwareTools:
-                    description: RemoveVMwareTools instructs the migration helper
-                      to remove VMware Tools post migration
+                    default: true
+                    description: |-
+                      RemoveVMwareTools instructs the migration helper to remove VMware Tools post migration.
+                      Defaults to true since most migrations require VMware Tools removal.
                     type: boolean
                 type: object
               customMetadata:

--- a/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_rollingmigrationplans.yaml
+++ b/k8s/migration/config/crd/bases/vjailbreak.k8s.pf9.io_rollingmigrationplans.yaml
@@ -87,8 +87,10 @@ spec:
                       migration plan should be synced
                     type: string
                   removeVMwareTools:
-                    description: RemoveVMwareTools instructs the migration helper
-                      to remove VMware Tools post migration
+                    default: true
+                    description: |-
+                      RemoveVMwareTools instructs the migration helper to remove VMware Tools post migration.
+                      Defaults to true since most migrations require VMware Tools removal.
                     type: boolean
                 type: object
               bmConfigRef:

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -1529,6 +1529,10 @@ func (r *MigrationPlanReconciler) buildBaseConfigMapData(
 	virtiodrivers string,
 	openstacknws, openstackports, openstackvolumetypes []string,
 ) map[string]string {
+	removeVMwareTools := true
+	if migrationplan.Spec.AdvancedOptions.RemoveVMwareTools != nil {
+		removeVMwareTools = *migrationplan.Spec.AdvancedOptions.RemoveVMwareTools
+	}
 	return map[string]string{
 		"SOURCE_VM_NAME":                    vmMachine.Spec.VMInfo.Name,
 		"SOURCE_VM_ID":                      vmMachine.Spec.VMInfo.VMID,
@@ -1552,7 +1556,7 @@ func (r *MigrationPlanReconciler) buildBaseConfigMapData(
 		"PERIODIC_SYNC_INTERVAL":            migrationplan.Spec.AdvancedOptions.PeriodicSyncInterval,
 		"PERIODIC_SYNC_ENABLED":             strconv.FormatBool(migrationplan.Spec.AdvancedOptions.PeriodicSyncEnabled),
 		"NETWORK_PERSISTENCE":               strconv.FormatBool(migrationplan.Spec.AdvancedOptions.NetworkPersistence),
-		"REMOVE_VMWARE_TOOLS":               strconv.FormatBool(migrationplan.Spec.AdvancedOptions.RemoveVMwareTools),
+		"REMOVE_VMWARE_TOOLS":               strconv.FormatBool(removeVMwareTools),
 		"ACKNOWLEDGE_NETWORK_CONFLICT_RISK": strconv.FormatBool(migrationplan.Spec.AdvancedOptions.AcknowledgeNetworkConflictRisk),
 		"DISCONNECT_SOURCE_NETWORK":         strconv.FormatBool(migrationobj.Spec.DisconnectSourceNetwork),
 	}

--- a/ui/src/features/migration/pages/MigrationForm.tsx
+++ b/ui/src/features/migration/pages/MigrationForm.tsx
@@ -67,7 +67,7 @@ const defaultMigrationOptions = {
   }
 }
 
-const defaultValues: Partial<FormValues> = {}
+const defaultValues: Partial<FormValues> = { removeVMwareTools: true }
 
 export default function MigrationFormDrawer({
   open,

--- a/ui/src/features/migration/pages/RollingMigrationForm.tsx
+++ b/ui/src/features/migration/pages/RollingMigrationForm.tsx
@@ -143,7 +143,7 @@ export default function RollingMigrationFormDrawer({
   const [vmOSAssignments, setVmOSAssignments] = useState<Record<string, string>>({})
 
   // Migration Options state
-  const { params, getParamsUpdater, updateParams } = useParams<RollingFormParams>({})
+  const { params, getParamsUpdater, updateParams } = useParams<RollingFormParams>({ removeVMwareTools: true })
 
   const { data: settingsConfigMap } = useSettingsConfigMapQuery()
   const networkPersistenceSeedRef = useRef(false)


### PR DESCRIPTION
## Summary
- Changes `RemoveVMwareTools` field from `bool` to `*bool` in the `AdvancedOptions` CRD type with `+kubebuilder:default=true`, so new MigrationPlans default to removing VMware Tools without explicit opt-in
- Controller updated to dereference `*bool` pointer, falling back to `true` when nil (handles existing MigrationPlans without the field set)
- UI forms (`MigrationForm`, `RollingMigrationForm`) initialize checkbox as checked to match backend default

## Why *bool instead of bool
`bool` with `omitempty` serializes `false` as absent, making it impossible to distinguish "user set false" from "not set". `*bool` allows the API server CRD default to apply when nil, while preserving explicit `false` values.

## Test plan
- [ ] Create a new MigrationPlan via UI — verify `removeVMwareTools` checkbox is checked by default
- [ ] Create a MigrationPlan via kubectl without setting `removeVMwareTools` — verify field defaults to `true` in the stored object
- [ ] Create a MigrationPlan with `removeVMwareTools: false` — verify it is preserved as `false`
- [ ] Run a migration — verify VMware Tools are removed by default
- [ ] Uncheck the box and run migration — verify VMware Tools are NOT removed

Closes #2096

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/platform9/vjailbreak/pull/2159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->