### PR TITLE
[2115] Fix IP address not populating on port creation due to MAC address case mismatch

### DIFF
--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -636,7 +636,8 @@ func (osclient *OpenStackClients) CheckIfPortExists(ctx context.Context, ipEntri
 		return nil, err
 	}
 	for _, port := range portList {
-		if port.MACAddress == mac {
+		// Neutron stores MACs lowercase; compare case-insensitively
+		if strings.EqualFold(port.MACAddress, mac) {
 			if port.DeviceID != "" {
 				return nil, fmt.Errorf("precheck failed: port %s (MAC %s) is already in use by device %s", port.ID, mac, port.DeviceID)
 			}

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -610,7 +610,8 @@ func AddWildcardNetplan(disks []vm.VMDisk, diskPath string, guestNetworks []vjai
 				continue
 			}
 			if len(gn.DNS) > 0 {
-				macToDNS[gn.MAC] = gn.DNS
+				// ipPerMac keys are canonical lowercase; match that case
+				macToDNS[strings.ToLower(gn.MAC)] = gn.DNS
 			}
 		}
 	}
@@ -825,7 +826,8 @@ func AddUdevRules(disks []vm.VMDisk, diskPath string, interfaces []string, macs 
 	// Create the udev rules content
 	var udevRules strings.Builder
 	for i, iface := range interfaces {
-		udevRules.WriteString(fmt.Sprintf("SUBSYSTEM==\"net\", ACTION==\"add\", ATTR{address}==\"%s\", NAME=\"%s\"\n", macs[i], iface))
+		// udev ATTR{address} matches sysfs, which is always lowercase
+		udevRules.WriteString(fmt.Sprintf("SUBSYSTEM==\"net\", ACTION==\"add\", ATTR{address}==\"%s\", NAME=\"%s\"\n", vm.CanonicalMAC(macs[i]), iface))
 		log.Printf("Adding udev rule: %s", udevRules.String())
 	}
 

--- a/v2v-helper/vm/netinfo.go
+++ b/v2v-helper/vm/netinfo.go
@@ -1,0 +1,61 @@
+package vm
+
+import (
+	"strings"
+
+	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
+)
+
+// CanonicalMAC lowercases a MAC address so it can be used as a map key.
+// vCenter preserves the case of manually-assigned MACs while the
+// VMwareMachine CR (populated from VMware Tools) may report a different
+// case, so every IPperMac key and lookup must go through this.
+func CanonicalMAC(mac string) string {
+	return strings.ToLower(strings.TrimSpace(mac))
+}
+
+// CollectIPsPerMac maps each NIC MAC (canonical lowercase) to the IPv4
+// addresses recorded in the VMwareMachine CR. GuestNetworks (VMware Tools
+// data) takes precedence; NetworkInterfaces is the fallback. IPv6 addresses
+// are skipped.
+func CollectIPsPerMac(macs []string, guestNetworks []vjailbreakv1alpha1.GuestNetwork, networkInterfaces []vjailbreakv1alpha1.NIC) map[string][]IpEntry {
+	ipPerMac := make(map[string][]IpEntry)
+	for _, macAddress := range macs {
+		key := CanonicalMAC(macAddress)
+		if guestNetworks != nil {
+			for _, guestNetwork := range guestNetworks {
+				if !strings.EqualFold(guestNetwork.MAC, macAddress) {
+					continue
+				}
+				if _, ok := ipPerMac[key]; !ok {
+					ipPerMac[key] = []IpEntry{}
+				}
+				if !strings.Contains(guestNetwork.IP, ":") {
+					ipPerMac[key] = append(ipPerMac[key], IpEntry{
+						IP:     guestNetwork.IP,
+						Prefix: guestNetwork.PrefixLength,
+					})
+				}
+			}
+			continue
+		}
+		for _, networkInterface := range networkInterfaces {
+			if !strings.EqualFold(networkInterface.MAC, macAddress) {
+				continue
+			}
+			if _, ok := ipPerMac[key]; !ok {
+				ipPerMac[key] = []IpEntry{}
+			}
+			for _, ipAddress := range networkInterface.IPAddress {
+				if strings.Contains(ipAddress, ":") {
+					continue
+				}
+				ipPerMac[key] = append(ipPerMac[key], IpEntry{
+					IP:     ipAddress,
+					Prefix: 0,
+				})
+			}
+		}
+	}
+	return ipPerMac
+}

--- a/v2v-helper/vm/netinfo_test.go
+++ b/v2v-helper/vm/netinfo_test.go
@@ -1,0 +1,147 @@
+package vm
+
+import (
+	"reflect"
+	"testing"
+
+	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
+)
+
+func TestCanonicalMAC(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "already lowercase", in: "00:50:56:9d:47:74", want: "00:50:56:9d:47:74"},
+		{name: "uppercase", in: "00:50:56:9D:47:74", want: "00:50:56:9d:47:74"},
+		{name: "mixed case with whitespace", in: " 00:50:56:9D:47:74 ", want: "00:50:56:9d:47:74"},
+		{name: "empty", in: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanonicalMAC(tt.in); got != tt.want {
+				t.Errorf("CanonicalMAC(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollectIPsPerMac(t *testing.T) {
+	tests := []struct {
+		name              string
+		macs              []string
+		guestNetworks     []vjailbreakv1alpha1.GuestNetwork
+		networkInterfaces []vjailbreakv1alpha1.NIC
+		want              map[string][]IpEntry
+	}{
+		{
+			// Regression for #2115: vCenter reports the MAC uppercase while the
+			// VMwareMachine CR stores it lowercase; the IP must still be found.
+			name: "uppercase vCenter MAC matches lowercase CR MAC",
+			macs: []string{"00:50:56:9D:47:74"},
+			guestNetworks: []vjailbreakv1alpha1.GuestNetwork{
+				{MAC: "00:50:56:9d:47:74", IP: "146.122.44.210", PrefixLength: 24},
+				{MAC: "00:50:56:9d:47:74", IP: "fe80::250:56ff:fe9d:4774", PrefixLength: 64},
+			},
+			want: map[string][]IpEntry{
+				"00:50:56:9d:47:74": {{IP: "146.122.44.210", Prefix: 24}},
+			},
+		},
+		{
+			name: "lowercase vCenter MAC matches uppercase CR MAC",
+			macs: []string{"00:50:56:9d:47:74"},
+			guestNetworks: []vjailbreakv1alpha1.GuestNetwork{
+				{MAC: "00:50:56:9D:47:74", IP: "10.0.0.5", PrefixLength: 24},
+			},
+			want: map[string][]IpEntry{
+				"00:50:56:9d:47:74": {{IP: "10.0.0.5", Prefix: 24}},
+			},
+		},
+		{
+			name: "IPv6-only guest network yields empty non-nil entry",
+			macs: []string{"00:50:56:9d:47:74"},
+			guestNetworks: []vjailbreakv1alpha1.GuestNetwork{
+				{MAC: "00:50:56:9d:47:74", IP: "fe80::1", PrefixLength: 64},
+			},
+			want: map[string][]IpEntry{
+				"00:50:56:9d:47:74": {},
+			},
+		},
+		{
+			name: "no matching guest network leaves MAC absent",
+			macs: []string{"00:50:56:9d:47:74"},
+			guestNetworks: []vjailbreakv1alpha1.GuestNetwork{
+				{MAC: "aa:bb:cc:dd:ee:ff", IP: "10.0.0.9", PrefixLength: 24},
+			},
+			want: map[string][]IpEntry{},
+		},
+		{
+			name: "network interfaces fallback with case mismatch",
+			macs: []string{"00:50:56:9D:47:74"},
+			networkInterfaces: []vjailbreakv1alpha1.NIC{
+				{MAC: "00:50:56:9d:47:74", IPAddress: []string{"146.122.44.210", "fe80::1"}},
+			},
+			want: map[string][]IpEntry{
+				"00:50:56:9d:47:74": {{IP: "146.122.44.210", Prefix: 0}},
+			},
+		},
+		{
+			name: "guest networks take precedence over network interfaces",
+			macs: []string{"00:50:56:9d:47:74"},
+			guestNetworks: []vjailbreakv1alpha1.GuestNetwork{
+				{MAC: "00:50:56:9d:47:74", IP: "10.1.1.1", PrefixLength: 16},
+			},
+			networkInterfaces: []vjailbreakv1alpha1.NIC{
+				{MAC: "00:50:56:9d:47:74", IPAddress: []string{"10.2.2.2"}},
+			},
+			want: map[string][]IpEntry{
+				"00:50:56:9d:47:74": {{IP: "10.1.1.1", Prefix: 16}},
+			},
+		},
+		{
+			name: "multiple NICs each keyed canonically",
+			macs: []string{"00:50:56:9D:47:74", "00:50:56:AA:BB:CC"},
+			guestNetworks: []vjailbreakv1alpha1.GuestNetwork{
+				{MAC: "00:50:56:9d:47:74", IP: "10.0.0.1", PrefixLength: 24},
+				{MAC: "00:50:56:aa:bb:cc", IP: "10.0.1.1", PrefixLength: 24},
+			},
+			want: map[string][]IpEntry{
+				"00:50:56:9d:47:74": {{IP: "10.0.0.1", Prefix: 24}},
+				"00:50:56:aa:bb:cc": {{IP: "10.0.1.1", Prefix: 24}},
+			},
+		},
+		{
+			name: "nil guest networks and nil interfaces",
+			macs: []string{"00:50:56:9d:47:74"},
+			want: map[string][]IpEntry{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CollectIPsPerMac(tt.macs, tt.guestNetworks, tt.networkInterfaces)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CollectIPsPerMac() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCollectIPsPerMacLookupByCanonicalVCenterMAC pins the invariant that a
+// lookup keyed by the canonicalized vCenter MAC (as done in
+// migrate.createPortsForNetworks) always finds the collected IPs.
+func TestCollectIPsPerMacLookupByCanonicalVCenterMAC(t *testing.T) {
+	vcenterMAC := "00:50:56:9D:47:74" // vCenter may preserve manual-MAC case
+	macs := []string{CanonicalMAC(vcenterMAC)}
+	got := CollectIPsPerMac(macs, []vjailbreakv1alpha1.GuestNetwork{
+		{MAC: "00:50:56:9d:47:74", IP: "146.122.44.210", PrefixLength: 24},
+	}, nil)
+
+	entries, ok := got[macs[0]]
+	if !ok {
+		t.Fatalf("lookup by canonical vCenter MAC %q missed; keys: %v", macs[0], got)
+	}
+	if len(entries) != 1 || entries[0].IP != "146.122.44.210" {
+		t.Errorf("entries = %#v, want single entry 146.122.44.210", entries)
+	}
+}

--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -203,12 +203,11 @@ func (vmops *VMOps) GetVMInfo(ostype string, rdmDisks []string) (VMInfo, error) 
 	var mac []string
 	for _, device := range o.Config.Hardware.Device {
 		if nic, ok := device.(types.BaseVirtualEthernetCard); ok {
-			mac = append(mac, nic.GetVirtualEthernetCard().MacAddress)
+			// Canonical lowercase so IPperMac lookups by vminfo.Mac always hit,
+			// regardless of the case vCenter reports for manually-assigned MACs
+			mac = append(mac, CanonicalMAC(nic.GetVirtualEthernetCard().MacAddress))
 		}
 	}
-	// Get IP addresses of the VM from vmwaremachines
-	ips := []string{}
-	ipPerMac := make(map[string][]IpEntry)
 
 	// Get the vmware machine from k8s
 	vmk8sName, err := k8sutils.GetVMwareMachineName()
@@ -221,46 +220,7 @@ func (vmops *VMOps) GetVMInfo(ostype string, rdmDisks []string) (VMInfo, error) 
 		return VMInfo{}, fmt.Errorf("failed to get vmware machine: %s", err)
 	}
 
-	for _, macAddresss := range mac {
-		// Get the IPs from the vmware machine.
-		if vmwareMachine.Spec.VMInfo.GuestNetworks != nil {
-			for _, guestNetwork := range vmwareMachine.Spec.VMInfo.GuestNetworks {
-				// Every mac should have a corresponding IP, Ignore link layer ip
-				if strings.EqualFold(guestNetwork.MAC, macAddresss) {
-					if _, ok := ipPerMac[guestNetwork.MAC]; !ok {
-						ipPerMac[guestNetwork.MAC] = []IpEntry{}
-					}
-					if !strings.Contains(guestNetwork.IP, ":") {
-						ips = append(ips, guestNetwork.IP)
-						ipPerMac[guestNetwork.MAC] = append(ipPerMac[guestNetwork.MAC], IpEntry{
-							IP:     guestNetwork.IP,
-							Prefix: guestNetwork.PrefixLength,
-						})
-					}
-				}
-			}
-		} else {
-			if vmwareMachine.Spec.VMInfo.NetworkInterfaces != nil {
-				for _, networkInterface := range vmwareMachine.Spec.VMInfo.NetworkInterfaces {
-					if networkInterface.MAC == macAddresss {
-						if _, ok := ipPerMac[networkInterface.MAC]; !ok {
-							ipPerMac[networkInterface.MAC] = []IpEntry{}
-						}
-						for _, ipAddress := range networkInterface.IPAddress {
-							if strings.Contains(ipAddress, ":") {
-								continue
-							}
-							ips = append(ips, ipAddress)
-							ipPerMac[networkInterface.MAC] = append(ipPerMac[networkInterface.MAC], IpEntry{
-								IP:     ipAddress,
-								Prefix: 0,
-							})
-						}
-					}
-				}
-			}
-		}
-	}
+	ipPerMac := CollectIPsPerMac(mac, vmwareMachine.Spec.VMInfo.GuestNetworks, vmwareMachine.Spec.VMInfo.NetworkInterfaces)
 
 	vmdisks := []VMDisk{}
 	for _, device := range o.Config.Hardware.Device {


### PR DESCRIPTION
## Issue
During migration, the v2v-helper created Neutron ports with an empty IP list even though the IP was correctly detected and stored in the VMwareMachine resource. The port then fell back to DHCP, and on subnets with no free addresses the migration failed with `IpAddressGenerationFailure`.

## RCA

MAC address case mismatch between two sources:

- The **VMwareMachine CR** stores MACs in lowercase.
- **vCenter hardware config** preserves the case of manually-assigned MACs, so `vminfo.Mac` can contain uppercase (e.g. `00:50:56:9D:47:74`).

- `GetVMInfo` matched the two case-insensitively (`strings.EqualFold`) but keyed the `IPperMac` map with the CR's lowercase MAC, while port creation looked the map up with the vCenter uppercase MAC — the lookup missed and returned an empty IP list. The `NetworkInterfaces` fallback branch was worse: it compared MACs with case-sensitive `==` and would not match at all.

## Fix

Normalize MACs to canonical lowercase at every boundary

## Which issue(s) this PR fixes

fixes #2115 

## Testing done

caps in MAC:
<img width="1440" height="811" alt="image" src="https://github.com/user-attachments/assets/02e14c5c-1950-44a9-b608-fd495e991332" />
<img width="1091" height="157" alt="image" src="https://github.com/user-attachments/assets/55c16f95-c250-47d9-aa47-1adb77d6886c" />

before:
<img width="1440" height="811" alt="image" src="https://github.com/user-attachments/assets/8ec69c69-ce87-4ec1-a6ff-6a5126794c34" />

after:
<img width="1440" height="813" alt="image" src="https://github.com/user-attachments/assets/4f586bfe-674e-46fd-a1f4-6255c40733c3" />
