### PR TITLE
[2167] fix(v2v-helper): Install vendored libnbd with libnbd-devel

### DIFF
--- a/v2v-helper/Dockerfile
+++ b/v2v-helper/Dockerfile
@@ -13,8 +13,10 @@ ENV RELEASE_VERSION=$RELEASE_VERSION
 # - libnbd-devel: Development files for NBD (Network Block Device) support
 #   Installed from vendored fc44 RPM to match the runtime libnbd version exactly
 WORKDIR /tmp/rpms
-COPY v2v-helper/nbdkit/libnbd-devel-1.25.5-1.fc44.x86_64.rpm /tmp/rpms/
+COPY v2v-helper/nbdkit/libnbd-1.25.5-1.fc44.x86_64.rpm \
+     v2v-helper/nbdkit/libnbd-devel-1.25.5-1.fc44.x86_64.rpm /tmp/rpms/
 RUN dnf install -y golang \
+    ./libnbd-1.25.5-1.fc44.x86_64.rpm \
     ./libnbd-devel-1.25.5-1.fc44.x86_64.rpm && \
     dnf clean all && rm -rf /var/cache/dnf /var/cache/yum /tmp/rpms/
 


### PR DESCRIPTION
## What this PR does / why we need it
Copy and install the vendored `libnbd-1.25.5-1.fc44.x86_64.rpm` (already present in `v2v-helper/nbdkit/`) alongside `libnbd-devel` in the builder stage, so the exact-version dependency is satisfied from the command line regardless of repo state — same pattern the runtime stage uses.

## Which issue(s) this PR fixes
fixes #2167 


## Testing done
<img width="844" height="548" alt="image" src="https://github.com/user-attachments/assets/ce1a9fd6-2dd5-4642-8c7b-6d5c9a4346ce" />
