### PR TITLE
Refactoring boot partition detection 

### DIFF
--- a/scripts/get-bootable-partition.sh
+++ b/scripts/get-bootable-partition.sh
@@ -3,6 +3,7 @@
 # Prints the correct BIOS boot disk (the one containing GRUB MBR)
 # Works with LVM and /boot on a separate disk.
 # Assumes we are running inside a guestfish-mounted environment
+exec 3>&1 1>&2
 
 # Step 1: Identify all disks in guest
 # List block devices (assuming /dev/vda, /dev/sda, etc. are available)
@@ -99,4 +100,50 @@ if [ -z "$bootdisk" ]; then
 fi
 
 echo "[DEBUG] Result: bootdisk=$bootdisk" >&2
-echo "$bootdisk"
+
+fail() { echo "[ERROR] $1" >&2; exit 1; }
+
+# (a) Non-empty
+[ -n "$bootdisk" ] || fail "no bootable disk could be determined"
+
+# (b) Whole-disk device path (/dev/sda, /dev/vdb, ...), not a partition or junk
+echo "$bootdisk" | grep -qE '^/dev/[sv]d[a-z]$' || \
+  fail "resolved bootdisk '$bootdisk' is not a whole-disk device path"
+
+# (c) Real block device in this environment
+[ -b "$bootdisk" ] || fail "resolved bootdisk '$bootdisk' is not a block device"
+
+# (d) Appliance-disk guard
+if [ "$#" -gt 0 ]; then
+  # Caller passed the authoritative guest-disk list (libguestfs list-devices,
+  # which excludes the appliance's own disk); bootdisk must be one of them.
+  _match=false
+  for _gd in "$@"; do
+    [ "$bootdisk" = "$_gd" ] && { _match=true; break; }
+  done
+  $_match || fail "resolved bootdisk '$bootdisk' is not among guest disks ($*) - refusing to return the appliance disk"
+else
+  # No allowlist: a genuine guest boot disk backs part of the mounted guest OS,
+  # while the appliance's own disk backs nothing in this mount namespace.
+  _backed=$(
+    # direct partition/whole-disk mounts on this disk
+    mount 2>/dev/null | awk '{print $1}' | grep -E "^${bootdisk}[0-9]*$"
+    # LVM: PVs on this disk whose VG is actually mounted
+    if command -v pvs >/dev/null 2>&1 && mount 2>/dev/null | grep -q '/dev/mapper/'; then
+      _vgs=$(mount 2>/dev/null | awk '{print $1}' | grep '^/dev/mapper/' \
+             | while read -r _dm; do lvs --noheadings -o vg_name "$_dm" 2>/dev/null; done \
+             | tr -d ' ' | sort -u)
+      for _vg in $_vgs; do
+        pvs --noheadings -o pv_name,vg_name 2>/dev/null \
+          | awk -v vg="$_vg" '$2 == vg {print $1}' | grep -E "^${bootdisk}[0-9]*$"
+      done
+    fi
+  )
+  [ -n "$_backed" ] || \
+    fail "resolved bootdisk '$bootdisk' backs no mounted guest filesystem - likely the libguestfs appliance disk"
+fi
+
+echo "[DEBUG] Validation passed: bootdisk=$bootdisk" >&2
+
+# The one and only write to the caller's stdout channel.
+echo "$bootdisk" >&3

--- a/scripts/get-bootable-partition.sh
+++ b/scripts/get-bootable-partition.sh
@@ -101,49 +101,6 @@ fi
 
 echo "[DEBUG] Result: bootdisk=$bootdisk" >&2
 
-fail() { echo "[ERROR] $1" >&2; exit 1; }
-
-# (a) Non-empty
-[ -n "$bootdisk" ] || fail "no bootable disk could be determined"
-
-# (b) Whole-disk device path (/dev/sda, /dev/vdb, ...), not a partition or junk
-echo "$bootdisk" | grep -qE '^/dev/[sv]d[a-z]$' || \
-  fail "resolved bootdisk '$bootdisk' is not a whole-disk device path"
-
-# (c) Real block device in this environment
-[ -b "$bootdisk" ] || fail "resolved bootdisk '$bootdisk' is not a block device"
-
-# (d) Appliance-disk guard
-if [ "$#" -gt 0 ]; then
-  # Caller passed the authoritative guest-disk list (libguestfs list-devices,
-  # which excludes the appliance's own disk); bootdisk must be one of them.
-  _match=false
-  for _gd in "$@"; do
-    [ "$bootdisk" = "$_gd" ] && { _match=true; break; }
-  done
-  $_match || fail "resolved bootdisk '$bootdisk' is not among guest disks ($*) - refusing to return the appliance disk"
-else
-  # No allowlist: a genuine guest boot disk backs part of the mounted guest OS,
-  # while the appliance's own disk backs nothing in this mount namespace.
-  _backed=$(
-    # direct partition/whole-disk mounts on this disk
-    mount 2>/dev/null | awk '{print $1}' | grep -E "^${bootdisk}[0-9]*$"
-    # LVM: PVs on this disk whose VG is actually mounted
-    if command -v pvs >/dev/null 2>&1 && mount 2>/dev/null | grep -q '/dev/mapper/'; then
-      _vgs=$(mount 2>/dev/null | awk '{print $1}' | grep '^/dev/mapper/' \
-             | while read -r _dm; do lvs --noheadings -o vg_name "$_dm" 2>/dev/null; done \
-             | tr -d ' ' | sort -u)
-      for _vg in $_vgs; do
-        pvs --noheadings -o pv_name,vg_name 2>/dev/null \
-          | awk -v vg="$_vg" '$2 == vg {print $1}' | grep -E "^${bootdisk}[0-9]*$"
-      done
-    fi
-  )
-  [ -n "$_backed" ] || \
-    fail "resolved bootdisk '$bootdisk' backs no mounted guest filesystem - likely the libguestfs appliance disk"
-fi
-
-echo "[DEBUG] Validation passed: bootdisk=$bootdisk" >&2
-
-# The one and only write to the caller's stdout channel.
+# The one and only write to the caller's stdout channel; all diagnostics above
+# went to stderr (see 'exec 3>&1 1>&2' at the top).
 echo "$bootdisk" >&3

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1240,13 +1240,15 @@ func (migobj *Migrate) handleLinuxOSDetection(vminfo vm.VMInfo, bootVolumeIndex 
 		return -1, "", "", -1, errors.New("empty bootable partition from the script")
 	}
 
-	// Map the resolved boot device to its position among the guest disks via
-	// list-devices (which excludes the appliance's own disk and lists attached
-	// disks in VMDisks order). This is immune to where the appliance disk lands in
-	// the kernel enumeration, unlike device-index which counts it.
-	finalBootIndex, err = virtv2v.GuestDiskIndex(vminfo.VMDisks, ans)
+	index, err := virtv2v.RunCommandInGuestAllVolumes(vminfo.VMDisks, "device-index", false, strings.TrimSpace(ans))
 	if err != nil {
+		fmt.Printf("failed to run command (%s): %v: %s\n", index, err, strings.TrimSpace(index))
 		return -1, "", "", -1, err
+	}
+
+	finalBootIndex, err = strconv.Atoi(strings.TrimSpace(index))
+	if err != nil {
+		return -1, "", "", -1, errors.Wrap(err, "failed to convert bootable partition index to int")
 	}
 	migobj.logMessage(fmt.Sprintf("Bootable partition index: %d", finalBootIndex))
 

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1240,15 +1240,13 @@ func (migobj *Migrate) handleLinuxOSDetection(vminfo vm.VMInfo, bootVolumeIndex 
 		return -1, "", "", -1, errors.New("empty bootable partition from the script")
 	}
 
-	index, err := virtv2v.RunCommandInGuestAllVolumes(vminfo.VMDisks, "device-index", false, strings.TrimSpace(ans))
+	// Map the resolved boot device to its position among the guest disks via
+	// list-devices (which excludes the appliance's own disk and lists attached
+	// disks in VMDisks order). This is immune to where the appliance disk lands in
+	// the kernel enumeration, unlike device-index which counts it.
+	finalBootIndex, err = virtv2v.GuestDiskIndex(vminfo.VMDisks, ans)
 	if err != nil {
-		fmt.Printf("failed to run command (%s): %v: %s\n", index, err, strings.TrimSpace(index))
 		return -1, "", "", -1, err
-	}
-
-	finalBootIndex, err = strconv.Atoi(strings.TrimSpace(index))
-	if err != nil {
-		return -1, "", "", -1, errors.Wrap(err, "failed to convert bootable partition index to int")
 	}
 	migobj.logMessage(fmt.Sprintf("Bootable partition index: %d", finalBootIndex))
 

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1221,6 +1221,11 @@ func (migobj *Migrate) handleLinuxOSDetection(vminfo vm.VMInfo, bootVolumeIndex 
 	finalBootIndex = bootVolumeIndex
 	finalOsPath = osPath
 
+	// Nothing downstream is safe to index if there are no disks.
+	if len(vminfo.VMDisks) == 0 {
+		return -1, "", "", -1, errors.New("no disks present for VM; cannot detect boot disk")
+	}
+
 	// Run get-bootable-partition.sh script
 	var ans string
 	var cmdErr error
@@ -1247,13 +1252,22 @@ func (migobj *Migrate) handleLinuxOSDetection(vminfo vm.VMInfo, bootVolumeIndex 
 	}
 	migobj.logMessage(fmt.Sprintf("Bootable partition index: %d", finalBootIndex))
 
+	// device-index can resolve to the libguestfs appliance's own disk (a slot past
+	// the guest's disks). Fail the migration rather than indexing vminfo.VMDisks out
+	// of range (which would panic) or silently converting the wrong disk.
+	if finalBootIndex < 0 || finalBootIndex >= len(vminfo.VMDisks) {
+		return -1, "", "", -1, errors.Errorf(
+			"detected boot disk index %d is out of range for %d disk(s); aborting migration",
+			finalBootIndex, len(vminfo.VMDisks))
+	}
+
 	// Detect ESP for UEFI VMs
 	espDiskIndex = -1
 	if vminfo.UEFI {
 		detectedESPIndex, espErr := virtv2v.DetectESPDiskIndex(vminfo.VMDisks)
 		if espErr != nil {
 			migobj.logMessage(fmt.Sprintf("Error detecting ESP disk: %v", espErr))
-		} else if detectedESPIndex >= 0 {
+		} else if detectedESPIndex >= 0 && detectedESPIndex < len(vminfo.VMDisks) {
 			espDiskIndex = detectedESPIndex
 			migobj.logMessage(fmt.Sprintf("ESP detected on Disk %d: %s", espDiskIndex, vminfo.VMDisks[espDiskIndex].Name))
 		} else {
@@ -1328,10 +1342,23 @@ func (migobj *Migrate) handleWindowsBootDetection(vminfo vm.VMInfo, bootVolumeIn
 	var finalBootIndex int
 	var err error
 
+	if len(vminfo.VMDisks) == 0 {
+		return -1, "", errors.New("no disks present for VM; cannot detect boot disk")
+	}
+
 	utils.PrintLog("checking for bootable volume in case of LDM")
 	finalBootIndex, err = virtv2v.GetBootableVolumeIndex(vminfo.VMDisks)
 	if err != nil {
 		return -1, "", errors.Wrap(err, "Failed to get bootable volume index")
+	}
+
+	// Same guard as the Linux path: GetBootableVolumeIndex resolves via device-index,
+	// which can point at the libguestfs appliance disk (past the guest's disks).
+	// Fail the migration rather than indexing vminfo.VMDisks out of range.
+	if finalBootIndex < 0 || finalBootIndex >= len(vminfo.VMDisks) {
+		return -1, "", errors.Errorf(
+			"detected boot disk index %d is out of range for %d disk(s); aborting migration",
+			finalBootIndex, len(vminfo.VMDisks))
 	}
 
 	osRelease, err := virtv2v.GetWindowsVersion(vminfo.VMDisks, vminfo.VMDisks[finalBootIndex].Path)

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -16,7 +16,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -762,6 +761,27 @@ func RunCommandInGuestAllVolumes(disks []vm.VMDisk, command string, write bool, 
 	return strings.ToLower(stdoutBuf.String()), nil
 }
 
+// GuestDiskIndex returns the position of device within the guest disks reported
+// by libguestfs list-devices. Unlike device-index, list-devices excludes the
+// appliance's own disk and lists the attached disks in -a order (== vm.VMDisk
+// order), so the returned position is a valid VMDisks index regardless of where
+// the appliance disk lands in the kernel enumeration. Returns an error if device
+// is not one of the guest disks (e.g. the caller resolved the appliance disk).
+func GuestDiskIndex(disks []vm.VMDisk, device string) (int, error) {
+	out, err := RunCommandInGuestAllVolumes(disks, "list-devices", false)
+	if err != nil {
+		return -1, fmt.Errorf("failed to list guest devices: %w", err)
+	}
+	device = strings.TrimSpace(device)
+	guestDisks := strings.Fields(strings.TrimSpace(out))
+	for i, d := range guestDisks {
+		if d == device {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("resolved boot device %q is not among guest disks %v (likely the libguestfs appliance disk)", device, guestDisks)
+}
+
 // GetDeviceNumberFromPartition returns the device index for a given partition name
 func GetDeviceNumberFromPartition(disks []vm.VMDisk, partition string) (int, error) {
 	command := "part-to-dev"
@@ -786,13 +806,9 @@ func GetDeviceNumberFromPartition(disks []vm.VMDisk, partition string) (int, err
 	}
 
 	if strings.TrimSpace(bootable) == "true" {
-		command = "device-index"
-		index, err := RunCommandInGuestAllVolumes(disks, command, false, strings.TrimSpace(device))
-		if err != nil {
-			fmt.Printf("failed to run command (%s): %v: %s\n", index, err, strings.TrimSpace(index))
-			return -1, err
-		}
-		return strconv.Atoi(strings.TrimSpace(index))
+		// Map to a VMDisks index via list-devices position (excludes the appliance
+		// disk), not device-index which counts it and depends on enumeration order.
+		return GuestDiskIndex(disks, strings.TrimSpace(device))
 	}
 
 	return -1, errors.New("partition is not bootable")

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -16,6 +16,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -761,29 +762,6 @@ func RunCommandInGuestAllVolumes(disks []vm.VMDisk, command string, write bool, 
 	return strings.ToLower(stdoutBuf.String()), nil
 }
 
-/*
-GuestDiskIndex returns the position of device within the guest disks reported
-by libguestfs list-devices. Unlike device-index, list-devices excludes the
-appliance's own disk and lists the attached disks in -a order (== vm.VMDisk
-order), so the returned position is a valid VMDisks index regardless of where
-the appliance disk lands in the kernel enumeration. Returns an error if device
-is not one of the guest disks (e.g. the caller resolved the appliance disk).
-*/
-func GuestDiskIndex(disks []vm.VMDisk, device string) (int, error) {
-	out, err := RunCommandInGuestAllVolumes(disks, "list-devices", false)
-	if err != nil {
-		return -1, fmt.Errorf("failed to list guest devices: %w", err)
-	}
-	device = strings.TrimSpace(device)
-	guestDisks := strings.Fields(strings.TrimSpace(out))
-	for i, d := range guestDisks {
-		if d == device {
-			return i, nil
-		}
-	}
-	return -1, fmt.Errorf("resolved boot device %q is not among guest disks %v (likely the libguestfs appliance disk)", device, guestDisks)
-}
-
 // GetDeviceNumberFromPartition returns the device index for a given partition name
 func GetDeviceNumberFromPartition(disks []vm.VMDisk, partition string) (int, error) {
 	command := "part-to-dev"
@@ -808,9 +786,13 @@ func GetDeviceNumberFromPartition(disks []vm.VMDisk, partition string) (int, err
 	}
 
 	if strings.TrimSpace(bootable) == "true" {
-		// Map to a VMDisks index via list-devices position (excludes the appliance
-		// disk), not device-index which counts it and depends on enumeration order.
-		return GuestDiskIndex(disks, strings.TrimSpace(device))
+		command = "device-index"
+		index, err := RunCommandInGuestAllVolumes(disks, command, false, strings.TrimSpace(device))
+		if err != nil {
+			fmt.Printf("failed to run command (%s): %v: %s\n", index, err, strings.TrimSpace(index))
+			return -1, err
+		}
+		return strconv.Atoi(strings.TrimSpace(index))
 	}
 
 	return -1, errors.New("partition is not bootable")

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -761,12 +761,14 @@ func RunCommandInGuestAllVolumes(disks []vm.VMDisk, command string, write bool, 
 	return strings.ToLower(stdoutBuf.String()), nil
 }
 
-// GuestDiskIndex returns the position of device within the guest disks reported
-// by libguestfs list-devices. Unlike device-index, list-devices excludes the
-// appliance's own disk and lists the attached disks in -a order (== vm.VMDisk
-// order), so the returned position is a valid VMDisks index regardless of where
-// the appliance disk lands in the kernel enumeration. Returns an error if device
-// is not one of the guest disks (e.g. the caller resolved the appliance disk).
+/*
+GuestDiskIndex returns the position of device within the guest disks reported
+by libguestfs list-devices. Unlike device-index, list-devices excludes the
+appliance's own disk and lists the attached disks in -a order (== vm.VMDisk
+order), so the returned position is a valid VMDisks index regardless of where
+the appliance disk lands in the kernel enumeration. Returns an error if device
+is not one of the guest disks (e.g. the caller resolved the appliance disk).
+*/
 func GuestDiskIndex(disks []vm.VMDisk, device string) (int, error) {
 	out, err := RunCommandInGuestAllVolumes(disks, "list-devices", false)
 	if err != nil {


### PR DESCRIPTION
## What this PR does / why we need it

Adding safety checks to avoid runtime panics over out of bound values and improving logging mechanism for boot partition detection script"
command inside the guestfish appliance.

