### PR TITLE
[2173] Remove beta tag from Storage Accelerated Copy

### DIFF
--- a/ui/src/config/navigation.tsx
+++ b/ui/src/config/navigation.tsx
@@ -65,12 +65,7 @@ export const navigationItems: NavigationItem[] = [
       {
         id: 'array-credentials',
         label: 'Storage Array',
-        path: '/dashboard/storage-management',
-        badge: {
-          label: 'Beta',
-          color: 'warning',
-          variant: 'outlined'
-        }
+        path: '/dashboard/storage-management'
       },
       {
         id: 'esxi-ssh-keys',

--- a/ui/src/features/migration/steps/NetworkAndStorageMappingStep.tsx
+++ b/ui/src/features/migration/steps/NetworkAndStorageMappingStep.tsx
@@ -243,7 +243,7 @@ export default function NetworkAndStorageMappingStep({
                       value={option.value}
                       control={<Radio />}
                       label={
-                        option.value === 'StorageAcceleratedCopy' || option.value === 'HotAdd' ? (
+                        option.value === 'HotAdd' ? (
                           <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
                             <Box component="span">{option.label}</Box>
                             <Chip


### PR DESCRIPTION
## What this PR does / why we need it

Storage Accelerated Copy is no longer beta. Remove the Beta chip from the storage copy-method radio option and the Beta badge from the Storage Array credentials nav item. Hot-Add / vJailbreak Proxy VMs remain beta.


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #2173 

## Testing done
