### PR TITLE
[2175] UI patch call for proxy vm retry

### DIFF
--- a/ui/src/api/proxyvms/proxyVMs.ts
+++ b/ui/src/api/proxyvms/proxyVMs.ts
@@ -73,5 +73,9 @@ export const retryProxyVMVerification = async (
       annotations: { 'vjailbreak.k8s.pf9.io/force-reconcile': String(Date.now()) }
     }
   }
-  return axios.patch<ProxyVM>({ endpoint, data: patch })
+  return axios.patch<ProxyVM>({
+    endpoint,
+    data: patch,
+    config: { headers: { 'Content-Type': 'application/merge-patch+json' } }
+  })
 }


### PR DESCRIPTION
Sends the correct `application/merge-patch+json` content type on the proxy VM retry PATCH so re-verification is accepted by the Kubernetes API server.

fixes #2175


__Testing Done__ 

<img width="1440" height="784" alt="image" src="https://github.com/user-attachments/assets/ab0cb9a6-93fb-49f3-890f-9f582168ee7c" />
