### PR TITLE
Configure guest network incase of ubuntu for fallback to dhcp case

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1627,7 +1627,6 @@ func (migobj *Migrate) addUdevRulesForUbuntu(vminfo vm.VMInfo, bootVolumeIndex i
 	return nil
 }
 
-// configureRHELNetwork handles RHEL-specific network configuration
 func (migobj *Migrate) configureRHELNetwork(vminfo vm.VMInfo, bootVolumeIndex int, osRelease string) error {
 	versionID := parseVersionID(osRelease)
 	majorVersion, err := strconv.Atoi(strings.Split(versionID, ".")[0])
@@ -1638,7 +1637,7 @@ func (migobj *Migrate) configureRHELNetwork(vminfo vm.VMInfo, bootVolumeIndex in
 	if majorVersion < 7 {
 		diskPath := vminfo.VMDisks[bootVolumeIndex].Path
 		if err := DetectAndHandleNetwork(diskPath, osRelease, vminfo); err != nil {
-			utils.PrintLog(fmt.Sprintf(`Warning: Failed to handle network: %v,Continuing with migration, 
+			utils.PrintLog(fmt.Sprintf(`Warning: Failed to handle network: %v,Continuing with migration,
                     network might not come up post migration, please check the network configuration post migration`, err))
 		}
 	}
@@ -2392,6 +2391,7 @@ func (migobj *Migrate) createPortsForNetworks(ctx context.Context, vminfo *vm.VM
 		if err != nil {
 			return nil, nil, nil, err
 		}
+		syncIPperMacFromPort(vminfo, mac, port)
 
 		networkids = append(networkids, network.ID)
 		portids = append(portids, port.ID)
@@ -2502,15 +2502,62 @@ func applyPreserveIPOverride(vminfo *vm.VMInfo, idx int, mac string, override ni
 	return detectedIPs
 }
 
-// applyPreserveMACOverride copies mac's IPs to the "" key and returns "" so
-// OpenStack generates a new MAC, when preserveMAC is false.
+// applyPreserveMACOverride moves mac's IPs to the "" key and returns "" so
+// OpenStack generates a new MAC, when preserveMAC is false. The real MAC
+// OpenStack assigns isn't known yet at this point in the flow — see
+// syncIPperMacFromPort, which re-keys "" to the real MAC once the port is
+// created.
 func applyPreserveMACOverride(vminfo *vm.VMInfo, idx int, mac string, preserveMAC bool) string {
 	if preserveMAC {
 		return mac
 	}
 	utils.PrintLog(fmt.Sprintf("NIC[%d]: preserveMAC=false for MAC %s — OpenStack will generate a new MAC", idx, mac))
 	vminfo.IPperMac[""] = vminfo.IPperMac[mac]
+	delete(vminfo.IPperMac, mac)
 	return ""
+}
+
+// syncIPperMacFromPort reconciles vminfo.IPperMac with the port OpenStack
+// actually created, keyed by placeholderMAC (the MAC passed to createPort:
+// the original MAC if preserveMAC=true, or "" if preserveMAC=false). Two
+// situations need reconciling once the real port exists:
+//
+//   - preserveMAC=false: OpenStack assigns a new MAC, but the entry is still
+//     sitting under the "" placeholder key. It's moved as-is to the real
+//     MAC (port.MACAddress) so MAC-keyed guest-config code (AddWildcardNetplan,
+//     the network-persistence script) can match it against the real NIC.
+//   - preserveIP=false + fallbackToDHCP=true: applyPreserveIPOverride left
+//     the entry nil so OpenStack would auto-allocate an IP instead of
+//     getting an explicit empty port. That nil is filled in with whatever
+//     IP(s) the port actually ended up with (possibly none, e.g. on an
+//     L2 network with no subnets).
+//
+// A NIC whose entries were already populated (preserveIP=true, or a custom
+// IP) is left untouched by the fill step: the port was created with exactly
+// that IP, so rebuilding from port.FixedIPs would risk losing a preserved
+// subnet prefix for no benefit.
+func syncIPperMacFromPort(vminfo *vm.VMInfo, placeholderMAC string, port *ports.Port) {
+	realMAC := port.MACAddress
+	if realMAC == "" {
+		// Defensive: don't lose the entry if a backend ever fails to echo a MAC.
+		realMAC = placeholderMAC
+	}
+
+	if realMAC != placeholderMAC {
+		vminfo.IPperMac[realMAC] = vminfo.IPperMac[placeholderMAC]
+		delete(vminfo.IPperMac, placeholderMAC)
+	}
+
+	if vminfo.IPperMac[realMAC] == nil {
+		// These IPs came from a live OpenStack auto-allocation, not a
+		// preserved/custom static IP — mark them so guest-config writers
+		// configure a real DHCP client instead of pinning the IP statically.
+		entries := make([]vm.IpEntry, 0, len(port.FixedIPs))
+		for _, fixedIP := range port.FixedIPs {
+			entries = append(entries, vm.IpEntry{IP: fixedIP.IPAddress, Prefix: 0, DHCP: true})
+		}
+		vminfo.IPperMac[realMAC] = entries
+	}
 }
 
 // LogMessage is an exported wrapper for logMessage that satisfies the esxissh.ProgressLogger interface.

--- a/v2v-helper/migrate/migrate_network_override_test.go
+++ b/v2v-helper/migrate/migrate_network_override_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
 	"github.com/platform9/vjailbreak/v2v-helper/vm"
 )
 
@@ -108,5 +109,150 @@ func TestApplyPreserveIPOverride_EmptySliceVsNilDistinctionMatters(t *testing.T)
 	applyPreserveIPOverride(vminfoDHCPOn, 0, mac, nicOverride{preserveIP: false}, nil, true)
 	if vminfoDHCPOn.IPperMac[mac] != nil {
 		t.Fatalf("fallbackToDHCP=true must produce a nil slice, got %#v", vminfoDHCPOn.IPperMac[mac])
+	}
+}
+
+// TestApplyPreserveMACOverride_RemovesStaleOriginalKey asserts that once the
+// entries are moved to the "" placeholder key, the original MAC key is
+// deleted rather than left behind holding a stale, unused copy.
+func TestApplyPreserveMACOverride_RemovesStaleOriginalKey(t *testing.T) {
+	const mac = "aa:bb:cc:dd:ee:ff"
+	vminfo := &vm.VMInfo{IPperMac: map[string][]vm.IpEntry{mac: {{IP: "10.0.0.5", Prefix: 24}}}}
+
+	got := applyPreserveMACOverride(vminfo, 0, mac, false)
+
+	if got != "" {
+		t.Fatalf("expected placeholder MAC \"\", got %q", got)
+	}
+	if _, exists := vminfo.IPperMac[mac]; exists {
+		t.Fatalf("expected original MAC key %q to be removed, still present: %#v", mac, vminfo.IPperMac[mac])
+	}
+	want := []vm.IpEntry{{IP: "10.0.0.5", Prefix: 24}}
+	if !reflect.DeepEqual(vminfo.IPperMac[""], want) {
+		t.Fatalf("IPperMac[\"\"] = %#v, want %#v", vminfo.IPperMac[""], want)
+	}
+}
+
+// TestSyncIPperMacFromPort covers reconciling vminfo.IPperMac with the
+// port OpenStack actually created, for the cases that need it: a MAC that
+// changed (preserveMAC=false), an IP that was left nil for OpenStack to
+// auto-allocate (preserveIP=false + fallbackToDHCP=true), both at once, and
+// the no-op case where nothing needs reconciling.
+func TestSyncIPperMacFromPort(t *testing.T) {
+	tests := []struct {
+		name           string
+		placeholderMAC string
+		initial        map[string][]vm.IpEntry
+		port           *ports.Port
+		wantIPperMac   map[string][]vm.IpEntry
+	}{
+		{
+			name:           "preserve everything, no error: already correct, left untouched (prefix preserved)",
+			placeholderMAC: "aa:bb:cc:dd:ee:ff",
+			initial: map[string][]vm.IpEntry{
+				"aa:bb:cc:dd:ee:ff": {{IP: "10.0.0.5", Prefix: 16}},
+			},
+			port: &ports.Port{
+				MACAddress: "aa:bb:cc:dd:ee:ff",
+				FixedIPs:   []ports.IP{{IPAddress: "10.0.0.5"}},
+			},
+			wantIPperMac: map[string][]vm.IpEntry{
+				"aa:bb:cc:dd:ee:ff": {{IP: "10.0.0.5", Prefix: 16}},
+			},
+		},
+		{
+			name:           "preserveMAC=false, preserveIP=true: rekeyed to real MAC, prefix preserved",
+			placeholderMAC: "",
+			initial: map[string][]vm.IpEntry{
+				"": {{IP: "10.0.0.5", Prefix: 16}},
+			},
+			port: &ports.Port{
+				MACAddress: "fa:16:3e:11:22:33",
+				FixedIPs:   []ports.IP{{IPAddress: "10.0.0.5"}},
+			},
+			wantIPperMac: map[string][]vm.IpEntry{
+				"fa:16:3e:11:22:33": {{IP: "10.0.0.5", Prefix: 16}},
+			},
+		},
+		{
+			name:           "preserveIP=false, fallbackToDHCP=true, preserveMAC=true: nil filled from port.FixedIPs",
+			placeholderMAC: "aa:bb:cc:dd:ee:ff",
+			initial: map[string][]vm.IpEntry{
+				"aa:bb:cc:dd:ee:ff": nil,
+			},
+			port: &ports.Port{
+				MACAddress: "aa:bb:cc:dd:ee:ff",
+				FixedIPs:   []ports.IP{{IPAddress: "192.168.50.77"}},
+			},
+			wantIPperMac: map[string][]vm.IpEntry{
+				"aa:bb:cc:dd:ee:ff": {{IP: "192.168.50.77", Prefix: 0, DHCP: true}},
+			},
+		},
+		{
+			name:           "preserveIP=false, fallbackToDHCP=true, preserveMAC=false: rekey and fill together",
+			placeholderMAC: "",
+			initial: map[string][]vm.IpEntry{
+				"": nil,
+			},
+			port: &ports.Port{
+				MACAddress: "fa:16:3e:aa:bb:cc",
+				FixedIPs:   []ports.IP{{IPAddress: "192.168.50.77"}},
+			},
+			wantIPperMac: map[string][]vm.IpEntry{
+				"fa:16:3e:aa:bb:cc": {{IP: "192.168.50.77", Prefix: 0, DHCP: true}},
+			},
+		},
+		{
+			name:           "preserveIP=false, fallbackToDHCP=true, L2 network: no FixedIPs, stays empty (not nil) so AddWildcardNetplan still skips it",
+			placeholderMAC: "",
+			initial: map[string][]vm.IpEntry{
+				"": nil,
+			},
+			port: &ports.Port{
+				MACAddress: "fa:16:3e:dd:ee:ff",
+				FixedIPs:   []ports.IP{},
+			},
+			wantIPperMac: map[string][]vm.IpEntry{
+				"fa:16:3e:dd:ee:ff": {},
+			},
+		},
+		{
+			name:           "preserveIP=false, fallbackToDHCP=false: explicit empty slice is left untouched, not treated as nil",
+			placeholderMAC: "aa:bb:cc:dd:ee:ff",
+			initial: map[string][]vm.IpEntry{
+				"aa:bb:cc:dd:ee:ff": {},
+			},
+			port: &ports.Port{
+				MACAddress: "aa:bb:cc:dd:ee:ff",
+				FixedIPs:   []ports.IP{},
+			},
+			wantIPperMac: map[string][]vm.IpEntry{
+				"aa:bb:cc:dd:ee:ff": {},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vminfo := &vm.VMInfo{IPperMac: tt.initial}
+
+			syncIPperMacFromPort(vminfo, tt.placeholderMAC, tt.port)
+
+			if len(vminfo.IPperMac) != len(tt.wantIPperMac) {
+				t.Fatalf("IPperMac has %d keys, want %d: got %#v", len(vminfo.IPperMac), len(tt.wantIPperMac), vminfo.IPperMac)
+			}
+			for wantMAC, wantEntries := range tt.wantIPperMac {
+				gotEntries, ok := vminfo.IPperMac[wantMAC]
+				if !ok {
+					t.Fatalf("expected key %q to be present, IPperMac=%#v", wantMAC, vminfo.IPperMac)
+				}
+				if gotEntries == nil {
+					t.Fatalf("IPperMac[%q] is nil, want non-nil %#v (nil vs empty-slice matters downstream)", wantMAC, wantEntries)
+				}
+				if !reflect.DeepEqual(gotEntries, wantEntries) {
+					t.Fatalf("IPperMac[%q] = %#v, want %#v", wantMAC, gotEntries, wantEntries)
+				}
+			}
+		})
 	}
 }

--- a/v2v-helper/pkg/utils/openstackopsutils.go
+++ b/v2v-helper/pkg/utils/openstackopsutils.go
@@ -812,9 +812,14 @@ func (osclient *OpenStackClients) CreatePortWithDHCP(ctx context.Context, networ
 		if err != nil {
 			return nil, fmt.Errorf("subnet not found for IP %s", iAddr.IPAddress)
 		}
+		// This IP came from a live DHCP fallback (the preferred static IP
+		// didn't fit the target subnet), not a preserved/custom static IP —
+		// mark it so guest-config writers configure a real DHCP client
+		// instead of pinning it statically.
 		ipPerMac[mac] = append(ipPerMac[mac], vm.IpEntry{
 			IP:     iAddr.IPAddress,
 			Prefix: 0,
+			DHCP:   true,
 		})
 		gatewayIP[mac] = dhcpSubnetId.GatewayIP
 	}

--- a/v2v-helper/pkg/utils/openstackopsutils_test.go
+++ b/v2v-helper/pkg/utils/openstackopsutils_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/ports"
+	"github.com/platform9/vjailbreak/v2v-helper/vm"
 )
 
 // TestIsHotplugFlavor verifies that hotplug intent is inferred solely from the
@@ -270,6 +271,74 @@ func TestGetCreateOpts_NilIPEntries_L2NetworkWithNoSubnets(t *testing.T) {
 	}
 	if _, ok := gatewayIP["aa:bb:cc:dd:ee:ff"]; ok {
 		t.Fatalf("expected no gateway to be recorded for a subnet-less L2 network, got: %v", gatewayIP)
+	}
+}
+
+// TestCreatePortWithDHCP_MarksEntriesAsDHCP verifies that the IP(s) it pulls
+// back from the created port are marked IpEntry.DHCP=true. These IPs came
+// from a live Neutron allocation (the preferred static IP didn't fit the
+// target subnet), not a preserved/custom static IP, so guest-config code
+// must configure a real DHCP client for them instead of pinning them
+// statically (see buildWildcardNetplanYAML in v2v-helper/virtv2v).
+func TestCreatePortWithDHCP_MarksEntriesAsDHCP(t *testing.T) {
+	const networkID = "net-1"
+	const subnetID = "subnet-1"
+	const mac = "aa:bb:cc:dd:ee:ff"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/networks/"+networkID):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"network": map[string]any{"id": networkID, "tags": []string{}},
+			})
+		case strings.Contains(r.URL.Path, "/subnets/"+subnetID):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"subnet": map[string]any{
+					"id":         subnetID,
+					"cidr":       "192.168.50.0/24",
+					"gateway_ip": "192.168.50.1",
+				},
+			})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/ports"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"port": map[string]any{
+					"id":          "port-1",
+					"mac_address": mac,
+					"fixed_ips": []map[string]any{
+						{"ip_address": "192.168.50.77", "subnet_id": subnetID},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := &OpenStackClients{NetworkingClient: newTestNetworkingClient(srv)}
+	network := &networks.Network{ID: networkID, Subnets: []string{subnetID}}
+	ipPerMac := map[string][]vm.IpEntry{
+		mac: {{IP: "10.0.0.5", Prefix: 24}}, // the static IP that didn't fit, about to be replaced
+	}
+	gatewayIP := map[string]string{}
+	createOpts := ports.CreateOpts{Name: "port-test", NetworkID: networkID}
+
+	port, err := client.CreatePortWithDHCP(t.Context(), network, ipPerMac, mac, gatewayIP, createOpts)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if port.ID != "port-1" {
+		t.Fatalf("expected port-1, got: %s", port.ID)
+	}
+
+	want := []vm.IpEntry{{IP: "192.168.50.77", Prefix: 0, DHCP: true}}
+	got := ipPerMac[mac]
+	if len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("ipPerMac[mac] = %#v, want %#v (DHCP must be true for a live Neutron allocation)", got, want)
+	}
+	if gatewayIP[mac] != "192.168.50.1" {
+		t.Fatalf("gatewayIP[mac] = %q, want %q", gatewayIP[mac], "192.168.50.1")
 	}
 }
 

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -615,6 +615,15 @@ func AddWildcardNetplanForL2(disks []vm.VMDisk, diskPath string) error {
 // keep the existing `dhcp4: false` + explicit `addresses:` behavior. A MAC
 // with both (uncommon, e.g. one preserved IP plus one DHCP-fallback IP on
 // the same NIC) gets both stanzas together.
+//
+// A MAC's `routes:`/`nameservers:` are only written when it has at least one
+// static entry — they're only meaningful alongside a static address we
+// determined ourselves. A purely DHCP-sourced MAC (no static entries at all)
+// gets neither: the DHCP client owns the gateway and DNS entirely, so
+// writing our own default route on top would fight with (or go stale
+// relative to) whatever the lease actually provides, and any carried-over
+// DNS servers come from the source VM's original network, which may not
+// even be reachable from the target network.
 func buildWildcardNetplanYAML(guestNetworks []vjailbreakv1alpha1.GuestNetwork, gatewayIP map[string]string, ipPerMac map[string][]vm.IpEntry) string {
 	macToIPs := ipPerMac
 	macToDNS := make(map[string][]string)
@@ -662,6 +671,14 @@ func buildWildcardNetplanYAML(guestNetworks []vjailbreakv1alpha1.GuestNetwork, g
 		} else {
 			b.WriteString("      dhcp4: false\n")
 		}
+		// Gateway and DNS are only meaningful alongside a static address we
+		// determined ourselves (preserved or custom IP). A MAC with no
+		// static entries is purely DHCP-sourced, so the DHCP client owns
+		// the gateway and DNS entirely — writing our own routes/nameservers
+		// on top would fight with (or go stale relative to) whatever the
+		// DHCP lease actually provides, and any carried-over DNS servers
+		// here come from the source VM's original network, which may not
+		// even be reachable from the target network.
 		if len(staticEntries) > 0 {
 			b.WriteString("      addresses:\n")
 			for _, e := range staticEntries {
@@ -672,21 +689,21 @@ func buildWildcardNetplanYAML(guestNetworks []vjailbreakv1alpha1.GuestNetwork, g
 				}
 				b.WriteString(fmt.Sprintf("        - %s/%d\n", e.IP, prefix))
 			}
-		}
-		if gateway, ok := gatewayIP[mac]; ok && gateway != "" {
-			if !routesAdded {
-				log.Printf("Writing default routes")
-				b.WriteString("      routes:\n")
-				b.WriteString("        - to: default\n")
-				b.WriteString(fmt.Sprintf("          via: %s\n", gateway))
-				routesAdded = true
+			if gateway, ok := gatewayIP[mac]; ok && gateway != "" {
+				if !routesAdded {
+					log.Printf("Writing default routes")
+					b.WriteString("      routes:\n")
+					b.WriteString("        - to: default\n")
+					b.WriteString(fmt.Sprintf("          via: %s\n", gateway))
+					routesAdded = true
+				}
 			}
-		}
-		if dns, ok := macToDNS[mac]; ok && len(dns) > 0 {
-			b.WriteString("      nameservers:\n")
-			b.WriteString("        addresses:\n")
-			for _, d := range dns {
-				b.WriteString(fmt.Sprintf("          - %s\n", d))
+			if dns, ok := macToDNS[mac]; ok && len(dns) > 0 {
+				b.WriteString("      nameservers:\n")
+				b.WriteString("        addresses:\n")
+				for _, d := range dns {
+					b.WriteString(fmt.Sprintf("          - %s\n", d))
+				}
 			}
 		}
 		idx++

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -600,8 +600,22 @@ func AddWildcardNetplanForL2(disks []vm.VMDisk, diskPath string) error {
 
 }
 
-func AddWildcardNetplan(disks []vm.VMDisk, diskPath string, guestNetworks []vjailbreakv1alpha1.GuestNetwork, gatewayIP map[string]string, ipPerMac map[string][]vm.IpEntry) error {
-	// Add wildcard to netplan
+// buildWildcardNetplanYAML constructs the netplan YAML written by
+// AddWildcardNetplan, split out as a pure function so the DHCP-vs-static
+// decision can be unit tested without touching a guest disk.
+//
+// For each MAC, entries are partitioned into DHCP-sourced ones (IpEntry.DHCP
+// == true — a live OpenStack/Neutron auto-allocation, e.g. fallback-to-DHCP
+// or a subnet-mismatch DHCP fallback) and static ones (a preserved or
+// user-assigned IP). DHCP-sourced entries get `dhcp4: true` so the guest
+// actually performs a DHCP handshake — pinning that IP as a static address
+// instead would leave some networks unreachable despite Neutron holding the
+// right fixed_ip, since port security on some backends ties the IP-to-port
+// binding to an observed lease, not just a fixed_ip match. Static entries
+// keep the existing `dhcp4: false` + explicit `addresses:` behavior. A MAC
+// with both (uncommon, e.g. one preserved IP plus one DHCP-fallback IP on
+// the same NIC) gets both stanzas together.
+func buildWildcardNetplanYAML(guestNetworks []vjailbreakv1alpha1.GuestNetwork, gatewayIP map[string]string, ipPerMac map[string][]vm.IpEntry) string {
 	macToIPs := ipPerMac
 	macToDNS := make(map[string][]string)
 	if len(guestNetworks) > 0 {
@@ -629,19 +643,35 @@ func AddWildcardNetplan(disks []vm.VMDisk, diskPath string, guestNetworks []vjai
 		if len(entries) == 0 {
 			continue
 		}
+		var staticEntries []vm.IpEntry
+		useDHCP := false
+		for _, e := range entries {
+			if e.DHCP {
+				useDHCP = true
+			} else {
+				staticEntries = append(staticEntries, e)
+			}
+		}
+
 		id := fmt.Sprintf("vj%d", idx)
 		b.WriteString(fmt.Sprintf("    %s:\n", id))
 		b.WriteString("      match:\n")
 		b.WriteString(fmt.Sprintf("        macaddress: %s\n", mac))
-		b.WriteString("      dhcp4: false\n")
-		b.WriteString("      addresses:\n")
-		for _, e := range entries {
-			// default prefix to 24 if zero
-			prefix := e.Prefix
-			if prefix == 0 {
-				prefix = 24
+		if useDHCP {
+			b.WriteString("      dhcp4: true\n")
+		} else {
+			b.WriteString("      dhcp4: false\n")
+		}
+		if len(staticEntries) > 0 {
+			b.WriteString("      addresses:\n")
+			for _, e := range staticEntries {
+				// default prefix to 24 if zero
+				prefix := e.Prefix
+				if prefix == 0 {
+					prefix = 24
+				}
+				b.WriteString(fmt.Sprintf("        - %s/%d\n", e.IP, prefix))
 			}
-			b.WriteString(fmt.Sprintf("        - %s/%d\n", e.IP, prefix))
 		}
 		if gateway, ok := gatewayIP[mac]; ok && gateway != "" {
 			if !routesAdded {
@@ -664,7 +694,11 @@ func AddWildcardNetplan(disks []vm.VMDisk, diskPath string, guestNetworks []vjai
 	if !routesAdded {
 		log.Println("WARNING: No gateway found")
 	}
-	netplanYAML := b.String()
+	return b.String()
+}
+
+func AddWildcardNetplan(disks []vm.VMDisk, diskPath string, guestNetworks []vjailbreakv1alpha1.GuestNetwork, gatewayIP map[string]string, ipPerMac map[string][]vm.IpEntry) error {
+	netplanYAML := buildWildcardNetplanYAML(guestNetworks, gatewayIP, ipPerMac)
 	log.Printf("NETPLAN YAML : %s", netplanYAML)
 	// Create the netplan file
 	err := os.WriteFile("/home/fedora/99-wildcard.network", []byte(netplanYAML), 0644)

--- a/v2v-helper/virtv2v/virtv2vops_test.go
+++ b/v2v-helper/virtv2v/virtv2vops_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/platform9/vjailbreak/v2v-helper/vm"
 )
 
 // ---------------------------------------------------------------------------
@@ -311,4 +313,197 @@ func TestConvertDisk_BlockDriverArg(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// buildWildcardNetplanYAML – DHCP-vs-static decision
+//
+// IpEntry.DHCP distinguishes an IP that came from a live OpenStack/Neutron
+// auto-allocation (fallback-to-DHCP, or a subnet-mismatch DHCP fallback)
+// from a preserved/custom static IP. DHCP-sourced entries must get a real
+// dhcp4: true so the guest performs an actual DHCP handshake instead of
+// having the IP pinned statically — some networks tie the IP-to-port
+// binding to an observed lease, so a static pin that never went through
+// DORA can leave the guest unreachable even though Neutron's port record is
+// correct.
+// ---------------------------------------------------------------------------
+
+func TestBuildWildcardNetplanYAML_StaticEntry(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {{IP: "10.0.0.5", Prefix: 24}},
+	}
+
+	yaml := buildWildcardNetplanYAML(nil, map[string]string{}, ipPerMac)
+
+	assert.Contains(t, yaml, "macaddress: aa:bb:cc:dd:ee:ff")
+	assert.Contains(t, yaml, "dhcp4: false", "static entry must get dhcp4: false")
+	assert.NotContains(t, yaml, "dhcp4: true", "static-only entry must not get dhcp4: true")
+	assert.Contains(t, yaml, "- 10.0.0.5/24", "static entry must be written as an address")
+}
+
+func TestBuildWildcardNetplanYAML_DHCPEntry(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {{IP: "192.168.50.77", Prefix: 0, DHCP: true}},
+	}
+
+	yaml := buildWildcardNetplanYAML(nil, map[string]string{}, ipPerMac)
+
+	assert.Contains(t, yaml, "dhcp4: true", "DHCP-sourced entry must get dhcp4: true")
+	assert.NotContains(t, yaml, "dhcp4: false", "DHCP-only entry must not get dhcp4: false")
+	assert.NotContains(t, yaml, "addresses:", "DHCP-only entry must not get a static addresses: block")
+	assert.NotContains(t, yaml, "192.168.50.77", "DHCP-sourced IP must not be pinned as a static address")
+}
+
+func TestBuildWildcardNetplanYAML_MixedEntries(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {
+			{IP: "10.0.0.5", Prefix: 24},
+			{IP: "192.168.50.77", Prefix: 0, DHCP: true},
+		},
+	}
+
+	yaml := buildWildcardNetplanYAML(nil, map[string]string{}, ipPerMac)
+
+	assert.Contains(t, yaml, "dhcp4: true", "any DHCP-sourced entry on the NIC should trigger dhcp4: true")
+	assert.Contains(t, yaml, "- 10.0.0.5/24", "the static entry should still be written as an address")
+	assert.NotContains(t, yaml, "192.168.50.77", "the DHCP-sourced entry must not appear under addresses:")
+}
+
+func TestBuildWildcardNetplanYAML_EmptyEntriesSkipped(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {},
+	}
+
+	yaml := buildWildcardNetplanYAML(nil, map[string]string{}, ipPerMac)
+
+	assert.NotContains(t, yaml, "aa:bb:cc:dd:ee:ff", "a MAC with zero entries must get no ethernet stanza")
+}
+
+func TestBuildWildcardNetplanYAML_GatewayUnaffectedByDHCPFlag(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {{IP: "192.168.50.77", Prefix: 0, DHCP: true}},
+	}
+	gatewayIP := map[string]string{"aa:bb:cc:dd:ee:ff": "192.168.50.1"}
+
+	yaml := buildWildcardNetplanYAML(nil, gatewayIP, ipPerMac)
+
+	assert.Contains(t, yaml, "via: 192.168.50.1", "gateway route must still be written for a DHCP-sourced entry")
+}
+
+// ---------------------------------------------------------------------------
+// buildRHELIfcfgFiles / buildRHELNetworkManagerKeyfiles – RHEL 7+ guest
+// network configuration (ifcfg / NetworkManager keyfile equivalents of
+// buildWildcardNetplanYAML). Same DHCP-vs-static contract: DHCP-sourced
+// entries must get a real DHCP client config (BOOTPROTO=dhcp / method=auto),
+// static entries get a pinned IP.
+// ---------------------------------------------------------------------------
+
+func TestBuildRHELIfcfgFiles_StaticEntry(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {{IP: "10.0.0.5", Prefix: 24}},
+	}
+
+	files := buildRHELIfcfgFiles(ipPerMac, map[string]string{}, map[string][]string{})
+
+	content, ok := files["ifcfg-vjb0"]
+	assert.True(t, ok, "expected ifcfg-vjb0 to be generated, got files: %#v", files)
+	assert.Contains(t, content, "HWADDR=aa:bb:cc:dd:ee:ff")
+	assert.Contains(t, content, "BOOTPROTO=none", "static entry must get BOOTPROTO=none")
+	assert.NotContains(t, content, "BOOTPROTO=dhcp", "static-only entry must not get BOOTPROTO=dhcp")
+	assert.Contains(t, content, "IPADDR=10.0.0.5")
+	assert.Contains(t, content, "PREFIX=24")
+}
+
+func TestBuildRHELIfcfgFiles_DHCPEntry(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {{IP: "192.168.50.77", Prefix: 0, DHCP: true}},
+	}
+
+	files := buildRHELIfcfgFiles(ipPerMac, map[string]string{}, map[string][]string{})
+
+	content := files["ifcfg-vjb0"]
+	assert.Contains(t, content, "BOOTPROTO=dhcp", "DHCP-sourced entry must get BOOTPROTO=dhcp")
+	assert.NotContains(t, content, "BOOTPROTO=none", "DHCP-only entry must not get BOOTPROTO=none")
+	assert.NotContains(t, content, "IPADDR=", "DHCP-sourced IP must not be pinned as a static IPADDR")
+}
+
+func TestBuildRHELIfcfgFiles_MixedEntries(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {
+			{IP: "10.0.0.5", Prefix: 24},
+			{IP: "192.168.50.77", Prefix: 0, DHCP: true},
+		},
+	}
+
+	files := buildRHELIfcfgFiles(ipPerMac, map[string]string{}, map[string][]string{})
+
+	content := files["ifcfg-vjb0"]
+	assert.Contains(t, content, "BOOTPROTO=dhcp", "any DHCP-sourced entry on the NIC should trigger BOOTPROTO=dhcp")
+	assert.NotContains(t, content, "IPADDR=10.0.0.5", "static entry must not be written when the MAC is treated as DHCP overall")
+}
+
+func TestBuildRHELIfcfgFiles_MultipleStaticIPsNumbered(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {
+			{IP: "10.0.0.5", Prefix: 24},
+			{IP: "10.0.0.6", Prefix: 24},
+		},
+	}
+
+	files := buildRHELIfcfgFiles(ipPerMac, map[string]string{"aa:bb:cc:dd:ee:ff": "10.0.0.1"}, map[string][]string{})
+
+	content := files["ifcfg-vjb0"]
+	assert.Contains(t, content, "IPADDR=10.0.0.5")
+	assert.Contains(t, content, "PREFIX=24")
+	assert.Contains(t, content, "IPADDR1=10.0.0.6")
+	assert.Contains(t, content, "PREFIX1=24")
+	assert.Contains(t, content, "GATEWAY=10.0.0.1")
+}
+
+func TestBuildRHELIfcfgFiles_EmptyEntriesSkipped(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {},
+	}
+
+	files := buildRHELIfcfgFiles(ipPerMac, map[string]string{}, map[string][]string{})
+
+	assert.Empty(t, files, "a MAC with zero entries must get no ifcfg file")
+}
+
+func TestBuildRHELNetworkManagerKeyfiles_StaticEntry(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {{IP: "10.0.0.5", Prefix: 24}},
+	}
+
+	files := buildRHELNetworkManagerKeyfiles(ipPerMac, map[string]string{"aa:bb:cc:dd:ee:ff": "10.0.0.1"}, map[string][]string{})
+
+	content, ok := files["vjb0.nmconnection"]
+	assert.True(t, ok, "expected vjb0.nmconnection to be generated, got files: %#v", files)
+	assert.Contains(t, content, "mac-address=aa:bb:cc:dd:ee:ff")
+	assert.Contains(t, content, "method=manual", "static entry must get method=manual")
+	assert.NotContains(t, content, "method=auto", "static-only entry must not get method=auto")
+	assert.Contains(t, content, "address1=10.0.0.5/24,10.0.0.1")
+}
+
+func TestBuildRHELNetworkManagerKeyfiles_DHCPEntry(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {{IP: "192.168.50.77", Prefix: 0, DHCP: true}},
+	}
+
+	files := buildRHELNetworkManagerKeyfiles(ipPerMac, map[string]string{}, map[string][]string{})
+
+	content := files["vjb0.nmconnection"]
+	assert.Contains(t, content, "method=auto", "DHCP-sourced entry must get method=auto")
+	assert.NotContains(t, content, "method=manual", "DHCP-only entry must not get method=manual")
+	assert.NotContains(t, content, "address1=", "DHCP-sourced IP must not be pinned as a static address")
+}
+
+func TestBuildRHELNetworkManagerKeyfiles_EmptyEntriesSkipped(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {},
+	}
+
+	files := buildRHELNetworkManagerKeyfiles(ipPerMac, map[string]string{}, map[string][]string{})
+
+	assert.Empty(t, files, "a MAC with zero entries must get no NetworkManager keyfile")
 }

--- a/v2v-helper/virtv2v/virtv2vops_test.go
+++ b/v2v-helper/virtv2v/virtv2vops_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
 	"github.com/platform9/vjailbreak/v2v-helper/vm"
 )
 
@@ -354,6 +355,33 @@ func TestBuildWildcardNetplanYAML_DHCPEntry(t *testing.T) {
 	assert.NotContains(t, yaml, "192.168.50.77", "DHCP-sourced IP must not be pinned as a static address")
 }
 
+// TestBuildWildcardNetplanYAML_DHCPOnlyEntryOmitsRoutesAndDNS covers exactly
+// the preserveIP=false + fallbackToDHCP=true + preserveMAC=true case: the MAC
+// is purely DHCP-sourced (no static entries), but gatewayIP[mac] and
+// macToDNS[mac] can still be populated (GetCreateOpts's auto-allocate branch
+// records a gateway even for a DHCP-sourced port, and macToDNS comes from the
+// source VM's GuestNetworks independent of the override). Neither should be
+// written: the DHCP client owns the gateway/DNS entirely, and a hand-written
+// default route or carried-over source-network DNS servers sitting next to
+// dhcp4: true would fight with (or go stale relative to) the actual lease.
+func TestBuildWildcardNetplanYAML_DHCPOnlyEntryOmitsRoutesAndDNS(t *testing.T) {
+	ipPerMac := map[string][]vm.IpEntry{
+		"aa:bb:cc:dd:ee:ff": {{IP: "192.168.50.77", Prefix: 0, DHCP: true}},
+	}
+	gatewayIP := map[string]string{"aa:bb:cc:dd:ee:ff": "192.168.50.1"}
+	guestNetworks := []vjailbreakv1alpha1.GuestNetwork{
+		{MAC: "aa:bb:cc:dd:ee:ff", IP: "10.0.0.5", DNS: []string{"10.0.0.2"}},
+	}
+
+	yaml := buildWildcardNetplanYAML(guestNetworks, gatewayIP, ipPerMac)
+
+	assert.Contains(t, yaml, "dhcp4: true")
+	assert.NotContains(t, yaml, "routes:", "a purely DHCP-sourced MAC must not get a hand-written default route")
+	assert.NotContains(t, yaml, "via: 192.168.50.1")
+	assert.NotContains(t, yaml, "nameservers:", "a purely DHCP-sourced MAC must not get carried-over source-network DNS servers")
+	assert.NotContains(t, yaml, "10.0.0.2")
+}
+
 func TestBuildWildcardNetplanYAML_MixedEntries(t *testing.T) {
 	ipPerMac := map[string][]vm.IpEntry{
 		"aa:bb:cc:dd:ee:ff": {
@@ -361,12 +389,14 @@ func TestBuildWildcardNetplanYAML_MixedEntries(t *testing.T) {
 			{IP: "192.168.50.77", Prefix: 0, DHCP: true},
 		},
 	}
+	gatewayIP := map[string]string{"aa:bb:cc:dd:ee:ff": "10.0.0.1"}
 
-	yaml := buildWildcardNetplanYAML(nil, map[string]string{}, ipPerMac)
+	yaml := buildWildcardNetplanYAML(nil, gatewayIP, ipPerMac)
 
 	assert.Contains(t, yaml, "dhcp4: true", "any DHCP-sourced entry on the NIC should trigger dhcp4: true")
 	assert.Contains(t, yaml, "- 10.0.0.5/24", "the static entry should still be written as an address")
 	assert.NotContains(t, yaml, "192.168.50.77", "the DHCP-sourced entry must not appear under addresses:")
+	assert.Contains(t, yaml, "via: 10.0.0.1", "a route is still written when the NIC also has a static entry")
 }
 
 func TestBuildWildcardNetplanYAML_EmptyEntriesSkipped(t *testing.T) {
@@ -379,15 +409,15 @@ func TestBuildWildcardNetplanYAML_EmptyEntriesSkipped(t *testing.T) {
 	assert.NotContains(t, yaml, "aa:bb:cc:dd:ee:ff", "a MAC with zero entries must get no ethernet stanza")
 }
 
-func TestBuildWildcardNetplanYAML_GatewayUnaffectedByDHCPFlag(t *testing.T) {
+func TestBuildWildcardNetplanYAML_GatewayWrittenForStaticEntry(t *testing.T) {
 	ipPerMac := map[string][]vm.IpEntry{
-		"aa:bb:cc:dd:ee:ff": {{IP: "192.168.50.77", Prefix: 0, DHCP: true}},
+		"aa:bb:cc:dd:ee:ff": {{IP: "192.168.50.77", Prefix: 24}},
 	}
 	gatewayIP := map[string]string{"aa:bb:cc:dd:ee:ff": "192.168.50.1"}
 
 	yaml := buildWildcardNetplanYAML(nil, gatewayIP, ipPerMac)
 
-	assert.Contains(t, yaml, "via: 192.168.50.1", "gateway route must still be written for a DHCP-sourced entry")
+	assert.Contains(t, yaml, "via: 192.168.50.1", "gateway route must be written for a static entry")
 }
 
 // ---------------------------------------------------------------------------

--- a/v2v-helper/vm/vmops.go
+++ b/v2v-helper/vm/vmops.go
@@ -57,6 +57,14 @@ type VMOperations interface {
 type IpEntry struct {
 	IP     string
 	Prefix int32
+	// DHCP marks an entry as coming from a live OpenStack/Neutron
+	// auto-allocation (fallback-to-DHCP) rather than a preserved or
+	// user-assigned static IP. Guest-config writers must configure a real
+	// DHCP client for these entries instead of pinning the IP statically,
+	// since the address may only be reachable after an actual DHCP
+	// handshake (e.g. on networks where port security ties the IP-to-port
+	// binding to an observed lease, not just a fixed_ip match).
+	DHCP bool
 }
 
 type VMInfo struct {


### PR DESCRIPTION
## What this PR does / why we need it
When the user unchecked preserve ip and cleared the ip input and selected fallback to dhcp. The ip given by neutron was not getting reflected inside the guest. 

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #2028 

## Special notes for your reviewer


## Testing done
2026/07/22 10:18:29 NETPLAN YAML : network:
version: 2
renderer: networkd
ethernets:
vj0:
match:
macaddress: fa:16:3e:85:a4:46
dhcp4: true
vj1:
match:
macaddress: fa:16:3e:7a:39:c3
dhcp4: true


both interfaces migrated to same network, preserve ip off and empty ip. ip's given by neutron and ip is pinging after migration. 
_please add testing details (logs, screenshots, etc.)_