### PR TITLE
[2176] Fix tags toggle needing two clicks to enable

### DIFF
--- a/ui/e2e/migration/tags-metadata.spec.ts
+++ b/ui/e2e/migration/tags-metadata.spec.ts
@@ -211,3 +211,28 @@ test.describe('TAGS-004 — section nav completion marking', () => {
     await expect(navItem.locator('svg[data-testid="CheckIcon"]')).toBeVisible()
   })
 })
+
+test.describe('TAGS-005 — GH-2176 regression: single click right after closing cluster selects', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockFormApis(page)
+  })
+
+  test('toggle enables on the first raw click, no extra click needed', async ({ page }) => {
+    await openFormWithClusters(page)
+    await scrollToTagsStep(page)
+
+    const switchRoot = page
+      .locator('[data-testid="preserve-source-tags-toggle"]')
+      .locator('xpath=ancestor::span[contains(@class,"MuiSwitch-root")]')
+    const box = await switchRoot.boundingBox()
+    if (!box) throw new Error('switch not visible')
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+
+    await page.mouse.click(cx, cy)
+    await expect(preserveToggleInput(page)).toBeChecked()
+
+    await page.mouse.click(cx, cy)
+    await expect(preserveToggleInput(page)).not.toBeChecked()
+  })
+})

--- a/ui/src/features/migration/steps/TagsAndMetadataSection.tsx
+++ b/ui/src/features/migration/steps/TagsAndMetadataSection.tsx
@@ -108,7 +108,8 @@ export default function TagsAndMetadataSection({
             <Switch
               data-testid="preserve-source-tags-toggle"
               checked={preserveSourceTags}
-              onChange={(e) => onChange('preserveSourceTags')(e.target.checked)}
+              onClick={() => onChange('preserveSourceTags')(!preserveSourceTags)}
+              onChange={() => {}}
             />
           }
           label="Preserve VMware tags and custom attributes"


### PR DESCRIPTION
## What this PR does / why we need it
Preserve VMware tags/attributes toggle needed a second click to enable.

**RCA:** When the toggle is the first thing clicked right after a cluster Select closes, that click's focus transfer desyncs React's controlled-checkbox change tracking, so the native checked flip gets silently reverted and onChange never fires. A second click (no competing focus transfer) works fine.

Fix: Drive the toggle off onClick (invert current state) instead of onChange/e.target.checked, since onClick fires reliably regardless of the focus-transfer race.

## Which issue(s) this PR fixes
fixes #2176 

## Testing done

https://github.com/user-attachments/assets/72091be4-1038-4f44-96d8-16cd4ac8b304
