### PR TITLE
[2184] Fix Migration Options toggles needing two clicks to enable

### DIFF
--- a/ui/e2e/migration/migration-options-toggle.spec.ts
+++ b/ui/e2e/migration/migration-options-toggle.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect, Page } from '@playwright/test'
+
+import {
+  goToMigrations,
+  openMigrationDrawer,
+  selectVmwareCluster,
+  selectPcdCluster,
+  mockRoute,
+  API,
+} from './helpers/migration.helpers'
+import {
+  MOCK_MIGRATIONS_LIST_EMPTY,
+  MOCK_MIGRATION_PLANS_LIST_EMPTY,
+  MOCK_VMWARE_CREDS_LIST,
+  MOCK_VMWARE_CRED_1,
+  MOCK_OPENSTACK_CRED_1,
+  MOCK_OPENSTACK_CREDS_LIST,
+  MOCK_VMWARE_CLUSTERS_LIST,
+  MOCK_PCD_CLUSTERS_LIST,
+  MOCK_VMWARE_MACHINES_LIST,
+} from './helpers/migration.fixtures'
+
+// GH #2176 follow-up — same root cause as the Tags & Metadata toggle (see
+// tags-metadata.spec.ts TAGS-005): a click landing right after a cluster Select's
+// menu closes also shifts DOM focus onto the click target, which desyncs React's
+// controlled-checkbox change tracking and silently reverts the native `checked`
+// flip before onChange fires. Whichever Migration Options toggle the user reaches
+// first after selecting clusters needed two clicks to enable; every toggle after
+// that worked normally. Fixed by driving all Migration Options checkboxes off
+// onClick (invert current state) instead of onChange/e.target.checked.
+async function mockFormApis(page: Page) {
+  await mockRoute(page, API.migrations, 'GET', MOCK_MIGRATIONS_LIST_EMPTY)
+  await mockRoute(page, API.migrationPlans, 'GET', MOCK_MIGRATION_PLANS_LIST_EMPTY)
+  await mockRoute(page, API.vmwareCreds, 'GET', MOCK_VMWARE_CREDS_LIST)
+  await mockRoute(page, API.vmwareCredByName('vcenter-cred-1'), 'GET', MOCK_VMWARE_CRED_1)
+  await mockRoute(page, API.vmwareClusters, 'GET', MOCK_VMWARE_CLUSTERS_LIST)
+  await mockRoute(page, API.vmwareMachines, 'GET', MOCK_VMWARE_MACHINES_LIST)
+  await mockRoute(page, API.rdmDisks, 'GET', {
+    apiVersion: 'vjailbreak.k8s.pf9.io/v1alpha1',
+    kind: 'RdmDiskList',
+    metadata: { continue: '', resourceVersion: '1' },
+    items: [],
+  })
+  await mockRoute(page, API.pcdClusters, 'GET', MOCK_PCD_CLUSTERS_LIST)
+  await mockRoute(page, API.openstackCredByName('pcd-cred-1'), 'GET', MOCK_OPENSTACK_CRED_1)
+  await mockRoute(page, API.openstackCreds, 'GET', MOCK_OPENSTACK_CREDS_LIST)
+}
+
+test.describe('MIGOPTS-001 — GH-2176 regression: Migration Options toggles respond to a single click', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockFormApis(page)
+  })
+
+  test('first toggle reached after closing cluster selects enables on the first raw click', async ({
+    page,
+  }) => {
+    await goToMigrations(page)
+    await openMigrationDrawer(page)
+    await selectVmwareCluster(page, 'DC1-Cluster')
+    await selectPcdCluster(page, 'pcd-cluster-1')
+    await page.waitForFunction(() => {
+      const menus = document.querySelectorAll('.MuiMenu-root')
+      return Array.from(menus).every((m) => m.getAttribute('aria-hidden') === 'true')
+    }, { timeout: 5000 })
+
+    // Jump straight to Migration Options, skipping every other step - this makes
+    // "Data copy method" the first control clicked after the selects close.
+    const checkbox = page.getByRole('checkbox', { name: /data copy method/i })
+    await checkbox.scrollIntoViewIfNeeded()
+    await expect(checkbox).toBeVisible()
+
+    const box = await checkbox.boundingBox()
+    if (!box) throw new Error('checkbox not visible')
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+
+    await page.mouse.click(cx, cy)
+    await expect(checkbox).toBeChecked()
+
+    await page.mouse.click(cx, cy)
+    await expect(checkbox).not.toBeChecked()
+  })
+})

--- a/ui/e2e/migration/migration-options-toggle.spec.ts
+++ b/ui/e2e/migration/migration-options-toggle.spec.ts
@@ -20,14 +20,6 @@ import {
   MOCK_VMWARE_MACHINES_LIST,
 } from './helpers/migration.fixtures'
 
-// GH #2176 follow-up — same root cause as the Tags & Metadata toggle (see
-// tags-metadata.spec.ts TAGS-005): a click landing right after a cluster Select's
-// menu closes also shifts DOM focus onto the click target, which desyncs React's
-// controlled-checkbox change tracking and silently reverts the native `checked`
-// flip before onChange fires. Whichever Migration Options toggle the user reaches
-// first after selecting clusters needed two clicks to enable; every toggle after
-// that worked normally. Fixed by driving all Migration Options checkboxes off
-// onClick (invert current state) instead of onChange/e.target.checked.
 async function mockFormApis(page: Page) {
   await mockRoute(page, API.migrations, 'GET', MOCK_MIGRATIONS_LIST_EMPTY)
   await mockRoute(page, API.migrationPlans, 'GET', MOCK_MIGRATION_PLANS_LIST_EMPTY)

--- a/ui/src/features/migration/steps/MigrationOptionsAlt.tsx
+++ b/ui/src/features/migration/steps/MigrationOptionsAlt.tsx
@@ -286,8 +286,9 @@ export default function MigrationOptionsAlt({
                     control={
                       <Checkbox
                         checked={selectedMigrationOptions.dataCopyMethod}
-                        onChange={(e) => {
-                          const isChecked = e.target.checked
+                        onChange={() => {}}
+                        onClick={() => {
+                          const isChecked = !selectedMigrationOptions.dataCopyMethod
                           updateSelectedMigrationOptions('dataCopyMethod')(isChecked)
                           if (!isChecked) {
                             onChange('dataCopyMethod')('cold')
@@ -340,8 +341,11 @@ export default function MigrationOptionsAlt({
                     control={
                       <Checkbox
                         checked={Boolean(params?.acknowledgeNetworkConflictRisk)}
-                        onChange={(e) => {
-                          onChange('acknowledgeNetworkConflictRisk')(e.target.checked)
+                        onChange={() => {}}
+                        onClick={() => {
+                          onChange('acknowledgeNetworkConflictRisk')(
+                            !params?.acknowledgeNetworkConflictRisk
+                          )
                         }}
                         color="warning"
                         size="small"
@@ -366,8 +370,9 @@ export default function MigrationOptionsAlt({
                     control={
                       <Checkbox
                         checked={selectedMigrationOptions?.dataCopyStartTime}
-                        onChange={(e) => {
-                          const isChecked = e.target.checked
+                        onChange={() => {}}
+                        onClick={() => {
+                          const isChecked = !selectedMigrationOptions?.dataCopyStartTime
                           updateSelectedMigrationOptions('dataCopyStartTime')(isChecked)
                           if (!isChecked) {
                             onChange('dataCopyStartTime')('')
@@ -419,8 +424,9 @@ export default function MigrationOptionsAlt({
                       <Checkbox
                         checked={selectedMigrationOptions.cutoverOption}
                         disabled={isPowerOffThenCopy}
-                        onChange={(e) => {
-                          const isChecked = e.target.checked
+                        onChange={() => {}}
+                        onClick={() => {
+                          const isChecked = !selectedMigrationOptions.cutoverOption
                           updateSelectedMigrationOptions('cutoverOption')(isChecked)
                           if (!isChecked) {
                             onChange('cutoverOption')(CUTOVER_TYPES.IMMEDIATE)
@@ -495,8 +501,9 @@ export default function MigrationOptionsAlt({
                           control={
                             <Checkbox
                               checked={selectedMigrationOptions.periodicSyncEnabled}
-                              onChange={(e) => {
-                                const isChecked = e.target.checked
+                              onChange={() => {}}
+                              onClick={() => {
+                                const isChecked = !selectedMigrationOptions.periodicSyncEnabled
                                 updateSelectedMigrationOptions('periodicSyncEnabled')(isChecked)
                                 if (isChecked) {
                                   onChange('periodicSyncInterval')(
@@ -551,8 +558,9 @@ export default function MigrationOptionsAlt({
                 control={
                   <Checkbox
                     checked={!!selectedMigrationOptions.postMigrationAction?.renameVm}
-                    onChange={(e) => {
-                      const isChecked = e.target.checked
+                    onChange={() => {}}
+                    onClick={() => {
+                      const isChecked = !selectedMigrationOptions.postMigrationAction?.renameVm
 
                       setValue(
                         'postMigrationActionSuffix',
@@ -594,8 +602,9 @@ export default function MigrationOptionsAlt({
                 control={
                   <Checkbox
                     checked={!!selectedMigrationOptions.postMigrationAction?.moveToFolder}
-                    onChange={(e) => {
-                      const isChecked = e.target.checked
+                    onChange={() => {}}
+                    onClick={() => {
+                      const isChecked = !selectedMigrationOptions.postMigrationAction?.moveToFolder
 
                       setValue(
                         'postMigrationActionFolderName',
@@ -653,8 +662,9 @@ export default function MigrationOptionsAlt({
                 control={
                   <Checkbox
                     checked={params?.disconnectSourceNetwork || false}
-                    onChange={(e) => {
-                      onChange('disconnectSourceNetwork')(e.target.checked)
+                    onChange={() => {}}
+                    onClick={() => {
+                      onChange('disconnectSourceNetwork')(!params?.disconnectSourceNetwork)
                     }}
                   />
                 }
@@ -674,8 +684,9 @@ export default function MigrationOptionsAlt({
                   <Checkbox
                     checked={params?.fallbackToDHCP || false}
                     disabled={hasL2Network}
-                    onChange={(e) => {
-                      onChange('fallbackToDHCP')(e.target.checked)
+                    onChange={() => {}}
+                    onClick={() => {
+                      onChange('fallbackToDHCP')(!params?.fallbackToDHCP)
                     }}
                   />
                 }
@@ -694,8 +705,9 @@ export default function MigrationOptionsAlt({
                     data-testid="migration-option-network-persistence"
                     checked={params?.networkPersistence || false}
                     disabled={hasSubnetMismatch}
-                    onChange={(e) => {
-                      onChange('networkPersistence')(e.target.checked)
+                    onChange={() => {}}
+                    onClick={() => {
+                      onChange('networkPersistence')(!params?.networkPersistence)
                     }}
                   />
                 }
@@ -733,8 +745,9 @@ export default function MigrationOptionsAlt({
                   control={
                     <Checkbox
                       checked={params?.useGPU || false}
-                      onChange={(e) => {
-                        const isChecked = e.target.checked
+                      onChange={() => {}}
+                      onClick={() => {
+                        const isChecked = !params?.useGPU
                         updateSelectedMigrationOptions('useGPU')(isChecked)
                         onChange('useGPU')(isChecked)
                       }}
@@ -768,8 +781,9 @@ export default function MigrationOptionsAlt({
                 control={
                   <Checkbox
                     checked={params?.removeVMwareTools || false}
-                    onChange={(e) => {
-                      onChange('removeVMwareTools')(e.target.checked)
+                    onChange={() => {}}
+                    onClick={() => {
+                      onChange('removeVMwareTools')(!params?.removeVMwareTools)
                     }}
                   />
                 }
@@ -788,8 +802,9 @@ export default function MigrationOptionsAlt({
                 control={
                   <Checkbox
                     checked={selectedMigrationOptions.postMigrationScript}
-                    onChange={(e) => {
-                      const isChecked = e.target.checked
+                    onChange={() => {}}
+                    onClick={() => {
+                      const isChecked = !selectedMigrationOptions.postMigrationScript
                       updateSelectedMigrationOptions('postMigrationScript')(isChecked)
                       if (!isChecked) {
                         onChange('postMigrationScript')('')


### PR DESCRIPTION
## What this PR does / why we need it
**Fix:** Same pattern as #2176 — every toggle now drives off onClick (inverts current React state) instead of onChange/e.target.checked, since onClick fires reliably regardless of the focus-transfer race. All existing side-effect logic per toggle (resetting dependent fields, etc.) preserved as-is.

## Which issue(s) this PR fixes
fixes #2184

## Testing done


https://github.com/user-attachments/assets/d9148b7c-6241-4dd4-83b8-e0a359f62ae4



