### PR TITLE
[2178] fix(migration): disable persist network interfaces when Preserve IP is off and mapped to diff network

### DIFF
--- a/ui/src/features/migration/pages/MigrationForm.tsx
+++ b/ui/src/features/migration/pages/MigrationForm.tsx
@@ -38,7 +38,7 @@ import type {
 import { useSectionTracking } from '../hooks/useSectionTracking'
 import { useNetworkIPsMap } from '../hooks/useNetworkIPsMap'
 import { useNetworkSubnetCompatibility } from '../hooks/useNetworkSubnetCompatibility'
-import { hasAnySubnetMismatch } from '../utils/subnetMismatch'
+import { hasAnySubnetMismatch, hasAnyPreserveIpDisabled } from '../utils/subnetMismatch'
 import { useFormSync } from '../hooks/useFormSync'
 import { useCredentialFetching } from '../hooks/useCredentialFetching'
 import { useMigrationFormSubmit } from '../hooks/useMigrationFormSubmit'
@@ -381,6 +381,7 @@ export default function MigrationFormDrawer({
     openstackNetworks: sortedOpenstackNetworks
   })
   const hasSubnetMismatch = hasAnySubnetMismatch(subnetWarnings)
+  const hasPreserveIpDisabled = hasAnyPreserveIpDisabled(params.vms || [])
 
   const { submitting, handleSubmit, handleClose } = useMigrationFormSubmit({
     params,
@@ -843,6 +844,7 @@ export default function MigrationFormDrawer({
                     stepNumber="6"
                     showHeader={false}
                     hasSubnetMismatch={hasSubnetMismatch}
+                    hasPreserveIpDisabled={hasPreserveIpDisabled}
                   />
                 </SurfaceCard>
               </Box>

--- a/ui/src/features/migration/pages/RollingMigrationForm.tsx
+++ b/ui/src/features/migration/pages/RollingMigrationForm.tsx
@@ -32,7 +32,7 @@ import { useHostConfigHandlers } from '../hooks/useHostConfigHandlers'
 import { useRollingFormData } from '../hooks/useRollingFormData'
 import { useNetworkIPsMap } from '../hooks/useNetworkIPsMap'
 import { useNetworkSubnetCompatibility } from '../hooks/useNetworkSubnetCompatibility'
-import { hasAnySubnetMismatch } from '../utils/subnetMismatch'
+import { hasAnySubnetMismatch, hasAnyPreserveIpDisabled } from '../utils/subnetMismatch'
 import { useRollingFormValidation } from '../hooks/useRollingFormValidation'
 import { useRollingFormSubmit } from '../hooks/useRollingFormSubmit'
 import { useSectionTracking } from '../hooks/useSectionTracking'
@@ -419,6 +419,7 @@ export default function RollingMigrationFormDrawer({
     openstackNetworks
   })
   const hasSubnetMismatch = hasAnySubnetMismatch(subnetWarnings)
+  const hasPreserveIpDisabled = hasAnyPreserveIpDisabled(subnetCheckVMs)
 
   // Update ESXi host config names when OpenStack host configs become available
   useEffect(() => {
@@ -1004,6 +1005,7 @@ export default function RollingMigrationFormDrawer({
                     getErrorsUpdater={getFieldErrorsUpdater}
                     showHeader={false}
                     hasSubnetMismatch={hasSubnetMismatch}
+                    hasPreserveIpDisabled={hasPreserveIpDisabled}
                   />
                 </SurfaceCard>
               </Box>

--- a/ui/src/features/migration/steps/MigrationOptionsAlt.tsx
+++ b/ui/src/features/migration/steps/MigrationOptionsAlt.tsx
@@ -87,6 +87,7 @@ export default function MigrationOptionsAlt({
   stepNumber,
   showHeader = true,
   hasSubnetMismatch = false,
+  hasPreserveIpDisabled = false,
   skipDefaultSeeding = false
 }: MigrationOptionsPropsInterface) {
   const { setValue } = useFormContext()
@@ -273,12 +274,16 @@ export default function MigrationOptionsAlt({
   }, [params, selectedMigrationOptions])
 
   // Persist IP is mutually exclusive with mapping to a network whose subnet
-  // does not contain the source VM IPs — auto-uncheck when a mismatch appears
+  // does not contain the source VM IPs, or with any selected VM having
+  // "Preserve IP" turned off (nothing left to persist) — auto-uncheck when
+  // either condition appears.
+  const disableNetworkPersistence = hasSubnetMismatch || hasPreserveIpDisabled
+
   useEffect(() => {
-    if (hasSubnetMismatch && params?.networkPersistence) {
+    if (disableNetworkPersistence && params?.networkPersistence) {
       onChange('networkPersistence')(false)
     }
-  }, [hasSubnetMismatch, params?.networkPersistence, onChange])
+  }, [disableNetworkPersistence, params?.networkPersistence, onChange])
 
   const isPCD = openstackCredentials?.metadata?.labels?.['vjailbreak.k8s.pf9.io/is-pcd'] === 'true'
   const hasL2Network = hasSelectedLayer2Network(
@@ -741,7 +746,7 @@ export default function MigrationOptionsAlt({
                   <Checkbox
                     data-testid="migration-option-network-persistence"
                     checked={params?.networkPersistence || false}
-                    disabled={hasSubnetMismatch}
+                    disabled={disableNetworkPersistence}
                     onChange={() => {}}
                     onClick={() => {
                       onChange('networkPersistence')(!params?.networkPersistence)
@@ -756,7 +761,7 @@ export default function MigrationOptionsAlt({
             <Box />
           </OptionRow>
 
-          {hasSubnetMismatch && (
+          {disableNetworkPersistence && (
             <Alert severity="info" sx={{ mt: 1 }} data-testid="network-persistence-subnet-alert">
               Persist source network interfaces is not available because some IP addresses of the
               selected VMs do not lie within the subnet of the selected destination network(s). Map

--- a/ui/src/features/migration/types.ts
+++ b/ui/src/features/migration/types.ts
@@ -370,6 +370,7 @@ export interface MigrationOptionsPropsInterface {
   stepNumber: string
   showHeader?: boolean
   hasSubnetMismatch?: boolean
+  hasPreserveIpDisabled?: boolean
   // True while a template/retry prefill is populating the form. Async global-default
   // effects must skip entirely in this window rather than race the prefill on load-order — settings and
   // prefill can each resolve first depending on network timing, so "only seed if unset"

--- a/ui/src/features/migration/utils/subnetMismatch.test.ts
+++ b/ui/src/features/migration/utils/subnetMismatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { hasAnySubnetMismatch } from './subnetMismatch'
+import { hasAnySubnetMismatch, hasAnyPreserveIpDisabled } from './subnetMismatch'
 
 describe('hasAnySubnetMismatch', () => {
   it('returns false for undefined warnings', () => {
@@ -29,5 +29,67 @@ describe('hasAnySubnetMismatch', () => {
         Mgmt: '1 IP address(es) of the selected VMs do not lie within the subnet of destination network'
       })
     ).toBe(true)
+  })
+})
+
+describe('hasAnyPreserveIpDisabled', () => {
+  it('returns false for undefined vms', () => {
+    expect(hasAnyPreserveIpDisabled(undefined)).toBe(false)
+  })
+
+  it('returns false for an empty vm list', () => {
+    expect(hasAnyPreserveIpDisabled([])).toBe(false)
+  })
+
+  it('returns false when a VM never had an IP (no networkInterfaces, no preserveIp)', () => {
+    expect(hasAnyPreserveIpDisabled([{ networkInterfaces: [] }])).toBe(false)
+  })
+
+  it('returns false when networkInterfaces are untouched (preserveIP undefined)', () => {
+    expect(
+      hasAnyPreserveIpDisabled([{ networkInterfaces: [{ preserveIP: undefined }] }])
+    ).toBe(false)
+  })
+
+  it('returns true when a networkInterface has preserveIP explicitly false (IP cleared)', () => {
+    expect(hasAnyPreserveIpDisabled([{ networkInterfaces: [{ preserveIP: false }] }])).toBe(true)
+  })
+
+  it('returns true when only one of several VMs has preserveIP disabled', () => {
+    expect(
+      hasAnyPreserveIpDisabled([
+        { networkInterfaces: [{ preserveIP: true }] },
+        { networkInterfaces: [{ preserveIP: false }] }
+      ])
+    ).toBe(true)
+  })
+
+  it('returns true when only one of several interfaces on a VM has preserveIP disabled', () => {
+    expect(
+      hasAnyPreserveIpDisabled([
+        { networkInterfaces: [{ preserveIP: true }, { preserveIP: false }] }
+      ])
+    ).toBe(true)
+  })
+
+  it('falls back to the top-level preserveIp override map when there are no networkInterfaces', () => {
+    expect(hasAnyPreserveIpDisabled([{ preserveIp: { 0: false } }])).toBe(true)
+  })
+
+  it('returns false for a top-level preserveIp map with no disabled entries', () => {
+    expect(hasAnyPreserveIpDisabled([{ preserveIp: { 0: true } }])).toBe(false)
+  })
+
+  it('prefers the top-level preserveIp override over the nic value at the same index', () => {
+    expect(
+      hasAnyPreserveIpDisabled([
+        { preserveIp: { 0: false }, networkInterfaces: [{ preserveIP: true }] }
+      ])
+    ).toBe(true)
+    expect(
+      hasAnyPreserveIpDisabled([
+        { preserveIp: { 0: true }, networkInterfaces: [{ preserveIP: false }] }
+      ])
+    ).toBe(false)
   })
 })

--- a/ui/src/features/migration/utils/subnetMismatch.ts
+++ b/ui/src/features/migration/utils/subnetMismatch.ts
@@ -8,3 +8,33 @@ export function hasAnySubnetMismatch(subnetWarnings: Record<string, string> | un
   if (!subnetWarnings) return false
   return Object.values(subnetWarnings).some((warning) => Boolean(warning && warning.trim()))
 }
+
+interface PreserveIpVm {
+  preserveIp?: Record<number, boolean>
+  networkInterfaces?: Array<{ preserveIP?: boolean }>
+}
+
+/**
+ * Returns true when any selected VM has explicitly disabled "Preserve IP" on
+ * one of its interfaces (e.g. via the IP edit dialog's "Preserve IP" toggle
+ * or "Clear All"). With no IP preserved for that interface, the subnet
+ * compatibility check has nothing to validate against and silently no-ops —
+ * so this is checked independently to keep "Persist source network
+ * interfaces" blocked in that case. Mirrors the vm.preserveIp-overrides-nic
+ * precedence used in StandardIpAddressCell.
+ */
+export function hasAnyPreserveIpDisabled(vms: PreserveIpVm[] | undefined): boolean {
+  if (!vms) return false
+  return vms.some((vm) => {
+    const overrides = vm.preserveIp
+    if (vm.networkInterfaces && vm.networkInterfaces.length > 0) {
+      return vm.networkInterfaces.some((nic, index) =>
+        overrides?.[index] !== undefined ? overrides[index] === false : nic.preserveIP === false
+      )
+    }
+    if (overrides) {
+      return Object.values(overrides).some((flag) => flag === false)
+    }
+    return false
+  })
+}


### PR DESCRIPTION
## What this PR does / why we need it
**RCA:** "Persist source network interfaces" checkbox disable state driven by hasSubnetMismatch, computed only when networkIPsMap has IPs for a mapped network. Clearing "Preserve IP" empties that map for the network → subnet check skips (ips.length===0 → return) → no mismatch ever recorded → checkbox stays enabled despite no IP to persist.

**Fix:** Added hasAnyPreserveIpDisabled() in subnetMismatch.ts — flags true if any selected VM has an interface with preserveIP === false. ORed with existing hasSubnetMismatch in MigrationOptionsAlt.tsx to gate checkbox disabled, auto-uncheck effect, and info alert. Wired into both MigrationForm.tsx and RollingMigrationForm.tsx.

## Which issue(s) this PR fixes
fixes #2178 

## Testing done


https://github.com/user-attachments/assets/ee2e367d-b838-41e8-9506-a523db20707b

