### PR TITLE
[2179] fix(migration): recompute subnet-mismatch warning when IP changes after network mapping

### DIFF
--- a/ui/src/features/migration/hooks/useBulkIPEdit.test.ts
+++ b/ui/src/features/migration/hooks/useBulkIPEdit.test.ts
@@ -1,0 +1,106 @@
+import type { SetStateAction } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { buildClearAllIpsUpdate, useBulkIPEdit } from './useBulkIPEdit'
+import type { VmDataWithFlavor } from '../types'
+
+describe('buildClearAllIpsUpdate', () => {
+  it('empties the IP field and turns Preserve IP off for every interface', () => {
+    const bulkEditIPs = { 'vm-1': { 0: '10.96.9.11' } }
+    const result = buildClearAllIpsUpdate(bulkEditIPs)
+
+    expect(result.clearedIPs).toEqual({ 'vm-1': { 0: '' } })
+    expect(result.clearedStatus).toEqual({ 'vm-1': { 0: 'empty' } })
+    expect(result.clearedPreserveIp).toEqual({ 'vm-1': { 0: false } })
+    expect(result.clearedCurrentIPs).toEqual({ 'vm-1': { 0: '' } })
+  })
+
+  it('covers every interface on a multi-NIC VM', () => {
+    const bulkEditIPs = { 'vm-1': { 0: '10.96.9.11', 1: '10.96.9.12' } }
+    const result = buildClearAllIpsUpdate(bulkEditIPs)
+
+    expect(result.clearedPreserveIp['vm-1']).toEqual({ 0: false, 1: false })
+    expect(result.clearedIPs['vm-1']).toEqual({ 0: '', 1: '' })
+  })
+
+  it('covers every selected VM independently', () => {
+    const bulkEditIPs = {
+      'vm-1': { 0: '10.96.9.11' },
+      'vm-2': { 0: '10.96.9.12' }
+    }
+    const result = buildClearAllIpsUpdate(bulkEditIPs)
+
+    expect(result.clearedPreserveIp).toEqual({
+      'vm-1': { 0: false },
+      'vm-2': { 0: false }
+    })
+  })
+
+  it('turns Preserve IP off even for a field that was already empty', () => {
+    const bulkEditIPs = { 'vm-1': { 0: '' } }
+    const result = buildClearAllIpsUpdate(bulkEditIPs)
+
+    expect(result.clearedPreserveIp).toEqual({ 'vm-1': { 0: false } })
+  })
+
+  it('returns empty maps when nothing is being edited', () => {
+    const result = buildClearAllIpsUpdate({})
+    expect(result.clearedIPs).toEqual({})
+    expect(result.clearedPreserveIp).toEqual({})
+  })
+})
+
+// applyIpAssignmentsToRows prefers bulkEditOverrides (a snapshot taken at dialog-open
+// time) over the live bulkPreserveIp state when persisting nic.preserveIP. Without
+// handleClearAllIPs also updating bulkEditOverrides, the persisted preserveIP flag
+// would silently snap back to the dialog-open value ("true") even though the user
+// just turned Preserve IP off via Clear All — undermining anything downstream that
+// reads nic.preserveIP (e.g. the Persist source network interfaces gate).
+describe('useBulkIPEdit — Clear All end-to-end', () => {
+  it('Clear All + Apply persists preserveIP=false and empties the IP, not the stale dialog-open value', async () => {
+    const vm: VmDataWithFlavor = {
+      id: 'vm-1',
+      name: 'akeyless-vm',
+      datastores: [],
+      networks: ['VM Network'],
+      vmState: 'running',
+      networkInterfaces: [
+        { mac: '00:50:56:87:3c:63', network: 'VM Network', ipAddress: ['10.96.9.11'] }
+      ]
+    }
+
+    // Stable references — the hook has an internal effect keyed on vmsWithFlavor's
+    // identity, so a fresh array/Set literal per render would loop forever.
+    const stableVmsWithFlavor: VmDataWithFlavor[] = [vm]
+    const stableSelectedVMs = new Set(['vm-1'])
+
+    let latestVmsWithFlavor: VmDataWithFlavor[] = stableVmsWithFlavor
+    const setVmsWithFlavor = vi.fn((updater: SetStateAction<VmDataWithFlavor[]>) => {
+      latestVmsWithFlavor =
+        typeof updater === 'function' ? updater(latestVmsWithFlavor) : updater
+    })
+    const setFormVms = vi.fn()
+
+    const { result } = renderHook(() =>
+      useBulkIPEdit({
+        vmsWithFlavor: stableVmsWithFlavor,
+        setVmsWithFlavor,
+        selectedVMs: stableSelectedVMs,
+        setFormVms,
+        openstackCredentials: undefined,
+        showToast: vi.fn(),
+        reportError: vi.fn()
+      })
+    )
+
+    act(() => result.current.handleOpenBulkIPAssignment())
+    act(() => result.current.handleClearAllIPs())
+    await act(async () => {
+      await result.current.handleApplyBulkIPs()
+    })
+
+    const updatedNic = latestVmsWithFlavor[0].networkInterfaces?.[0]
+    expect(updatedNic?.preserveIP).toBe(false)
+    expect(updatedNic?.ipAddress).toEqual([])
+  })
+})

--- a/ui/src/features/migration/hooks/useBulkIPEdit.test.ts
+++ b/ui/src/features/migration/hooks/useBulkIPEdit.test.ts
@@ -55,7 +55,8 @@ describe('buildClearAllIpsUpdate', () => {
 // handleClearAllIPs also updating bulkEditOverrides, the persisted preserveIP flag
 // would silently snap back to the dialog-open value ("true") even though the user
 // just turned Preserve IP off via Clear All — undermining anything downstream that
-// reads nic.preserveIP (e.g. the Persist source network interfaces gate).
+// reads nic.preserveIP (e.g. the Persist source network interfaces gate, and the
+// subnet-mismatch recompute which reads the IP via useNetworkIPsMap).
 describe('useBulkIPEdit — Clear All end-to-end', () => {
   it('Clear All + Apply persists preserveIP=false and empties the IP, not the stale dialog-open value', async () => {
     const vm: VmDataWithFlavor = {

--- a/ui/src/features/migration/hooks/useBulkIPEdit.ts
+++ b/ui/src/features/migration/hooks/useBulkIPEdit.ts
@@ -10,6 +10,46 @@ import {
 } from '../utils/ipValidation'
 import type { VmDataWithFlavor, BulkIpEdit, BulkIpClear } from '../types'
 
+export interface ClearAllIpsUpdate {
+  clearedIPs: Record<string, Record<number, string>>
+  clearedStatus: Record<string, Record<number, 'empty' | 'valid' | 'invalid' | 'validating'>>
+  clearedPreserveIp: Record<string, Record<number, boolean>>
+  clearedCurrentIPs: Record<string, Record<number, string>>
+}
+
+/**
+ * Pure computation for "Clear All": empties every IP field AND turns Preserve IP off
+ * for each one. Preserve IP must flip too — collectIpsToApply/collectIpsToClear in
+ * handleApplyBulkIPs both treat an empty field with Preserve IP still on as a no-op,
+ * so without this the Apply button silently does nothing to the VM's IP despite the
+ * field looking cleared.
+ */
+export function buildClearAllIpsUpdate(
+  bulkEditIPs: Record<string, Record<number, string>>
+): ClearAllIpsUpdate {
+  const clearedIPs: ClearAllIpsUpdate['clearedIPs'] = {}
+  const clearedStatus: ClearAllIpsUpdate['clearedStatus'] = {}
+  const clearedPreserveIp: ClearAllIpsUpdate['clearedPreserveIp'] = {}
+  const clearedCurrentIPs: ClearAllIpsUpdate['clearedCurrentIPs'] = {}
+
+  Object.keys(bulkEditIPs).forEach((vmName) => {
+    clearedIPs[vmName] = {}
+    clearedStatus[vmName] = {}
+    clearedPreserveIp[vmName] = {}
+    clearedCurrentIPs[vmName] = {}
+
+    Object.keys(bulkEditIPs[vmName]).forEach((interfaceIndexStr) => {
+      const interfaceIndex = parseInt(interfaceIndexStr)
+      clearedIPs[vmName][interfaceIndex] = ''
+      clearedStatus[vmName][interfaceIndex] = 'empty'
+      clearedPreserveIp[vmName][interfaceIndex] = false
+      clearedCurrentIPs[vmName][interfaceIndex] = ''
+    })
+  })
+
+  return { clearedIPs, clearedStatus, clearedPreserveIp, clearedCurrentIPs }
+}
+
 function flattenBulkIps(items: BulkIpEdit[]): Array<{ vmName: string; interfaceIndex: number; ip: string }> {
   const flattened: Array<{ vmName: string; interfaceIndex: number; ip: string }> = []
   items.forEach((item) => {
@@ -305,26 +345,47 @@ export function useBulkIPEdit({
   }
 
   const handleClearAllIPs = () => {
-    const clearedIPs: Record<string, Record<number, string>> = {}
-    const clearedStatus: Record<
-      string,
-      Record<number, 'empty' | 'valid' | 'invalid' | 'validating'>
-    > = {}
-
-    Object.keys(bulkEditIPs).forEach((vmName) => {
-      clearedIPs[vmName] = {}
-      clearedStatus[vmName] = {}
-
-      Object.keys(bulkEditIPs[vmName]).forEach((interfaceIndexStr) => {
-        const interfaceIndex = parseInt(interfaceIndexStr)
-        clearedIPs[vmName][interfaceIndex] = ''
-        clearedStatus[vmName][interfaceIndex] = 'empty'
-      })
-    })
+    const { clearedIPs, clearedStatus, clearedPreserveIp, clearedCurrentIPs } =
+      buildClearAllIpsUpdate(bulkEditIPs)
 
     setBulkEditIPs(clearedIPs)
     setBulkValidationStatus(clearedStatus)
     setBulkValidationMessages({})
+    setBulkPreserveIp((prev) => {
+      const next = { ...prev }
+      Object.entries(clearedPreserveIp).forEach(([vmName, interfaces]) => {
+        next[vmName] = { ...next[vmName], ...interfaces }
+      })
+      return next
+    })
+    setBulkCurrentIPs((prev) => {
+      const next = { ...prev }
+      Object.entries(clearedCurrentIPs).forEach(([vmName, interfaces]) => {
+        next[vmName] = { ...next[vmName], ...interfaces }
+      })
+      return next
+    })
+    // bulkEditOverrides is a second, independent snapshot of preserveIP/preserveMAC
+    // taken at dialog-open time — applyIpAssignmentsToRows prefers it over the live
+    // bulkPreserveIp state when persisting nic.preserveIP. Left stale here, the
+    // persisted flag would silently snap back to "true" despite Preserve IP now
+    // being off, undermining any check that relies on nic.preserveIP (e.g. the
+    // Persist source network interfaces gate).
+    setBulkEditOverrides((prev) => {
+      const next = { ...prev }
+      Object.entries(clearedPreserveIp).forEach(([vmName, interfaces]) => {
+        next[vmName] = { ...next[vmName] }
+        Object.keys(interfaces).forEach((interfaceIndexStr) => {
+          const interfaceIndex = parseInt(interfaceIndexStr)
+          const existing = next[vmName][interfaceIndex]
+          next[vmName][interfaceIndex] = {
+            preserveIP: false,
+            preserveMAC: existing?.preserveMAC ?? true
+          }
+        })
+      })
+      return next
+    })
   }
 
   const validateRequiredIpsForPreserveEnabled = () => {

--- a/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.test.ts
+++ b/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest'
-import { computeSubnetCheckSignature } from './useNetworkSubnetCompatibility'
+import { describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { computeSubnetCheckSignature, useNetworkSubnetCompatibility } from './useNetworkSubnetCompatibility'
+import type { OpenstackCreds } from 'src/api/openstack-creds/model'
+import type { VmData } from 'src/features/migration/api/migration-templates/model'
+
+vi.mock('src/api/openstack-creds/openstackCreds', () => ({
+  checkNetworkSubnetCompatibility: vi.fn()
+}))
+
+import { checkNetworkSubnetCompatibility } from 'src/api/openstack-creds/openstackCreds'
 
 describe('computeSubnetCheckSignature', () => {
   it('returns a stable signature for the same mappings and IPs', () => {
@@ -82,4 +91,57 @@ describe('computeSubnetCheckSignature', () => {
     const withNoEntry = computeSubnetCheckSignature(mappings, new Map())
     expect(withEmptyEntry).toBe(withNoEntry)
   })
+})
+
+describe('useNetworkSubnetCompatibility — stale response race', () => {
+  // checkNetworkSubnetCompatibility can take over a second in practice. If the user
+  // clears the IP while that call for the pre-edit IP is still in flight, clearTimeout
+  // only cancels the pending *timer* — it can't cancel an already-running async body.
+  // Without the requestId guard, that stale call lands after the correct (cleared)
+  // result and silently reinstates the pre-edit warning.
+  it('does not let a slow, superseded API call overwrite a newer result', async () => {
+    let resolveFirstCall!: (value: unknown) => void
+    const firstCallPromise = new Promise((resolve) => {
+      resolveFirstCall = resolve
+    })
+    vi.mocked(checkNetworkSubnetCompatibility).mockImplementationOnce(
+      () => firstCallPromise as ReturnType<typeof checkNetworkSubnetCompatibility>
+    )
+
+    const openstackCredentials = {
+      metadata: { name: 'creds-1', namespace: 'default' }
+    } as unknown as OpenstackCreds
+    const networkMappings = [{ source: 'VM Network', target: 'secondnetwork' }]
+    const selectedVMs: VmData[] = [{ id: 'vm-1', name: 'vm-1', datastores: [] }]
+
+    const { result, rerender } = renderHook(
+      ({ networkIPsMap }) =>
+        useNetworkSubnetCompatibility({
+          networkMappings,
+          openstackCredentials,
+          selectedVMs,
+          networkIPsMap,
+          openstackNetworks: []
+        }),
+      { initialProps: { networkIPsMap: new Map([['VM Network', ['10.96.9.11']]]) } }
+    )
+
+    // Let the 350ms debounce fire so the (slow, still-unresolved) first API call starts.
+    await new Promise((r) => setTimeout(r, 400))
+
+    // User clears the IP — ips.length===0 for this mapping so the new recompute
+    // resolves without an API call, well before the stale first call finishes.
+    rerender({ networkIPsMap: new Map([['VM Network', []]]) })
+    await waitFor(() => expect(result.current['VM Network']).toBeUndefined(), { timeout: 1000 })
+
+    // The slow original call for the pre-edit IP finally resolves as incompatible.
+    resolveFirstCall({
+      all_compatible: false,
+      results: [{ ip: '10.96.9.11', is_compatible: false }],
+      subnet_cidrs: ['192.168.0.0/24']
+    })
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(result.current['VM Network']).toBeUndefined()
+  }, 10000)
 })

--- a/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.test.ts
+++ b/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { computeSubnetCheckSignature } from './useNetworkSubnetCompatibility'
+
+describe('computeSubnetCheckSignature', () => {
+  it('returns a stable signature for the same mappings and IPs', () => {
+    const mappings = [{ source: 'VM Network', target: 'secondnetwork' }]
+    const ipsMap = new Map([['VM Network', ['10.96.10.169']]])
+    expect(computeSubnetCheckSignature(mappings, ipsMap)).toBe(
+      computeSubnetCheckSignature(mappings, ipsMap)
+    )
+  })
+
+  it('changes when a VM IP is cleared after the mapping is made (mappings unchanged)', () => {
+    const mappings = [{ source: 'VM Network', target: 'secondnetwork' }]
+    const before = computeSubnetCheckSignature(mappings, new Map([['VM Network', ['10.96.10.169']]]))
+    const after = computeSubnetCheckSignature(mappings, new Map([['VM Network', []]]))
+    expect(before).not.toBe(after)
+  })
+
+  it('changes when a VM IP is edited to a different address (mappings unchanged)', () => {
+    const mappings = [{ source: 'VM Network', target: 'secondnetwork' }]
+    const before = computeSubnetCheckSignature(mappings, new Map([['VM Network', ['10.96.10.169']]]))
+    const after = computeSubnetCheckSignature(mappings, new Map([['VM Network', ['192.168.0.50']]]))
+    expect(before).not.toBe(after)
+  })
+
+  it('changes when the network mapping target changes (IPs unchanged)', () => {
+    const ipsMap = new Map([['VM Network', ['10.96.10.169']]])
+    const before = computeSubnetCheckSignature(
+      [{ source: 'VM Network', target: 'secondnetwork' }],
+      ipsMap
+    )
+    const after = computeSubnetCheckSignature(
+      [{ source: 'VM Network', target: 'thirdnetwork' }],
+      ipsMap
+    )
+    expect(before).not.toBe(after)
+  })
+
+  it('is insensitive to IP ordering within a network', () => {
+    const mappings = [{ source: 'VM Network', target: 'secondnetwork' }]
+    const a = computeSubnetCheckSignature(
+      mappings,
+      new Map([['VM Network', ['10.0.0.1', '10.0.0.2']]])
+    )
+    const b = computeSubnetCheckSignature(
+      mappings,
+      new Map([['VM Network', ['10.0.0.2', '10.0.0.1']]])
+    )
+    expect(a).toBe(b)
+  })
+
+  it('handles multiple mappings independently', () => {
+    const mappings = [
+      { source: 'VM Network', target: 'secondnetwork' },
+      { source: 'Mgmt', target: 'mgmt-net' }
+    ]
+    const before = computeSubnetCheckSignature(
+      mappings,
+      new Map([
+        ['VM Network', ['10.96.10.169']],
+        ['Mgmt', ['10.1.1.5']]
+      ])
+    )
+    const after = computeSubnetCheckSignature(
+      mappings,
+      new Map([
+        ['VM Network', ['10.96.10.169']],
+        ['Mgmt', []]
+      ])
+    )
+    expect(before).not.toBe(after)
+  })
+
+  it('returns a deterministic empty-state signature for no mappings', () => {
+    expect(computeSubnetCheckSignature([], new Map())).toBe(computeSubnetCheckSignature([], new Map()))
+  })
+
+  it('treats a network with no IP entry the same as an empty IP list', () => {
+    const mappings = [{ source: 'VM Network', target: 'secondnetwork' }]
+    const withEmptyEntry = computeSubnetCheckSignature(mappings, new Map([['VM Network', []]]))
+    const withNoEntry = computeSubnetCheckSignature(mappings, new Map())
+    expect(withEmptyEntry).toBe(withNoEntry)
+  })
+})

--- a/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.test.ts
+++ b/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 import { computeSubnetCheckSignature, useNetworkSubnetCompatibility } from './useNetworkSubnetCompatibility'
 import type { OpenstackCreds } from 'src/api/openstack-creds/model'
@@ -93,13 +93,80 @@ describe('computeSubnetCheckSignature', () => {
   })
 })
 
-describe('useNetworkSubnetCompatibility — stale response race', () => {
-  // checkNetworkSubnetCompatibility can take over a second in practice. If the user
-  // clears the IP while that call for the pre-edit IP is still in flight, clearTimeout
-  // only cancels the pending *timer* — it can't cancel an already-running async body.
-  // Without the requestId guard, that stale call lands after the correct (cleared)
-  // result and silently reinstates the pre-edit warning.
+describe('useNetworkSubnetCompatibility', () => {
+  const openstackCredentials = {
+    metadata: { name: 'creds-1', namespace: 'default' }
+  } as unknown as OpenstackCreds
+  const networkMappings = [{ source: 'VM Network', target: 'secondnetwork' }]
+  const selectedVMs: VmData[] = [{ id: 'vm-1', name: 'vm-1', datastores: [] }]
+
+  beforeEach(() => {
+    vi.mocked(checkNetworkSubnetCompatibility).mockReset()
+  })
+
+  it('recomputes and shows a warning when the mapping is first made', async () => {
+    vi.mocked(checkNetworkSubnetCompatibility).mockResolvedValueOnce({
+      all_compatible: false,
+      results: [{ ip: '10.96.9.11', is_compatible: false, reason: 'out of subnet' }],
+      subnet_cidrs: ['192.168.0.0/24']
+    })
+
+    const { result } = renderHook(() =>
+      useNetworkSubnetCompatibility({
+        networkMappings,
+        openstackCredentials,
+        selectedVMs,
+        networkIPsMap: new Map([['VM Network', ['10.96.9.11']]]),
+        openstackNetworks: []
+      })
+    )
+
+    await waitFor(() => expect(result.current['VM Network']).toContain('10.96.9.11'), {
+      timeout: 1000
+    })
+  })
+
+  it('recomputes when the VM IP changes after the mapping already exists (selection/mapping unchanged)', async () => {
+    vi.mocked(checkNetworkSubnetCompatibility)
+      .mockResolvedValueOnce({
+        all_compatible: false,
+        results: [{ ip: '10.96.9.11', is_compatible: false, reason: 'out of subnet' }],
+        subnet_cidrs: ['192.168.0.0/24']
+      })
+      .mockResolvedValueOnce({
+        all_compatible: true,
+        results: [{ ip: '192.168.0.50', is_compatible: true, reason: '' }],
+        subnet_cidrs: ['192.168.0.0/24']
+      })
+
+    const { result, rerender } = renderHook(
+      ({ networkIPsMap }) =>
+        useNetworkSubnetCompatibility({
+          networkMappings,
+          openstackCredentials,
+          selectedVMs,
+          networkIPsMap,
+          openstackNetworks: []
+        }),
+      { initialProps: { networkIPsMap: new Map([['VM Network', ['10.96.9.11']]]) } }
+    )
+
+    await waitFor(() => expect(result.current['VM Network']).toContain('10.96.9.11'), {
+      timeout: 1000
+    })
+
+    // IP edited to one that now falls inside the subnet — mapping itself is unchanged.
+    rerender({ networkIPsMap: new Map([['VM Network', ['192.168.0.50']]]) })
+
+    await waitFor(() => expect(result.current['VM Network']).toBeUndefined(), { timeout: 1000 })
+  })
+
   it('does not let a slow, superseded API call overwrite a newer result', async () => {
+    // checkNetworkSubnetCompatibility can take over a second in practice. If the user
+    // clears the IP while that call for the pre-edit IP is still in flight, clearTimeout
+    // only cancels the pending *timer* — it can't cancel an already-running async body.
+    // Without the requestId guard, that stale call lands after the correct (cleared)
+    // result and silently reinstates the pre-edit warning.
     let resolveFirstCall!: (value: unknown) => void
     const firstCallPromise = new Promise((resolve) => {
       resolveFirstCall = resolve
@@ -107,12 +174,6 @@ describe('useNetworkSubnetCompatibility — stale response race', () => {
     vi.mocked(checkNetworkSubnetCompatibility).mockImplementationOnce(
       () => firstCallPromise as ReturnType<typeof checkNetworkSubnetCompatibility>
     )
-
-    const openstackCredentials = {
-      metadata: { name: 'creds-1', namespace: 'default' }
-    } as unknown as OpenstackCreds
-    const networkMappings = [{ source: 'VM Network', target: 'secondnetwork' }]
-    const selectedVMs: VmData[] = [{ id: 'vm-1', name: 'vm-1', datastores: [] }]
 
     const { result, rerender } = renderHook(
       ({ networkIPsMap }) =>
@@ -144,4 +205,37 @@ describe('useNetworkSubnetCompatibility — stale response race', () => {
 
     expect(result.current['VM Network']).toBeUndefined()
   }, 10000)
+
+  it('clears warnings immediately when all VMs are deselected', () => {
+    const { result, rerender } = renderHook(
+      ({ selectedVMs }) =>
+        useNetworkSubnetCompatibility({
+          networkMappings,
+          openstackCredentials,
+          selectedVMs,
+          networkIPsMap: new Map([['VM Network', ['10.96.9.11']]]),
+          openstackNetworks: []
+        }),
+      { initialProps: { selectedVMs } }
+    )
+
+    rerender({ selectedVMs: [] })
+    expect(result.current).toEqual({})
+  })
+
+  it('skips the API call for L2 (simple_network) target networks', async () => {
+    const { result } = renderHook(() =>
+      useNetworkSubnetCompatibility({
+        networkMappings,
+        openstackCredentials,
+        selectedVMs,
+        networkIPsMap: new Map([['VM Network', ['10.96.9.11']]]),
+        openstackNetworks: [{ name: 'secondnetwork', tags: ['simple_network'] } as never]
+      })
+    )
+
+    await new Promise((r) => setTimeout(r, 500))
+    expect(checkNetworkSubnetCompatibility).not.toHaveBeenCalled()
+    expect(result.current['VM Network']).toBeUndefined()
+  })
 })

--- a/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.ts
+++ b/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.ts
@@ -15,6 +15,23 @@ interface UseNetworkSubnetCompatibilityParams {
   openstackNetworks: PCDNetworkInfo[]
 }
 
+/**
+ * Signature used to decide whether a recompute is needed. Must change whenever
+ * either the network mappings OR the per-network IP data changes — keying off
+ * mappings alone misses IP edits/clears made after a mapping is created, which
+ * leaves the subnet-mismatch warning stuck showing the pre-edit IP.
+ */
+export function computeSubnetCheckSignature(
+  mappings: Array<{ source?: string; target?: string }>,
+  networkIPsMap: Map<string, string[]>
+): string {
+  const mappingsKey = mappings.map((m) => `${m.source}|${m.target}`).join(',')
+  const ipsKey = mappings
+    .map((m) => `${m.source}:${[...(networkIPsMap.get(m.source ?? '') ?? [])].sort().join(',')}`)
+    .join('|')
+  return `${mappingsKey}::${ipsKey}`
+}
+
 export function useNetworkSubnetCompatibility({
   networkMappings,
   openstackCredentials,
@@ -23,7 +40,7 @@ export function useNetworkSubnetCompatibility({
   openstackNetworks
 }: UseNetworkSubnetCompatibilityParams): Record<string, string> {
   const [subnetWarnings, setSubnetWarnings] = useState<Record<string, string>>({})
-  const prevMappingsRef = useRef<string>('')
+  const prevSignatureRef = useRef<string>('')
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const apiCacheRef = useRef<Map<string, CheckNetworkSubnetCompatibilityResponse>>(new Map())
   const prevCredNameRef = useRef<string | undefined>(undefined)
@@ -31,9 +48,9 @@ export function useNetworkSubnetCompatibility({
   useEffect(() => {
     const completeMappings = (networkMappings || []).filter((m) => m.source && m.target)
 
-    const mappingsKey = completeMappings.map((m) => `${m.source}|${m.target}`).join(',')
-    if (mappingsKey === prevMappingsRef.current) return
-    prevMappingsRef.current = mappingsKey
+    const signature = computeSubnetCheckSignature(completeMappings, networkIPsMap)
+    if (signature === prevSignatureRef.current) return
+    prevSignatureRef.current = signature
 
     if (!openstackCredentials || completeMappings.length === 0 || selectedVMs.length === 0) {
       setSubnetWarnings({})

--- a/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.ts
+++ b/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.ts
@@ -44,6 +44,12 @@ export function useNetworkSubnetCompatibility({
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const apiCacheRef = useRef<Map<string, CheckNetworkSubnetCompatibilityResponse>>(new Map())
   const prevCredNameRef = useRef<string | undefined>(undefined)
+  // Bumped on every recompute that actually starts. The check-compatibility API call
+  // can take over a second — if the user edits/clears an IP while an older call for
+  // the pre-edit IP is still in flight, clearTimeout only cancels the *timer*, not an
+  // already-firing async body. Without this guard the stale call lands after the new
+  // (correct) result and silently overwrites it back to the pre-edit warning text.
+  const requestIdRef = useRef(0)
 
   useEffect(() => {
     const completeMappings = (networkMappings || []).filter((m) => m.source && m.target)
@@ -51,6 +57,7 @@ export function useNetworkSubnetCompatibility({
     const signature = computeSubnetCheckSignature(completeMappings, networkIPsMap)
     if (signature === prevSignatureRef.current) return
     prevSignatureRef.current = signature
+    const requestId = ++requestIdRef.current
 
     if (!openstackCredentials || completeMappings.length === 0 || selectedVMs.length === 0) {
       setSubnetWarnings({})
@@ -111,6 +118,10 @@ export function useNetworkSubnetCompatibility({
         })
       )
 
+      // A newer recompute has since started (e.g. the user edited the IP again while
+      // this one's API call was in flight) — drop this stale result instead of
+      // clobbering the newer one.
+      if (requestIdRef.current !== requestId) return
       setSubnetWarnings(nextWarnings)
     }, 350)
 

--- a/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.ts
+++ b/ui/src/features/migration/hooks/useNetworkSubnetCompatibility.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import {
   checkNetworkSubnetCompatibility,
   CheckNetworkSubnetCompatibilityResponse
@@ -15,21 +15,26 @@ interface UseNetworkSubnetCompatibilityParams {
   openstackNetworks: PCDNetworkInfo[]
 }
 
+const DEBOUNCE_MS = 350
+
 /**
- * Signature used to decide whether a recompute is needed. Must change whenever
- * either the network mappings OR the per-network IP data changes — keying off
- * mappings alone misses IP edits/clears made after a mapping is created, which
- * leaves the subnet-mismatch warning stuck showing the pre-edit IP.
+ * Primitive signature of everything that should trigger a recompute: which
+ * source->target mappings exist, and the current IPs behind each source
+ * network. Built from primitives (not object refs) so the effect below re-fires
+ * on real content changes only — an IP edited/cleared after a mapping already
+ * exists changes this signature just like a new mapping would, so the
+ * subnet-mismatch warning never gets stuck showing a pre-edit IP.
  */
 export function computeSubnetCheckSignature(
   mappings: Array<{ source?: string; target?: string }>,
   networkIPsMap: Map<string, string[]>
 ): string {
-  const mappingsKey = mappings.map((m) => `${m.source}|${m.target}`).join(',')
-  const ipsKey = mappings
-    .map((m) => `${m.source}:${[...(networkIPsMap.get(m.source ?? '') ?? [])].sort().join(',')}`)
+  return mappings
+    .map((m) => {
+      const ips = [...(networkIPsMap.get(m.source ?? '') ?? [])].sort()
+      return `${m.source}>${m.target}:${ips.join(',')}`
+    })
     .join('|')
-  return `${mappingsKey}::${ipsKey}`
 }
 
 export function useNetworkSubnetCompatibility({
@@ -40,46 +45,48 @@ export function useNetworkSubnetCompatibility({
   openstackNetworks
 }: UseNetworkSubnetCompatibilityParams): Record<string, string> {
   const [subnetWarnings, setSubnetWarnings] = useState<Record<string, string>>({})
-  const prevSignatureRef = useRef<string>('')
-  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const apiCacheRef = useRef<Map<string, CheckNetworkSubnetCompatibilityResponse>>(new Map())
-  const prevCredNameRef = useRef<string | undefined>(undefined)
   // Bumped on every recompute that actually starts. The check-compatibility API call
   // can take over a second — if the user edits/clears an IP while an older call for
-  // the pre-edit IP is still in flight, clearTimeout only cancels the *timer*, not an
-  // already-firing async body. Without this guard the stale call lands after the new
-  // (correct) result and silently overwrites it back to the pre-edit warning text.
+  // the pre-edit IP is still in flight, only the latest result should be allowed to
+  // win, otherwise a stale response can land after the fresh one and clobber it.
   const requestIdRef = useRef(0)
 
+  const completeMappings = useMemo(
+    () => (networkMappings || []).filter((m) => m.source && m.target),
+    [networkMappings]
+  )
+
+  const signature = useMemo(
+    () => computeSubnetCheckSignature(completeMappings, networkIPsMap),
+    [completeMappings, networkIPsMap]
+  )
+
+  const credName = openstackCredentials?.metadata.name
+  const credsNamespace = openstackCredentials?.metadata.namespace
+
+  const networksKey = useMemo(
+    () =>
+      openstackNetworks
+        .map((n) => `${n.name}:${Array.isArray(n.tags) && n.tags.includes('simple_network') ? 1 : 0}`)
+        .sort()
+        .join(','),
+    [openstackNetworks]
+  )
+
   useEffect(() => {
-    const completeMappings = (networkMappings || []).filter((m) => m.source && m.target)
-
-    const signature = computeSubnetCheckSignature(completeMappings, networkIPsMap)
-    if (signature === prevSignatureRef.current) return
-    prevSignatureRef.current = signature
-    const requestId = ++requestIdRef.current
-
-    if (!openstackCredentials || completeMappings.length === 0 || selectedVMs.length === 0) {
+    if (!credName || completeMappings.length === 0 || selectedVMs.length === 0) {
       setSubnetWarnings({})
       return
     }
 
-    const credName = openstackCredentials.metadata.name
-    if (credName !== prevCredNameRef.current) {
-      apiCacheRef.current.clear()
-      prevCredNameRef.current = credName
-    }
+    const requestId = ++requestIdRef.current
 
-    const credsNamespace = openstackCredentials.metadata.namespace
-
-    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
-
-    debounceTimerRef.current = setTimeout(async () => {
+    const timer = setTimeout(async () => {
       const nextWarnings: Record<string, string> = {}
 
       await Promise.all(
         completeMappings.map(async (mapping) => {
-          const ips = networkIPsMap.get(mapping.source) ?? []
+          const ips = networkIPsMap.get(mapping.source ?? '') ?? []
           if (ips.length === 0) return
 
           const isL2Network = openstackNetworks.some(
@@ -88,20 +95,14 @@ export function useNetworkSubnetCompatibility({
           )
           if (isL2Network) return
 
-          const cacheKey = `${mapping.target}|${[...ips].sort().join(',')}`
-          const cached = apiCacheRef.current.get(cacheKey)
-
           try {
-            const result =
-              cached ??
-              (await checkNetworkSubnetCompatibility({
+            const result: CheckNetworkSubnetCompatibilityResponse =
+              await checkNetworkSubnetCompatibility({
                 ips,
-                network_name: mapping.target,
+                network_name: mapping.target as string,
                 creds_name: credName,
-                creds_namespace: credsNamespace
-              }))
-
-            if (!cached) apiCacheRef.current.set(cacheKey, result)
+                creds_namespace: credsNamespace as string
+              })
 
             if (!result.all_compatible) {
               const incompatibleIPs = result.results
@@ -109,11 +110,12 @@ export function useNetworkSubnetCompatibility({
                 .map((r) => r.ip)
               const cidrList =
                 result.subnet_cidrs?.length > 0 ? ` (${result.subnet_cidrs.join(', ')})` : ''
-              nextWarnings[mapping.source] =
+              nextWarnings[mapping.source as string] =
                 `${incompatibleIPs.length} IP address(es) of the selected VMs [${incompatibleIPs.join(', ')}] do not lie within the subnet of destination network ${mapping.target} ${cidrList}. ` +
                 `Ensure fallback to DHCP is enabled, otherwise it may lead to migration failures`
             }
           } catch {
+            // Ignore transient API errors; the next recompute will retry.
           }
         })
       )
@@ -123,12 +125,15 @@ export function useNetworkSubnetCompatibility({
       // clobbering the newer one.
       if (requestIdRef.current !== requestId) return
       setSubnetWarnings(nextWarnings)
-    }, 350)
+    }, DEBOUNCE_MS)
 
-    return () => {
-      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current)
-    }
-  }, [networkMappings, openstackCredentials, selectedVMs, networkIPsMap, openstackNetworks])
+    return () => clearTimeout(timer)
+    // signature + networksKey capture every input that should drive a recompute as
+    // stable primitives; completeMappings/networkIPsMap/openstackNetworks are read
+    // from the closure but intentionally left out of the deps so the effect re-fires
+    // on content changes rather than on every new array/object reference.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signature, networksKey, credName, credsNamespace, selectedVMs.length])
 
   return subnetWarnings
 }


### PR DESCRIPTION
## What this PR does / why we need it
**RCA:** useNetworkSubnetCompatibility.ts gated its recompute effect on mappingsKey — a signature built only from network mapping source|target pairs. Editing or clearing a VM's IP after the mapping was already made doesn't change that key, so the effect's if (mappingsKey === prevMappingsRef.current) return guard short-circuits and subnetWarnings never recomputes. The banner (and the "Persist source network interfaces" gate that reads the same state) keeps showing the stale IP/message indefinitely, even after the IP is updated to something now compatible (or incompatible) with the mapped subnet.

**Fix:** Extracted computeSubnetCheckSignature(mappings, networkIPsMap) — folds each mapping's resolved IPs (sorted, for order-independence) into the dedup key alongside the mapping pairs. Any IP edit/clear now changes the signature, so the effect re-runs and rebuilds subnetWarnings from scratch, correctly dropping or updating the affected network's message. checkNetworkSubnetCompatibility API-response caching (apiCacheRef, keyed by target+IPs) is untouched — this only fixes the outer gate that was skipping recompute entirely.

## Which issue(s) this PR fixes
fixes #2179

## Testing done


https://github.com/user-attachments/assets/c5291944-8431-43cc-b66b-e432ad46aaef


