### PR TITLE
[2213] Fix migration stuck in ConvertingDisk after transient VM creation timeout

### DIFF
--- a/k8s/migration/pkg/utils/migrationutils.go
+++ b/k8s/migration/pkg/utils/migrationutils.go
@@ -128,7 +128,7 @@ func CreateMigratingCondition(migration *vjailbreakv1alpha1.Migration, eventList
 func CreateFailedCondition(migration *vjailbreakv1alpha1.Migration, eventList *corev1.EventList) []corev1.PodCondition {
 	existingConditions := migration.Status.Conditions
 	for i := 0; i < len(eventList.Items); i++ {
-		if eventList.Items[i].Reason != constants.MigrationReason || !strings.Contains(eventList.Items[i].Message, "failed to") {
+		if eventList.Items[i].Reason != constants.MigrationReason || !strings.Contains(eventList.Items[i].Message, constants.EventMessageMigrationFailed) {
 			continue
 		}
 

--- a/k8s/migration/pkg/utils/migrationutils_test.go
+++ b/k8s/migration/pkg/utils/migrationutils_test.go
@@ -177,6 +177,11 @@ func TestCreateSucceededCondition(t *testing.T) {
 			}
 			if hasMigrated != tt.wantMigrated {
 				t.Errorf("hasMigrated = %v, want %v", hasMigrated, tt.wantMigrated)
+			}
+		})
+	}
+}
+
 func TestCreateFailedCondition_StripsCleanupBoilerplate(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/k8s/migration/pkg/utils/migrationutils_test.go
+++ b/k8s/migration/pkg/utils/migrationutils_test.go
@@ -1,0 +1,183 @@
+package utils
+
+import (
+	"testing"
+
+	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
+	"github.com/platform9/vjailbreak/pkg/common/constants"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func makeEvent(reason, message string) corev1.Event {
+	return corev1.Event{
+		Reason:        reason,
+		Message:       message,
+		LastTimestamp: metav1.Now(),
+	}
+}
+
+func makeMigration() *vjailbreakv1alpha1.Migration {
+	return &vjailbreakv1alpha1.Migration{}
+}
+
+func TestCreateFailedCondition(t *testing.T) {
+	tests := []struct {
+		name           string
+		events         []corev1.Event
+		wantConditions int
+		wantFailed     bool
+	}{
+		{
+			name: "cleanup event sets Failed condition",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, "failed to create target instance: timeout. Trying to perform cleanup"),
+			},
+			wantConditions: 1,
+			wantFailed:     true,
+		},
+		{
+			name: "bare EventMessageMigrationFailed sets Failed condition",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, constants.EventMessageMigrationFailed),
+			},
+			wantConditions: 1,
+			wantFailed:     true,
+		},
+		{
+			name: "lowercase 'failed to' no longer triggers Failed condition",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, "VM created despite CreateTargetInstance error (failed to create VM: context deadline exceeded), skipping cleanup"),
+			},
+			wantConditions: 0,
+			wantFailed:     false,
+		},
+		{
+			name: "capital 'Failed to' warning does not trigger Failed condition",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, "Warning: Failed to disconnect source VM network interfaces: timeout"),
+			},
+			wantConditions: 0,
+			wantFailed:     false,
+		},
+		{
+			name: "wrong reason ignored",
+			events: []corev1.Event{
+				makeEvent("SomeOtherReason", constants.EventMessageMigrationFailed),
+			},
+			wantConditions: 0,
+			wantFailed:     false,
+		},
+		{
+			name:           "empty event list",
+			events:         []corev1.Event{},
+			wantConditions: 0,
+			wantFailed:     false,
+		},
+		{
+			name: "only last cleanup event wins (multiple cleanup events)",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, "error A. Trying to perform cleanup"),
+				makeEvent(constants.MigrationReason, "error B. Trying to perform cleanup"),
+			},
+			wantConditions: 1,
+			wantFailed:     true,
+		},
+		{
+			name: "mix of matching and non-matching events",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, "VM created successfully: ID: abc-123"),
+				makeEvent(constants.MigrationReason, "Warning: Failed to disconnect source VM: timeout"),
+				makeEvent(constants.MigrationReason, "failed to create instance. Trying to perform cleanup"),
+			},
+			wantConditions: 1,
+			wantFailed:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			migration := makeMigration()
+			eventList := &corev1.EventList{Items: tt.events}
+
+			got := CreateFailedCondition(migration, eventList)
+
+			if len(got) != tt.wantConditions {
+				t.Errorf("got %d conditions, want %d", len(got), tt.wantConditions)
+			}
+
+			hasFailed := false
+			for _, c := range got {
+				if c.Type == constants.MigrationConditionTypeFailed {
+					hasFailed = true
+					break
+				}
+			}
+			if hasFailed != tt.wantFailed {
+				t.Errorf("hasFailed = %v, want %v", hasFailed, tt.wantFailed)
+			}
+		})
+	}
+}
+
+func TestCreateSucceededCondition(t *testing.T) {
+	tests := []struct {
+		name         string
+		events       []corev1.Event
+		wantMigrated bool
+	}{
+		{
+			name: "VM created successfully event sets Migrated condition",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, "VM created successfully: ID: abc-123"),
+			},
+			wantMigrated: true,
+		},
+		{
+			name: "recovery path message also sets Migrated condition",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, "VM created successfully: ID: abc-123 (recovered from timeout)"),
+			},
+			wantMigrated: true,
+		},
+		{
+			name: "wrong reason ignored",
+			events: []corev1.Event{
+				makeEvent("Other", "VM created successfully: ID: abc-123"),
+			},
+			wantMigrated: false,
+		},
+		{
+			name: "cleanup event does not set Migrated condition",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, "failed to create instance. Trying to perform cleanup"),
+			},
+			wantMigrated: false,
+		},
+		{
+			name:         "empty events",
+			events:       []corev1.Event{},
+			wantMigrated: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			migration := makeMigration()
+			eventList := &corev1.EventList{Items: tt.events}
+
+			got := CreateSucceededCondition(migration, eventList)
+
+			hasMigrated := false
+			for _, c := range got {
+				if c.Type == constants.MigrationConditionTypeMigrated {
+					hasMigrated = true
+					break
+				}
+			}
+			if hasMigrated != tt.wantMigrated {
+				t.Errorf("hasMigrated = %v, want %v", hasMigrated, tt.wantMigrated)
+			}
+		})
+	}
+}

--- a/v2v-helper/migrate/hotadd_copy.go
+++ b/v2v-helper/migrate/hotadd_copy.go
@@ -394,7 +394,7 @@ func (migobj *Migrate) cleanupHotAdd(ctx context.Context, sshClient *esxissh.Cli
 			continue
 		}
 		if _, err := sshClient.ExecuteCommand(fmt.Sprintf("kill %d 2>/dev/null; true", t.NBDPid)); err != nil {
-			migobj.logMessage(fmt.Sprintf("Warning: failed to kill qemu-nbd PID %d: %v", t.NBDPid, err))
+			utils.PrintLog(fmt.Sprintf("Warning: failed to kill qemu-nbd PID %d: %v", t.NBDPid, err))
 		}
 	}
 
@@ -402,7 +402,7 @@ func (migobj *Migrate) cleanupHotAdd(ctx context.Context, sshClient *esxissh.Cli
 	if proxyVMObj != nil {
 		var vmProps mo.VirtualMachine
 		if err := proxyVMObj.Properties(ctx, proxyVMObj.Reference(), []string{"config.hardware.device"}, &vmProps); err != nil {
-			migobj.logMessage(fmt.Sprintf("Warning: failed to read proxy VM devices during cleanup: %v", err))
+			utils.PrintLog(fmt.Sprintf("Warning: failed to read proxy VM devices during cleanup: %v", err))
 		} else {
 			for _, t := range transfers {
 				if t.DiskKey == 0 {
@@ -411,7 +411,7 @@ func (migobj *Migrate) cleanupHotAdd(ctx context.Context, sshClient *esxissh.Cli
 				for _, dev := range vmProps.Config.Hardware.Device {
 					if dev.GetVirtualDevice().Key == t.DiskKey {
 						if err := proxyVMObj.RemoveDevice(ctx, true, dev); err != nil {
-							migobj.logMessage(fmt.Sprintf("Warning: failed to detach disk key %d from proxy VM: %v", t.DiskKey, err))
+							utils.PrintLog(fmt.Sprintf("Warning: failed to detach disk key %d from proxy VM: %v", t.DiskKey, err))
 						}
 						break
 					}
@@ -422,7 +422,7 @@ func (migobj *Migrate) cleanupHotAdd(ctx context.Context, sshClient *esxissh.Cli
 
 	// Remove the source VM snapshot.
 	if err := migobj.VMops.DeleteSnapshot(hotAddSnapName); err != nil {
-		migobj.logMessage(fmt.Sprintf("Warning: failed to remove snapshot '%s': %v", hotAddSnapName, err))
+		utils.PrintLog(fmt.Sprintf("Warning: failed to remove snapshot '%s': %v", hotAddSnapName, err))
 	}
 
 	// Decrement the proxy VM's attached disk count for every disk we attached.
@@ -515,7 +515,7 @@ func (migobj *Migrate) HotAddCopyDisks(ctx context.Context, vminfo vm.VMInfo) er
 	}
 	defer func() {
 		if err := sshClient.Disconnect(); err != nil {
-			migobj.logMessage(fmt.Sprintf("Warning: failed to disconnect SSH client: %v", err))
+			utils.PrintLog(fmt.Sprintf("Warning: failed to disconnect SSH client: %v", err))
 		}
 	}()
 

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -354,10 +354,10 @@ func (migobj *Migrate) DetachAllVolumesWithCleanup(ctx context.Context, vminfo v
 	return nil
 }
 
-func (migobj *Migrate) verifyVMCreatedDespiteTimeout(ctx context.Context, vminfo vm.VMInfo) error {
+func (migobj *Migrate) verifyVMCreatedDespiteTimeout(ctx context.Context, vminfo vm.VMInfo) (string, error) {
 	vjailbreakUUID, err := utils.GetCurrentInstanceUUID()
 	if err != nil {
-		return errors.Wrap(err, "failed to get vJailbreak instance UUID")
+		return "", errors.Wrap(err, "failed to get vJailbreak instance UUID")
 	}
 
 	var bootDisk *vm.VMDisk
@@ -368,34 +368,34 @@ func (migobj *Migrate) verifyVMCreatedDespiteTimeout(ctx context.Context, vminfo
 		}
 	}
 	if bootDisk == nil || bootDisk.OpenstackVol == nil {
-		return fmt.Errorf("no boot volume found")
+		return "", fmt.Errorf("no boot volume found")
 	}
 
 	volume, err := migobj.Openstackclients.GetVolume(ctx, bootDisk.OpenstackVol.ID)
 	if err != nil {
-		return errors.Wrap(err, "failed to get boot volume")
+		return "", errors.Wrap(err, "failed to get boot volume")
 	}
 
 	if len(volume.Attachments) == 0 {
-		return fmt.Errorf("boot volume is not attached to any server")
+		return "", fmt.Errorf("boot volume is not attached to any server")
 	}
 
 	attachedServerID := volume.Attachments[0].ServerID
 	if attachedServerID == vjailbreakUUID {
-		return fmt.Errorf("boot volume is still attached to vJailbreak VM")
+		return "", fmt.Errorf("boot volume is still attached to vJailbreak VM")
 	}
 
 	status, err := migobj.Openstackclients.GetServerStatus(ctx, attachedServerID)
 	if err != nil {
-		return errors.Wrap(err, "failed to get target VM status")
+		return "", errors.Wrap(err, "failed to get target VM status")
 	}
 
 	if strings.ToUpper(status) != "ACTIVE" {
-		return fmt.Errorf("target VM %s is in %s state", attachedServerID, status)
+		return "", fmt.Errorf("target VM %s is in %s state", attachedServerID, status)
 	}
 
 	migobj.logMessage(fmt.Sprintf("Boot volume attached to active target VM %s", attachedServerID))
-	return nil
+	return attachedServerID, nil
 }
 
 func (migobj *Migrate) DeleteAllVolumes(ctx context.Context, vminfo vm.VMInfo) error {
@@ -2231,8 +2231,9 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 
 	err = migobj.CreateTargetInstance(ctx, vminfo, networkids, portids, ipaddresses, espDiskIndex)
 	if err != nil {
-		if recoveryErr := migobj.verifyVMCreatedDespiteTimeout(ctx, vminfo); recoveryErr == nil {
-			migobj.logMessage(fmt.Sprintf("VM created despite CreateTargetInstance error (%v), skipping cleanup", err))
+		if serverID, recoveryErr := migobj.verifyVMCreatedDespiteTimeout(ctx, vminfo); recoveryErr == nil {
+			utils.PrintLog(fmt.Sprintf("VM created despite CreateTargetInstance error (%v), skipping cleanup", err))
+			migobj.logMessage(fmt.Sprintf("VM created successfully: ID: %s", serverID))
 		} else {
 			if cleanuperror := migobj.cleanup(ctx, vminfo, fmt.Sprintf("failed to create target instance: %s", err), portids, vcenterSettings); cleanuperror != nil {
 				// combine both errors
@@ -2243,7 +2244,7 @@ func (migobj *Migrate) MigrateVM(ctx context.Context) error {
 	}
 
 	if err := migobj.DisconnectSourceNetworkIfRequested(); err != nil {
-		migobj.logMessage(fmt.Sprintf("Warning: Failed to disconnect source VM network interfaces: %v", err))
+		utils.PrintLog(fmt.Sprintf("Warning: Failed to disconnect source VM network interfaces: %v", err))
 	}
 
 	return nil

--- a/v2v-helper/migrate/vaai_copy.go
+++ b/v2v-helper/migrate/vaai_copy.go
@@ -243,7 +243,7 @@ func (migobj *Migrate) copyDiskViaStorageAcceleratedCopy(ctx context.Context, es
 	defer func() {
 		migobj.logMessage("Cleaning up volume mappings")
 		if err := migobj.StorageProvider.UnmapVolumeFromGroup(initiatorGroup, targetVol, mappingContext); err != nil {
-			migobj.logMessage(fmt.Sprintf("Warning: Failed to unmap target volume: %v", err))
+			utils.PrintLog(fmt.Sprintf("Warning: Failed to unmap target volume: %v", err))
 		}
 	}()
 


### PR DESCRIPTION
## Summary

- `verifyVMCreatedDespiteTimeout` now returns `(string, error)` so caller gets the confirmed server ID
- Recovery path uses `utils.PrintLog` for error context (no K8s Event) and emits `logMessage("VM created successfully: ID: %s")` so the controller transitions correctly
- `CreateFailedCondition` now matches `EventMessageMigrationFailed` ("Trying to perform cleanup") instead of loose `"failed to"` substring — eliminates false Failed conditions on non-fatal warnings
- Non-fatal cleanup warnings in `hotadd_copy.go`, `vaai_copy.go`, and post-success `DisconnectSourceNetworkIfRequested` downgraded from `logMessage` to `utils.PrintLog` to avoid spurious K8s Events

## Root Cause

When `CreateTargetInstance` timed out but the VM was confirmed ACTIVE via `verifyVMCreatedDespiteTimeout`, the recovery path called `logMessage` with `"failed to"` in the message. This:
1. Created a Kubernetes Event containing `"failed to"` → triggered the loose `CreateFailedCondition` check
2. Never emitted `"VM created successfully"` → controller never saw the success signal → migration stuck at `ConvertingDisk`

## Test plan

- [x] Unit tests added in `migrationutils_test.go` covering the fixed condition matching logic
- [x] Run `cd k8s/migration && make test`
- [x] Verify migration completes when `CreateTargetInstance` times out but VM becomes ACTIVE

Closes #2132

🤖 Generated with [Claude Code](https://claude.com/claude-code)