### PR TITLE
Add Proxy VM port requirements for vJailbreak Accelerated Copy

### DIFF
--- a/docs/src/content/docs/concepts/vjailbreak-accelerated-copy.md
+++ b/docs/src/content/docs/concepts/vjailbreak-accelerated-copy.md
@@ -31,6 +31,7 @@ vJailbreak Accelerated Copy bypasses this limitation by:
 
 - **Proxy VM**: A Linux VM running in the same vCenter with `qemu-nbd` and `openssh-server` installed
 - **SSH access**: vJailbreak must be able to SSH into the Proxy VM as root
+- **Open ports**: The Proxy VM must accept inbound TCP from the vJailbreak VM on **22** (SSH) and **10809–11808** (`qemu-nbd`, one port per disk copied in parallel)
 - **disk.EnableUUID**: Must be set to `TRUE` on the Proxy VM in vCenter
 - **vCenter permissions**: Sufficient permissions to snapshot VMs and attach/detach disks
 
@@ -290,7 +291,7 @@ Error: failed to connect to NBD endpoint on proxy VM
 **Resolution:**
 1. Verify the Proxy VM is still running and SSH is accessible
 2. Check that `qemu-nbd` started successfully — review v2v helper logs
-3. Ensure the NBD port (typically in the 10809+ range) is not blocked by a firewall between the Proxy VM and vJailbreak
+3. Ensure the NBD ports (TCP **10809–11808**, one per disk copied in parallel) are not blocked by a firewall between the Proxy VM and vJailbreak
 4. Confirm the Proxy VM's guest IP is correct (VMware Tools must be running)
 
 ### Block Device Not Found in Proxy VM

--- a/docs/src/content/docs/introduction/getting_started.mdx
+++ b/docs/src/content/docs/introduction/getting_started.mdx
@@ -13,6 +13,12 @@ provisioning operations including creation of volumes, VMs.
 ### Network and access requirements
 Ensure that your vJailbreak VM can communicate with your OpenStack and VMware environments. This includes any setup required for VPNs, etc.
 
+:::note[vJailbreak Accelerated Copy]
+When using the **vJailbreak Accelerated Copy** data copy method, the onboarded Proxy VM must accept the following inbound TCP traffic from the vJailbreak VM:
+- **10809–11808** — used by `qemu-nbd` to expose attached disks (one port per disk copied in parallel)
+- **22** — SSH, used by vJailbreak to control the Proxy VM
+:::
+
 <ReadMore>Further details can be found in [Prerequisites](../prerequisites/).</ReadMore>
 
 ### Download vJailbreak Image

--- a/docs/src/content/docs/introduction/prerequisites.md
+++ b/docs/src/content/docs/introduction/prerequisites.md
@@ -109,6 +109,8 @@ Please refer the following table for the required ports:
 | 443 | TCP | PCD nodes | VMware ESXi hosts | Disk transfer authentication |
 | 902 | TCP | PCD nodes | VMware ESXi hosts | Disk transfer data copy via NFC protocol (see NFC limitations above) |
 | 5480 | TCP | PCD nodes | VMware vCenter API endpoint | VMware Site Recovery Manager Appliance Management Interface |
+| 22 | TCP | vJailbreak VM | Proxy VM | vJailbreak Accelerated Copy only: SSH control of the Proxy VM |
+| 10809–11808 | TCP | vJailbreak VM | Proxy VM | vJailbreak Accelerated Copy only: `qemu-nbd` disk transfer (one port per disk copied in parallel) |
 
 
 ### What network connectivity do I need for vJailbreak?


### PR DESCRIPTION
Documents the inbound TCP ports that must be open on the onboarded Proxy VM for vJailbreak Accelerated Copy — 22 (SSH control) and 10809–11808 (`qemu-nbd`, one per parallel disk) — in the getting started, prerequisites, and Accelerated Copy concept pages.