### PR TITLE
[2193] Prevent checkbox selection column from being hidden via Manage Columns

### DIFF
--- a/ui/src/components/grid/CommonDataGrid.test.ts
+++ b/ui/src/components/grid/CommonDataGrid.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { GRID_CHECKBOX_SELECTION_COL_DEF } from '@mui/x-data-grid'
+import { defaultGetTogglableColumns } from './CommonDataGrid'
+
+describe('defaultGetTogglableColumns', () => {
+  it('excludes the row-selection checkbox column', () => {
+    const columns = [
+      { field: 'name' },
+      { field: GRID_CHECKBOX_SELECTION_COL_DEF.field },
+      { field: 'status' }
+    ]
+
+    expect(defaultGetTogglableColumns(columns)).toEqual(['name', 'status'])
+  })
+
+  it('returns all fields when no checkbox column is present', () => {
+    const columns = [{ field: 'name' }, { field: 'status' }]
+
+    expect(defaultGetTogglableColumns(columns)).toEqual(['name', 'status'])
+  })
+})

--- a/ui/src/components/grid/CommonDataGrid.tsx
+++ b/ui/src/components/grid/CommonDataGrid.tsx
@@ -1,5 +1,11 @@
 import { Box, CircularProgress, Typography, styled } from '@mui/material'
-import { DataGrid, DataGridProps, GridOverlay, GridValidRowModel } from '@mui/x-data-grid'
+import {
+  DataGrid,
+  DataGridProps,
+  GridOverlay,
+  GridValidRowModel,
+  GRID_CHECKBOX_SELECTION_COL_DEF
+} from '@mui/x-data-grid'
 import { alpha } from '@mui/material/styles'
 import type { SxProps, Theme } from '@mui/material/styles'
 
@@ -50,6 +56,9 @@ type CommonDataGridProps<R extends GridValidRowModel> = DataGridProps<R> & {
   emptyMessage?: string
 }
 
+export const defaultGetTogglableColumns = (columns: { field: string }[]) =>
+  columns.filter((column) => column.field !== GRID_CHECKBOX_SELECTION_COL_DEF.field).map((column) => column.field)
+
 export default function CommonDataGrid<R extends GridValidRowModel>(props: CommonDataGridProps<R>) {
   const { loadingMessage, emptyMessage, slots, slotProps, sx, ...rest } = props
 
@@ -57,6 +66,14 @@ export default function CommonDataGrid<R extends GridValidRowModel>(props: Commo
     loadingOverlay: () => <DefaultLoadingOverlay loadingMessage={loadingMessage} />,
     noRowsOverlay: () => <DefaultNoRowsOverlay emptyMessage={emptyMessage} />,
     ...slots
+  }
+
+  const mergedSlotProps = {
+    ...slotProps,
+    columnsManagement: {
+      getTogglableColumns: defaultGetTogglableColumns,
+      ...slotProps?.columnsManagement
+    }
   }
 
   const baseSx = (theme) => ({
@@ -126,5 +143,5 @@ export default function CommonDataGrid<R extends GridValidRowModel>(props: Commo
     return [baseSx, sx]
   })()
 
-  return <DataGrid {...rest} slots={mergedSlots} slotProps={slotProps} sx={mergedSx} />
+  return <DataGrid {...rest} slots={mergedSlots} slotProps={mergedSlotProps} sx={mergedSx} />
 }

--- a/ui/src/components/grid/index.ts
+++ b/ui/src/components/grid/index.ts
@@ -1,4 +1,4 @@
 export { default as CustomSearchToolbar, DATE_FILTER_OPTIONS } from './CustomSearchToolbar'
 export { default as CustomLoadingOverlay } from './CustomLoadingOverlay'
-export { default as CommonDataGrid } from './CommonDataGrid'
+export { default as CommonDataGrid, defaultGetTogglableColumns } from './CommonDataGrid'
 export { default as ListingToolbar } from './ListingToolbar'

--- a/ui/src/features/migration/steps/VmsSelectionStep.tsx
+++ b/ui/src/features/migration/steps/VmsSelectionStep.tsx
@@ -21,7 +21,7 @@ import {
   GridRow,
   GridRowSelectionModel,
 } from '@mui/x-data-grid'
-import { CustomLoadingOverlay, CustomSearchToolbar } from 'src/components/grid'
+import { CustomLoadingOverlay, CustomSearchToolbar, defaultGetTogglableColumns } from 'src/components/grid'
 import { Step } from 'src/shared/components/forms'
 import * as React from 'react'
 import { RdmDisk } from 'src/api/rdm-disks/model'
@@ -307,6 +307,9 @@ function VmsSelectionStep(props: VmsSelectionStepProps) {
                     </Box>
                   ),
                 }}
+                slotProps={{
+                  columnsManagement: { getTogglableColumns: defaultGetTogglableColumns },
+                }}
                 disableColumnFilter
                 loading={loadingVMs}
               />
@@ -383,6 +386,9 @@ function VmsSelectionStep(props: VmsSelectionStepProps) {
                       </Tooltip>
                     )
                   },
+                }}
+                slotProps={{
+                  columnsManagement: { getTogglableColumns: defaultGetTogglableColumns },
                 }}
                 loading={loadingVms || loadingMigratedVms}
                 checkboxSelection


### PR DESCRIPTION
## What this PR does / why we need it

- Checkbox row-selection column showed up in DataGrid's "Manage columns" panel, letting users hide/show it like a normal data column. Not valid — it's a selection control, must always stay visible.
- Added defaultGetTogglableColumns in CommonDataGrid (shared wrapper, used by 7/8 tables) that excludes the checkbox field from the togglable-columns list by default.
- VmsSelectionStep.tsx uses raw MUI DataGrid (not the common wrapper) — wired both its grid instances to the same shared helper instead of duplicating logic.

## Which issue(s) this PR fixes
fixes #2193 

## Testing done

https://github.com/user-attachments/assets/5fbb05d0-bce1-4529-a437-305a7cfe21a3

