### PR TITLE
[2191] Grid/list toggle wraps left instead of staying inline on Templates tooolbar

### DIFF
--- a/ui/src/features/migration/components/templates/TemplatesToolbar.tsx
+++ b/ui/src/features/migration/components/templates/TemplatesToolbar.tsx
@@ -70,7 +70,7 @@ export default function TemplatesToolbar({
         data-testid="templates-search"
         size="small"
         variant="standard"
-        sx={{ width: '100%', maxWidth: 220, minWidth: 0 }}
+        sx={{ width: 220, minWidth: 0 }}
         InputProps={{
           sx: { '& .MuiInputBase-input': { textOverflow: 'ellipsis' } },
           startAdornment: (


### PR DESCRIPTION
## What this PR does / why we need it
**RCA:**
TemplatesToolbar.tsx:73 search TextField had sx={{ width: '100%', maxWidth: 220, minWidth: 0 }} inside flex-wrap container. width:'100%' resolves as flex-basis; combined with flexWrap:'wrap' parent, forced ToggleButtonGroup (grid/list view) onto new line, left-aligned — even with ~250px unused space to its right. Not viewport/breakpoint-dependent — pure flex-basis miscalculation, so identical across all browsers/resolutions as reported.

**Fix:**
width: 220 (drop redundant width:'100%' + maxWidth). Removes flex-basis ambiguity, keeps toolbar on one line, toggle stays right next to Sort dropdown.

## Which issue(s) this PR fixes
fixes #2191

## Testing done
<img width="1439" height="816" alt="image" src="https://github.com/user-attachments/assets/57e7c746-b0fb-457f-a3e7-c2ece4af92a1" />
