### PR TITLE
[2194] Fix: Converting Disk status should not show count of disks

### DIFF
--- a/ui/src/features/migration/components/detail/MigrationPhaseDetail.tsx
+++ b/ui/src/features/migration/components/detail/MigrationPhaseDetail.tsx
@@ -107,10 +107,7 @@ function CopyingPhaseDetail({ migration }: { migration: Migration }) {
 
 // ─── Converting Disk ─────────────────────────────────────────────────────────
 
-function ConvertingDiskDetail({ migration }: { migration: Migration }) {
-  const status = migration.status
-  const totalDisks = status?.totalDisks
-
+function ConvertingDiskDetail() {
   return (
     <Box
       sx={{
@@ -129,7 +126,7 @@ function ConvertingDiskDetail({ migration }: { migration: Migration }) {
         Converting Disk Format
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        {`Converting ${totalDisks != null ? `${totalDisks} ` : ''}disk${totalDisks !== 1 ? 's' : ''} from VMDK to target format using virt-v2v.`}
+        Converting disk from VMDK to target format using virt-v2v.
       </Typography>
       <LinearProgress variant="indeterminate" sx={{ height: 6, borderRadius: 3 }} />
     </Box>
@@ -405,7 +402,7 @@ export default function MigrationPhaseDetail({
       return <CopyingPhaseDetail migration={migration} />
 
     case Phase.ConvertingDisk:
-      return <ConvertingDiskDetail migration={migration} />
+      return <ConvertingDiskDetail />
 
     case Phase.AwaitingAdminCutOver:
     case Phase.AwaitingCutOverStartTime:

--- a/ui/src/features/migration/utils/phaseUtils.test.ts
+++ b/ui/src/features/migration/utils/phaseUtils.test.ts
@@ -62,6 +62,16 @@ describe('derivePhaseStates — active migration', () => {
     expect(states[5].status).toBe('pending')
   })
 
+  it('does not reveal disk count while converting (GHI #2194)', () => {
+    const migration = {
+      metadata: { creationTimestamp: T0 },
+      status: { phase: Phase.ConvertingDisk, conditions: fullConditions, currentDisk: 1, totalDisks: 2 }
+    } as unknown as Migration
+    const states = derivePhaseStates(migration)
+
+    expect(states[4].detail).toBe('Converting disk format…')
+  })
+
   it('pauses at cutover while awaiting admin', () => {
     const states = derivePhaseStates(
       buildMigration(Phase.AwaitingAdminCutOver, [condition('Validated', 2), condition('DataCopy', 30)])

--- a/ui/src/features/migration/utils/phaseUtils.ts
+++ b/ui/src/features/migration/utils/phaseUtils.ts
@@ -122,14 +122,7 @@ function activeDetail(migration: Migration, designIndex: number): string {
       return 'Transferring disk data…'
     }
     case 3: return 'Waiting for admin to initiate cutover.'
-    case 4: {
-      if (status?.currentDisk != null && status?.totalDisks) {
-        const diskNum = parseInt(String(status.currentDisk), 10)
-        const display = Number.isNaN(diskNum) ? status.currentDisk : diskNum + 1
-        return `Converting disk ${display} of ${status.totalDisks}`
-      }
-      return 'Converting disk format…'
-    }
+    case 4: return 'Converting disk format…'
     default: return 'In progress…'
   }
 }

--- a/ui/src/features/migration/utils/phaseUtils.ts
+++ b/ui/src/features/migration/utils/phaseUtils.ts
@@ -122,7 +122,7 @@ function activeDetail(migration: Migration, designIndex: number): string {
       return 'Transferring disk data…'
     }
     case 3: return 'Waiting for admin to initiate cutover.'
-    case 4: return 'Converting disk format…'
+    case 4: return 'Converting disk.'
     default: return 'In progress…'
   }
 }


### PR DESCRIPTION
## What this PR does / why we need it
Disk count/index shouldn't surface in UI messaging for this phase — should read as a generic conversion-in-progress message. So changed the message

## Which issue(s) this PR fixes
fixes #2194

## Testing done
<img width="1436" height="810" alt="image" src="https://github.com/user-attachments/assets/f89012e0-eea9-4ef8-8861-97793439c9cf" />
<img width="1438" height="811" alt="image" src="https://github.com/user-attachments/assets/c76e7285-9472-4018-b921-f19cfd6b0219" />
