### PR TITLE
[2201] Show migration failure messages on the UI

### DIFF
--- a/k8s/migration/pkg/utils/migrationutils.go
+++ b/k8s/migration/pkg/utils/migrationutils.go
@@ -123,19 +123,12 @@ func CreateMigratingCondition(migration *vjailbreakv1alpha1.Migration, eventList
 	return existingConditions
 }
 
-// eventMessageRecoveredFromTimeout marks a recovery message that mentions "failed to" but
-// is not an actual failure.
-const eventMessageRecoveredFromTimeout = "skipping cleanup"
-
 // isFailureEventMessage reports whether an event message represents a genuine terminal
-// migration failure, matched case-insensitively. Warning messages and the timeout-recovery
-// message are excluded since they don't represent a real failure.
+// migration failure, matched case-insensitively. Warning messages are excluded since they
+// don't represent a real failure.
 func isFailureEventMessage(msg string) bool {
 	trimmed := strings.TrimSpace(msg)
 	if strings.HasPrefix(trimmed, constants.EventMessageWarningPrefix) {
-		return false
-	}
-	if strings.Contains(trimmed, eventMessageRecoveredFromTimeout) {
 		return false
 	}
 	lower := strings.ToLower(trimmed)

--- a/k8s/migration/pkg/utils/migrationutils.go
+++ b/k8s/migration/pkg/utils/migrationutils.go
@@ -123,24 +123,13 @@ func CreateMigratingCondition(migration *vjailbreakv1alpha1.Migration, eventList
 	return existingConditions
 }
 
-// eventMessageRecoveredFromTimeout is the one known message that legitimately contains
-// "failed to" while describing a migration that RECOVERED, not one that failed: when
-// CreateTargetInstance times out but verifyVMCreatedDespiteTimeout later confirms the VM
-// was actually created, migrate.go logs "VM created despite CreateTargetInstance error
-// (failed to create VM: ...), skipping cleanup" and continues normally. It must never be
-// mistaken for a terminal failure.
+// eventMessageRecoveredFromTimeout marks a recovery message that mentions "failed to" but
+// is not an actual failure.
 const eventMessageRecoveredFromTimeout = "skipping cleanup"
 
 // isFailureEventMessage reports whether an event message represents a genuine terminal
-// migration failure. It matches the cleanup-boilerplate marker (set when migobj.cleanup()
-// runs), virt-v2v/nbd root-cause messages surfaced from debug logs (e.g. "failed to run
-// nbdcopy: ...", see v2v-helper/nbd/nbdops.go and virtv2v/virtv2vops.go), and v2v-helper's
-// top-level error handling in main.go (e.g. "Failed to migrate VM: ..." and early setup
-// failures before MigrateVM even starts) — case-insensitively, since these come from
-// different layers with inconsistent capitalization. It excludes "Warning: ..." messages
-// (non-fatal mid-migration warnings, e.g. migrate.go's get-bootable-partition/
-// generate-mount-persistence warnings) and the timeout-recovery message above, neither of
-// which represent an actual failure.
+// migration failure, matched case-insensitively. Warning messages and the timeout-recovery
+// message are excluded since they don't represent a real failure.
 func isFailureEventMessage(msg string) bool {
 	trimmed := strings.TrimSpace(msg)
 	if strings.HasPrefix(trimmed, constants.EventMessageWarningPrefix) {

--- a/k8s/migration/pkg/utils/migrationutils.go
+++ b/k8s/migration/pkg/utils/migrationutils.go
@@ -123,12 +123,43 @@ func CreateMigratingCondition(migration *vjailbreakv1alpha1.Migration, eventList
 	return existingConditions
 }
 
+// eventMessageRecoveredFromTimeout is the one known message that legitimately contains
+// "failed to" while describing a migration that RECOVERED, not one that failed: when
+// CreateTargetInstance times out but verifyVMCreatedDespiteTimeout later confirms the VM
+// was actually created, migrate.go logs "VM created despite CreateTargetInstance error
+// (failed to create VM: ...), skipping cleanup" and continues normally. It must never be
+// mistaken for a terminal failure.
+const eventMessageRecoveredFromTimeout = "skipping cleanup"
+
+// isFailureEventMessage reports whether an event message represents a genuine terminal
+// migration failure. It matches the cleanup-boilerplate marker (set when migobj.cleanup()
+// runs), virt-v2v/nbd root-cause messages surfaced from debug logs (e.g. "failed to run
+// nbdcopy: ...", see v2v-helper/nbd/nbdops.go and virtv2v/virtv2vops.go), and v2v-helper's
+// top-level error handling in main.go (e.g. "Failed to migrate VM: ..." and early setup
+// failures before MigrateVM even starts) — case-insensitively, since these come from
+// different layers with inconsistent capitalization. It excludes "Warning: ..." messages
+// (non-fatal mid-migration warnings, e.g. migrate.go's get-bootable-partition/
+// generate-mount-persistence warnings) and the timeout-recovery message above, neither of
+// which represent an actual failure.
+func isFailureEventMessage(msg string) bool {
+	trimmed := strings.TrimSpace(msg)
+	if strings.HasPrefix(trimmed, constants.EventMessageWarningPrefix) {
+		return false
+	}
+	if strings.Contains(trimmed, eventMessageRecoveredFromTimeout) {
+		return false
+	}
+	lower := strings.ToLower(trimmed)
+	return strings.Contains(lower, strings.ToLower(constants.EventMessageMigrationFailed)) ||
+		strings.Contains(lower, strings.ToLower(constants.EventMessageFailed))
+}
+
 // CreateFailedCondition creates or updates a failed condition for a migration based on events.
 // It analyzes event logs to identify failure reasons and updates the migration's status conditions accordingly.
 func CreateFailedCondition(migration *vjailbreakv1alpha1.Migration, eventList *corev1.EventList) []corev1.PodCondition {
 	existingConditions := migration.Status.Conditions
 	for i := 0; i < len(eventList.Items); i++ {
-		if eventList.Items[i].Reason != constants.MigrationReason || !strings.Contains(eventList.Items[i].Message, constants.EventMessageMigrationFailed) {
+		if eventList.Items[i].Reason != constants.MigrationReason || !isFailureEventMessage(eventList.Items[i].Message) {
 			continue
 		}
 

--- a/k8s/migration/pkg/utils/migrationutils_test.go
+++ b/k8s/migration/pkg/utils/migrationutils_test.go
@@ -45,12 +45,16 @@ func TestCreateFailedCondition(t *testing.T) {
 			wantFailed:     true,
 		},
 		{
-			name: "lowercase 'failed to' no longer triggers Failed condition",
+			// This exact message is logged via utils.PrintLog, not migobj.logMessage, so it
+			// never actually reaches eventList in production — but matching is otherwise
+			// correct: lowercase "failed to" is a real failure signal (e.g. virt-v2v/nbd
+			// root-cause messages).
+			name: "lowercase 'failed to' triggers Failed condition",
 			events: []corev1.Event{
 				makeEvent(constants.MigrationReason, "VM created despite CreateTargetInstance error (failed to create VM: context deadline exceeded), skipping cleanup"),
 			},
-			wantConditions: 0,
-			wantFailed:     false,
+			wantConditions: 1,
+			wantFailed:     true,
 		},
 		{
 			name: "capital 'Failed to' warning does not trigger Failed condition",

--- a/k8s/migration/pkg/utils/migrationutils_test.go
+++ b/k8s/migration/pkg/utils/migrationutils_test.go
@@ -93,6 +93,38 @@ func TestCreateFailedCondition(t *testing.T) {
 			wantConditions: 1,
 			wantFailed:     true,
 		},
+		{
+			// v2v-helper's top-level error handler (main.go) reports
+			// terminal failures as "Failed to migrate VM: <err>." without ever routing through
+			// migobj.cleanup(), so this never contains "Trying to perform cleanup". Requiring
+			// that phrase made these genuine failures invisible on the migrations page and details page.
+			name: "top-level 'Failed to migrate VM' event sets Failed condition",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, "Failed to migrate VM: failed to convert disks: some error. "),
+			},
+			wantConditions: 1,
+			wantFailed:     true,
+		},
+		{
+			// failures during early setup (before MigrateVM even
+			// starts, e.g. vCenter/OpenStack connection issues) never call cleanup() either.
+			name: "early setup 'Failed to' event sets Failed condition",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, "Failed to validate vCenter connection: dial tcp: timeout"),
+			},
+			wantConditions: 1,
+			wantFailed:     true,
+		},
+		{
+			// Non-fatal mid-migration warnings (migrate.go's get-bootable-partition.sh /
+			// generate-mount-persistence.sh warnings) must still not be mistaken for failures.
+			name: "warning-prefixed 'Failed to' from a mid-migration script does not trigger Failed condition",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, "Warning: Failed to run get-bootable-partition.sh: exit status 1"),
+			},
+			wantConditions: 0,
+			wantFailed:     false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -385,6 +385,7 @@ const (
 	EventMessageMigrationFailed                   = "Trying to perform cleanup"
 	EventMessageCopyingDisk                       = "Copying disk"
 	EventMessageFailed                            = "Failed to"
+	EventMessageWarningPrefix                     = "Warning:"
 	EventDisconnect                               = "Disconnected network interfaces"
 	// EventMessageDataCopied is sent by v2v-helper when data-only mode completes disk copy/conversion.
 	EventMessageDataCopied = "DataOnly mode: disk copy and conversion complete, skipping VM creation"
@@ -670,9 +671,9 @@ runcmd:
 		vjailbreakv1alpha1.VMMigrationPhaseAttachingDisksToProxy:   6,
 		vjailbreakv1alpha1.VMMigrationPhaseIdentifyingBlockDevices: 7,
 		// Common phases to both the copy methods.
-		vjailbreakv1alpha1.VMMigrationPhaseCopying:             11,
-		vjailbreakv1alpha1.VMMigrationPhaseHotAddTransferring:  11,
-		vjailbreakv1alpha1.VMMigrationPhaseHotAddCleanup:       12,
+		vjailbreakv1alpha1.VMMigrationPhaseCopying:                  11,
+		vjailbreakv1alpha1.VMMigrationPhaseHotAddTransferring:       11,
+		vjailbreakv1alpha1.VMMigrationPhaseHotAddCleanup:            12,
 		vjailbreakv1alpha1.VMMigrationPhaseAwaitingCutOverStartTime: 12,
 		vjailbreakv1alpha1.VMMigrationPhaseAwaitingAdminCutOver:     13,
 		// Post-cutover phases: these happen after admin triggers cutover

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1238,7 +1238,7 @@ func (migobj *Migrate) handleLinuxOSDetection(vminfo vm.VMInfo, bootVolumeIndex 
 	var cmdErr error
 
 	if ans, cmdErr = virtv2v.RunGetBootablePartitionScript(vminfo.VMDisks); cmdErr != nil {
-		migobj.logMessage(fmt.Sprintf("Warning: Failed to run get-bootable-partition.sh: %v", cmdErr))
+		utils.PrintLog(fmt.Sprintf("Warning: Failed to run get-bootable-partition.sh: %v", cmdErr))
 	} else if ans != "" {
 		migobj.logMessage(fmt.Sprintf("Bootable partition: %s", ans))
 	}
@@ -1304,7 +1304,7 @@ func (migobj *Migrate) handleLinuxOSDetection(vminfo vm.VMInfo, bootVolumeIndex 
 	if autoFstabUpdate {
 		migobj.logMessage("Running generate-mount-persistence.sh script")
 		if err := virtv2v.RunMountPersistenceScript(vminfo.VMDisks, vminfo.VMDisks[finalBootIndex].Path, osRelease); err != nil {
-			migobj.logMessage(fmt.Sprintf("Warning: Failed to run generate-mount-persistence.sh: %v", err))
+			utils.PrintLog(fmt.Sprintf("Warning: Failed to run generate-mount-persistence.sh: %v", err))
 			// Don't fail the migration, just log the warning
 		} else {
 			migobj.logMessage("Successfully ran generate-mount-persistence.sh script")


### PR DESCRIPTION
## What this PR does / why we need it
**RCA:** PR #2192 : Narrowed the match to only "Trying to perform cleanup". Side effect: broke visibility for almost every other failure type.

**Fix:** This PR restores broad detection of genuine failures while still correctly ignoring the one harmless recovery case the earlier fix was meant to handle, and also filters out non-fatal warning messages so they don't get mistaken for failures. As a result, users again see the actual error message for a failed migration, without reintroducing the original stuck-migration problem.

## Which issue(s) this PR fixes
fixes #2201 

## Testing done

https://github.com/user-attachments/assets/03dd11bd-0370-437a-960c-05c66883b69a

