### PR TITLE
Support encrypted volume types in pcd. 

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -610,7 +610,7 @@ func (migobj *Migrate) SyncCBT(ctx context.Context, vminfo vm.VMInfo) error {
 			changedBlockCopySuccess := true
 			startTime := time.Now()
 			migobj.logMessage(fmt.Sprintf("Periodic Sync: Starting incremental block copy for disk %d at %s", idx, startTime))
-			err = nbdops[idx].CopyChangedBlocks(ctx, changedAreas, vminfo.VMDisks[idx].Path)
+			err = nbdops[idx].CopyChangedBlocks(ctx, changedAreas, vminfo.VMDisks[idx].Path, vminfo.VMDisks[idx].OpenstackVol.Encrypted)
 			if err != nil {
 				migobj.logMessage(fmt.Sprintf("Periodic Sync: Failed to copy changed blocks for disk %d: %v", idx, err))
 				select {
@@ -1066,7 +1066,7 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 
 					// Use exponential backoff for retry logic (3 retries, 30 second cap)
 					copyErr := utils.DoRetryWithExponentialBackoff(ctx, func() error {
-						return nbdops[idx].CopyChangedBlocks(ctx, changedAreas, vminfo.VMDisks[idx].Path)
+						return nbdops[idx].CopyChangedBlocks(ctx, changedAreas, vminfo.VMDisks[idx].Path, vminfo.VMDisks[idx].OpenstackVol.Encrypted)
 					}, 3, 30*time.Second)
 
 					if copyErr != nil {

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -970,7 +970,7 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 				migobj.logMessage(fmt.Sprintf("  Source: %s", extractFileName(disk.SnapBackingDisk)))
 				migobj.logMessage(fmt.Sprintf("  Target: %s (Volume ID: %s)", disk.Path, disk.OpenstackVol.ID))
 
-				err = nbdops[idx].CopyDisk(ctx, disk.Path, idx)
+				err = nbdops[idx].CopyDisk(ctx, disk.Path, idx, disk.OpenstackVol.Encrypted)
 				if err != nil {
 					return vminfo, errors.Wrap(err, fmt.Sprintf("failed to copy disk %s (DeviceKey=%d)", disk.Name, disk.Disk.Key))
 				}

--- a/v2v-helper/migrate/migrate_test.go
+++ b/v2v-helper/migrate/migrate_test.go
@@ -299,13 +299,13 @@ func TestLiveReplicateDisks(t *testing.T) {
 			AnyTimes(),
 		mockOpenStackOps.EXPECT().AttachVolumeToVM(gomock.Any(), "id1").Return(nil).AnyTimes(),
 		mockOpenStackOps.EXPECT().FindDevice("id1").Return("/dev/sda", nil).AnyTimes(),
-		mockNBD.EXPECT().CopyDisk(context.TODO(), "/dev/sda", 0).Return(nil).AnyTimes(),
+		mockNBD.EXPECT().CopyDisk(context.TODO(), "/dev/sda", 0, false).Return(nil).AnyTimes(),
 		mockOpenStackOps.EXPECT().DetachVolumeFromVM(gomock.Any(), gomock.Any()).Return(nil).AnyTimes(),
 		mockOpenStackOps.EXPECT().WaitForVolume(gomock.Any(), gomock.Any()).Return(nil).AnyTimes(),
 
 		mockOpenStackOps.EXPECT().AttachVolumeToVM(gomock.Any(), "id2").Return(nil).AnyTimes(),
 		mockOpenStackOps.EXPECT().FindDevice("id2").Return("/dev/sdb", nil).AnyTimes(),
-		mockNBD.EXPECT().CopyDisk(context.TODO(), "/dev/sdb", 1).Return(nil).AnyTimes(),
+		mockNBD.EXPECT().CopyDisk(context.TODO(), "/dev/sdb", 1, false).Return(nil).AnyTimes(),
 		// 1. Both Disks Change
 		mockVMOps.EXPECT().
 			UpdateDiskInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes(),

--- a/v2v-helper/migrate/migrate_test.go
+++ b/v2v-helper/migrate/migrate_test.go
@@ -339,7 +339,7 @@ func TestLiveReplicateDisks(t *testing.T) {
 			AnyTimes(),
 		mockOpenStackOps.EXPECT().AttachVolumeToVM(gomock.Any(), "id1").Return(nil).AnyTimes(),
 		mockOpenStackOps.EXPECT().FindDevice("id1").Return("/dev/sda", nil).AnyTimes(),
-		mockNBD.EXPECT().CopyChangedBlocks(context.TODO(), changedAreasexample, "/dev/sda").Return(nil).AnyTimes(),
+		mockNBD.EXPECT().CopyChangedBlocks(context.TODO(), changedAreasexample, "/dev/sda", false).Return(nil).AnyTimes(),
 		mockOpenStackOps.EXPECT().DetachVolumeFromVM(gomock.Any(), gomock.Any()).Return(nil).AnyTimes(),
 		mockOpenStackOps.EXPECT().WaitForVolume(gomock.Any(), gomock.Any()).Return(nil).AnyTimes(),
 		// Incremental Copy Disk 2
@@ -359,7 +359,7 @@ func TestLiveReplicateDisks(t *testing.T) {
 			AnyTimes(),
 		mockOpenStackOps.EXPECT().AttachVolumeToVM(gomock.Any(), "id2").Return(nil).AnyTimes(),
 		mockOpenStackOps.EXPECT().FindDevice("id2").Return("/dev/sdb", nil).AnyTimes(),
-		mockNBD.EXPECT().CopyChangedBlocks(context.TODO(), changedAreasexample, "/dev/sdb").Return(nil).AnyTimes(),
+		mockNBD.EXPECT().CopyChangedBlocks(context.TODO(), changedAreasexample, "/dev/sdb", false).Return(nil).AnyTimes(),
 		// 2. Only Disk 1 Changes
 		mockVMOps.EXPECT().
 			UpdateDiskInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes(),
@@ -383,7 +383,7 @@ func TestLiveReplicateDisks(t *testing.T) {
 		mockNBD.EXPECT().StartNBDServer(&object.VirtualMachine{}, envURL, envUserName, envPassword, thumbprint, "migration-snap", "[ds1] test_vm/test_vm.vmdk", dummychan).Return(nil).AnyTimes(),
 		mockOpenStackOps.EXPECT().AttachVolumeToVM(gomock.Any(), "id1").Return(nil).AnyTimes(),
 		mockOpenStackOps.EXPECT().FindDevice("id1").Return("/dev/sda", nil).AnyTimes(),
-		mockNBD.EXPECT().CopyChangedBlocks(context.TODO(), changedAreasexample, "/dev/sda").Return(nil).AnyTimes(),
+		mockNBD.EXPECT().CopyChangedBlocks(context.TODO(), changedAreasexample, "/dev/sda", false).Return(nil).AnyTimes(),
 		mockOpenStackOps.EXPECT().DetachVolumeFromVM(gomock.Any(), gomock.Any()).Return(nil).AnyTimes(),
 		mockOpenStackOps.EXPECT().WaitForVolume(gomock.Any(), gomock.Any()).Return(nil).AnyTimes(),
 		// No copy for Disk 2

--- a/v2v-helper/nbd/nbdops.go
+++ b/v2v-helper/nbd/nbdops.go
@@ -32,7 +32,7 @@ type NBDOperations interface {
 	StartNBDServer(vm *object.VirtualMachine, server, username, password, thumbprint, snapref, file string, progchan chan string) error
 	StopNBDServer() error
 	CopyDisk(ctx context.Context, dest string, diskindex int, destEncrypted bool) error
-	CopyChangedBlocks(ctx context.Context, changedAreas types.DiskChangeInfo, path string) error
+	CopyChangedBlocks(ctx context.Context, changedAreas types.DiskChangeInfo, path string, destEncrypted bool) error
 	GetProgress() (int64, int64, time.Duration)
 }
 
@@ -502,24 +502,13 @@ func pwrite(fd *os.File, buffer []byte, offset uint64) (int, error) {
 	return written, nil
 }
 
-// zeroRange fills the destination range with zero bytes
-func zeroRange(fd *os.File, offset int64, length int64) error {
-	punch := func(offset int64, length int64) error {
-		utils.PrintLog(fmt.Sprintf("Punching %d-byte hole at offset %d", length, offset))
-		flags := uint32(unix.FALLOC_FL_PUNCH_HOLE | unix.FALLOC_FL_KEEP_SIZE)
-		return syscall.Fallocate(int(fd.Fd()), flags, offset, length)
-	}
-
-	punchErr := punch(offset, length)
-	if punchErr == nil {
-		return nil
-	}
-	// Fall back to writing zeros directly. This is the slow path; it
-	// triggers on filesystems that don't support FALLOC_FL_PUNCH_HOLE
-	// (some NFS configurations, tmpfs, certain block-backed targets).
-	utils.PrintLog(fmt.Sprintf("Failed to punch hole at offset %d, falling back to pwrite: %v", offset, punchErr))
-	utils.PrintLog(fmt.Sprintf("Unable to zero range %d - %d on destination, falling back to pwrite: %v", offset, offset+length, punchErr))
-
+// writeZeros writes `length` zero bytes to the destination starting at
+// `offset` using pwrite. Unlike hole-punching, this pushes real zero bytes
+// down the destination's normal write path. For an encrypted destination
+// that is exactly what is required: the QEMU LUKS layer encrypts the zeros
+// as they are written, so they decrypt back to zero on readback. (A punched
+// hole only clears the underlying ciphertext, which decrypts to garbage.)
+func writeZeros(fd *os.File, offset int64, length int64) error {
 	count := int64(0)
 	const blocksize = 16 << 20
 	buffer := bytes.Repeat([]byte{0}, blocksize)
@@ -536,18 +525,49 @@ func zeroRange(fd *os.File, offset int64, length int64) error {
 		// reported as a successful migration.
 		written, err := pwrite(fd, buffer, uint64(offset+count))
 		if err != nil {
-			return errors.Wrapf(err, "zeroRange fallback pwrite failed at offset %d (%d/%d bytes written before failure)", offset+count, count, length)
+			return errors.Wrapf(err, "writeZeros pwrite failed at offset %d (%d/%d bytes written before failure)", offset+count, count, length)
 		}
 		count += int64(written)
 	}
 	return nil
 }
 
-func copyRange(fd *os.File, handle *libnbd.Libnbd, block *BlockStatusData) error {
+// zeroRange fills the destination range with zero bytes.
+//
+// For a plain (unencrypted) destination it first tries
+// FALLOC_FL_PUNCH_HOLE, which is cheap — it deallocates the region instead
+// of writing, and the region then reads back as zero.
+//
+// For an encrypted destination, punching a hole is unsafe: the punch/discard
+// only clears the underlying ciphertext storage, but the guest reads back
+// through the QEMU LUKS layer, and decrypting raw zeros yields garbage, not
+// zero plaintext. So when destEncrypted is true we skip the punch entirely
+// and write real zeros through the encryption engine (via writeZeros), which
+// then decrypt back to zero correctly.
+func zeroRange(fd *os.File, offset int64, length int64, destEncrypted bool) error {
+	if destEncrypted {
+		return writeZeros(fd, offset, length)
+	}
+
+	utils.PrintLog(fmt.Sprintf("Punching %d-byte hole at offset %d", length, offset))
+	flags := uint32(unix.FALLOC_FL_PUNCH_HOLE | unix.FALLOC_FL_KEEP_SIZE)
+	punchErr := syscall.Fallocate(int(fd.Fd()), flags, offset, length)
+	if punchErr == nil {
+		return nil
+	}
+	// Fall back to writing zeros directly. This is the slow path; it
+	// triggers on filesystems that don't support FALLOC_FL_PUNCH_HOLE
+	// (some NFS configurations, tmpfs, certain block-backed targets).
+	utils.PrintLog(fmt.Sprintf("Failed to punch hole at offset %d, falling back to pwrite: %v", offset, punchErr))
+	utils.PrintLog(fmt.Sprintf("Unable to zero range %d - %d on destination, falling back to pwrite: %v", offset, offset+length, punchErr))
+	return writeZeros(fd, offset, length)
+}
+
+func copyRange(fd *os.File, handle *libnbd.Libnbd, block *BlockStatusData, destEncrypted bool) error {
 	isZeroOrHole := (block.Flags & (libnbd.STATE_ZERO | libnbd.STATE_HOLE)) != 0
 
 	if isZeroOrHole {
-		err := zeroRange(fd, block.Offset, block.Length)
+		err := zeroRange(fd, block.Offset, block.Length, destEncrypted)
 		if err != nil {
 			return fmt.Errorf("failed to zero range at offset %d: %v", block.Offset, err)
 		}
@@ -578,16 +598,18 @@ func copyRange(fd *os.File, handle *libnbd.Libnbd, block *BlockStatusData) error
 }
 
 // copyBlockParallel handles a single BlockStatusData. For zero/hole blocks it
-// punches a hole locally (no source read needed). For data blocks larger than
-// SubRangeSize it splits the block into sub-ranges and dispatches them across
-// the handle pool so that multiple Preads run in flight concurrently — which
-// is the only way to exceed single-stream VDDK throughput. Smaller blocks
-// take a single handle from the pool and run copyRange as before.
-func copyBlockParallel(ctx context.Context, fd *os.File, pool *handlePool, block *BlockStatusData) error {
+// zeroes the range locally (no source read needed) — punching a hole for
+// plain destinations, or writing real zeros for encrypted ones (see
+// zeroRange). For data blocks larger than SubRangeSize it splits the block
+// into sub-ranges and dispatches them across the handle pool so that multiple
+// Preads run in flight concurrently — which is the only way to exceed
+// single-stream VDDK throughput. Smaller blocks take a single handle from the
+// pool and run copyRange as before.
+func copyBlockParallel(ctx context.Context, fd *os.File, pool *handlePool, block *BlockStatusData, destEncrypted bool) error {
 	isZeroOrHole := (block.Flags & (libnbd.STATE_ZERO | libnbd.STATE_HOLE)) != 0
 
 	if isZeroOrHole {
-		return zeroRange(fd, block.Offset, block.Length)
+		return zeroRange(fd, block.Offset, block.Length, destEncrypted)
 	}
 
 	// Small block: keep the original single-handle path to avoid sub-range
@@ -598,7 +620,7 @@ func copyBlockParallel(ctx context.Context, fd *os.File, pool *handlePool, block
 			return fmt.Errorf("acquire handle for small block at offset %d: %v", block.Offset, err)
 		}
 		defer pool.Release(handle)
-		return copyRange(fd, handle, block)
+		return copyRange(fd, handle, block, destEncrypted)
 	}
 
 	// Plan sub-ranges. Each sub-range is treated as a fresh data block so
@@ -630,7 +652,7 @@ func copyBlockParallel(ctx context.Context, fd *os.File, pool *handlePool, block
 				return
 			}
 			defer pool.Release(handle)
-			if err := copyRange(fd, handle, subRange); err != nil {
+			if err := copyRange(fd, handle, subRange, destEncrypted); err != nil {
 				errCh <- fmt.Errorf("sub-range %d at offset %d failed: %v", subRangeIdx, subRange.Offset, err)
 				return
 			}
@@ -648,7 +670,7 @@ func (nbdserver *NBDServer) GetProgress() (int64, int64, time.Duration) {
 	return nbdserver.CopiedSize, nbdserver.TotalSize, nbdserver.Duration
 }
 
-func (nbdserver *NBDServer) CopyChangedBlocks(ctx context.Context, changedAreas types.DiskChangeInfo, path string) error {
+func (nbdserver *NBDServer) CopyChangedBlocks(ctx context.Context, changedAreas types.DiskChangeInfo, path string, destEncrypted bool) error {
 	// Coalesce CBT-reported extents to amortize per-extent overhead. Holes
 	// inside a coalesced range will be discovered by getBlockStatus and
 	// punched cheaply via fallocate, so there's no read amplification beyond
@@ -773,7 +795,7 @@ func (nbdserver *NBDServer) CopyChangedBlocks(ctx context.Context, changedAreas 
 				retries := uint64(0)
 				waitTime := 1 * time.Minute
 				for blockIdx := 0; blockIdx < len(blocks); {
-					if err := copyBlockParallel(copyCtx, fd, pool, blocks[blockIdx]); err != nil {
+					if err := copyBlockParallel(copyCtx, fd, pool, blocks[blockIdx], destEncrypted); err != nil {
 						// If we were cancelled (peer worker errored), don't
 						// log a confusing failure or burn retries — just exit.
 						if copyCtx.Err() != nil {

--- a/v2v-helper/nbd/nbdops.go
+++ b/v2v-helper/nbd/nbdops.go
@@ -31,7 +31,7 @@ import (
 type NBDOperations interface {
 	StartNBDServer(vm *object.VirtualMachine, server, username, password, thumbprint, snapref, file string, progchan chan string) error
 	StopNBDServer() error
-	CopyDisk(ctx context.Context, dest string, diskindex int) error
+	CopyDisk(ctx context.Context, dest string, diskindex int, destEncrypted bool) error
 	CopyChangedBlocks(ctx context.Context, changedAreas types.DiskChangeInfo, path string) error
 	GetProgress() (int64, int64, time.Duration)
 }
@@ -286,7 +286,29 @@ func (nbdserver *NBDServer) StopNBDServer() error {
 	return nil
 }
 
-func (nbdserver *NBDServer) CopyDisk(ctx context.Context, dest string, diskindex int) error {
+// buildNbdcopyArgs constructs the argument list for the nbdcopy invocation
+// used by CopyDisk. It is a pure function (no exec, no I/O) specifically so
+// the --target-is-zero decision can be unit tested without shelling out.
+//
+// --target-is-zero tells nbdcopy to trust that the destination already reads
+// as all-zero, so it can skip writing any source region that is itself
+// zero/sparse. That assumption holds for a plain, freshly created Cinder
+// volume, but not for an encrypted one: encryption is applied transparently
+// at the QEMU layer, so a region that was never actually written through the
+// encryption engine does not decrypt back to zero on readback - it decrypts
+// to pseudo-random, key-derived noise. Skipping those regions produces a
+// disk that looks corrupted (missing partition table, unbootable) even
+// though the copy reported success. For encrypted destinations we must fall
+// back to a full, dense copy - slower, but correct.
+func buildNbdcopyArgs(sockUrl, dest string, destEncrypted bool) []string {
+	args := []string{"--progress=3"}
+	if !destEncrypted {
+		args = append(args, "--target-is-zero")
+	}
+	return append(args, sockUrl, dest)
+}
+
+func (nbdserver *NBDServer) CopyDisk(ctx context.Context, dest string, diskindex int, destEncrypted bool) error {
 	// Copy the disk from source to destination
 	progressRead, progressWrite, err := os.Pipe()
 	if err != nil {
@@ -295,7 +317,13 @@ func (nbdserver *NBDServer) CopyDisk(ctx context.Context, dest string, diskindex
 	defer progressRead.Close()
 	defer progressWrite.Close()
 
-	cmd := exec.CommandContext(ctx, "nbdcopy", "--progress=3", "--target-is-zero", generateSockUrl(nbdserver.tmp_dir), dest)
+	if destEncrypted {
+		utils.PrintLog(fmt.Sprintf(
+			"Disk %d destination volume is encrypted; disabling nbdcopy --target-is-zero and doing a full dense copy", diskindex))
+	}
+
+	args := buildNbdcopyArgs(generateSockUrl(nbdserver.tmp_dir), dest, destEncrypted)
+	cmd := exec.CommandContext(ctx, "nbdcopy", args...)
 	cmd.ExtraFiles = []*os.File{progressWrite}
 
 	cmdString := cmd.String()

--- a/v2v-helper/nbd/nbdops.go
+++ b/v2v-helper/nbd/nbdops.go
@@ -558,7 +558,6 @@ func zeroRange(fd *os.File, offset int64, length int64, destEncrypted bool) erro
 	// Fall back to writing zeros directly. This is the slow path; it
 	// triggers on filesystems that don't support FALLOC_FL_PUNCH_HOLE
 	// (some NFS configurations, tmpfs, certain block-backed targets).
-	utils.PrintLog(fmt.Sprintf("Failed to punch hole at offset %d, falling back to pwrite: %v", offset, punchErr))
 	utils.PrintLog(fmt.Sprintf("Unable to zero range %d - %d on destination, falling back to pwrite: %v", offset, offset+length, punchErr))
 	return writeZeros(fd, offset, length)
 }

--- a/v2v-helper/nbd/nbdops_mock.go
+++ b/v2v-helper/nbd/nbdops_mock.go
@@ -52,17 +52,17 @@ func (mr *MockNBDOperationsMockRecorder) CopyChangedBlocks(ctx, changedAreas, pa
 }
 
 // CopyDisk mocks base method.
-func (m *MockNBDOperations) CopyDisk(ctx context.Context, dest string, diskindex int) error {
+func (m *MockNBDOperations) CopyDisk(ctx context.Context, dest string, diskindex int, destEncrypted bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CopyDisk", ctx, dest, diskindex)
+	ret := m.ctrl.Call(m, "CopyDisk", ctx, dest, diskindex, destEncrypted)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CopyDisk indicates an expected call of CopyDisk.
-func (mr *MockNBDOperationsMockRecorder) CopyDisk(ctx, dest, diskindex interface{}) *gomock.Call {
+func (mr *MockNBDOperationsMockRecorder) CopyDisk(ctx, dest, diskindex, destEncrypted interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyDisk", reflect.TypeOf((*MockNBDOperations)(nil).CopyDisk), ctx, dest, diskindex)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyDisk", reflect.TypeOf((*MockNBDOperations)(nil).CopyDisk), ctx, dest, diskindex, destEncrypted)
 }
 
 // GetProgress mocks base method.

--- a/v2v-helper/nbd/nbdops_mock.go
+++ b/v2v-helper/nbd/nbdops_mock.go
@@ -38,17 +38,17 @@ func (m *MockNBDOperations) EXPECT() *MockNBDOperationsMockRecorder {
 }
 
 // CopyChangedBlocks mocks base method.
-func (m *MockNBDOperations) CopyChangedBlocks(ctx context.Context, changedAreas types.DiskChangeInfo, path string) error {
+func (m *MockNBDOperations) CopyChangedBlocks(ctx context.Context, changedAreas types.DiskChangeInfo, path string, destEncrypted bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CopyChangedBlocks", ctx, changedAreas, path)
+	ret := m.ctrl.Call(m, "CopyChangedBlocks", ctx, changedAreas, path, destEncrypted)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CopyChangedBlocks indicates an expected call of CopyChangedBlocks.
-func (mr *MockNBDOperationsMockRecorder) CopyChangedBlocks(ctx, changedAreas, path interface{}) *gomock.Call {
+func (mr *MockNBDOperationsMockRecorder) CopyChangedBlocks(ctx, changedAreas, path, destEncrypted interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyChangedBlocks", reflect.TypeOf((*MockNBDOperations)(nil).CopyChangedBlocks), ctx, changedAreas, path)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyChangedBlocks", reflect.TypeOf((*MockNBDOperations)(nil).CopyChangedBlocks), ctx, changedAreas, path, destEncrypted)
 }
 
 // CopyDisk mocks base method.

--- a/v2v-helper/nbd/nbdops_test.go
+++ b/v2v-helper/nbd/nbdops_test.go
@@ -84,3 +84,53 @@ func TestPasswordRedactionLogic(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildNbdcopyArgs covers the --target-is-zero decision used by
+// CopyDisk. Encrypted Cinder destinations must never receive
+// --target-is-zero: encryption is applied transparently at the QEMU layer,
+// so a region skipped as "already zero" was never actually written through
+// the encryption engine and does not decrypt back to zero on readback. See
+// buildNbdcopyArgs's doc comment for the full explanation.
+func TestBuildNbdcopyArgs(t *testing.T) {
+	const sockUrl = "nbd+unix:///?socket=/tmp/nbdkit-test/nbdkit.sock"
+	const dest = "/dev/sda"
+
+	tests := []struct {
+		name          string
+		destEncrypted bool
+		wantArgs      []string
+	}{
+		{
+			name:          "plain (unencrypted) destination keeps --target-is-zero",
+			destEncrypted: false,
+			wantArgs:      []string{"--progress=3", "--target-is-zero", sockUrl, dest},
+		},
+		{
+			name:          "encrypted destination drops --target-is-zero and does a dense copy",
+			destEncrypted: true,
+			wantArgs:      []string{"--progress=3", sockUrl, dest},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotArgs := buildNbdcopyArgs(sockUrl, dest, tt.destEncrypted)
+			assert.Equal(t, tt.wantArgs, gotArgs)
+		})
+	}
+}
+
+// TestBuildNbdcopyArgs_NeverSkipsZeroTrustSilently is a focused regression
+// guard: whatever buildNbdcopyArgs does, an encrypted destination must never
+// end up with --target-is-zero in the argument list, and a plain
+// destination must always keep the optimization (so cold-migration copy
+// speed doesn't silently regress for the common, unencrypted case).
+func TestBuildNbdcopyArgs_NeverSkipsZeroTrustSilently(t *testing.T) {
+	encryptedArgs := buildNbdcopyArgs("sock", "dest", true)
+	assert.NotContains(t, encryptedArgs, "--target-is-zero",
+		"encrypted destinations must not use --target-is-zero")
+
+	plainArgs := buildNbdcopyArgs("sock", "dest", false)
+	assert.Contains(t, plainArgs, "--target-is-zero",
+		"plain destinations should keep the --target-is-zero optimization")
+}

--- a/v2v-helper/nbd/nbdops_test.go
+++ b/v2v-helper/nbd/nbdops_test.go
@@ -3,12 +3,16 @@
 package nbd
 
 import (
+	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestPasswordRedactionLogic verifies that passwords are properly redacted from command strings
@@ -133,4 +137,80 @@ func TestBuildNbdcopyArgs_NeverSkipsZeroTrustSilently(t *testing.T) {
 	plainArgs := buildNbdcopyArgs("sock", "dest", false)
 	assert.Contains(t, plainArgs, "--target-is-zero",
 		"plain destinations should keep the --target-is-zero optimization")
+}
+
+// newFilledTempFile creates a temp file of size bytes, filled with 0xFF so
+// that "became zero" is observable (a fresh file is already zero, which would
+// make the assertions meaningless).
+func newFilledTempFile(t *testing.T, size int) *os.File {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "dest.img")
+	require.NoError(t, os.WriteFile(path, bytes.Repeat([]byte{0xFF}, size), 0o644))
+	fd, err := os.OpenFile(path, os.O_RDWR, 0o644)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = fd.Close() })
+	return fd
+}
+
+func readAllFrom(t *testing.T, fd *os.File, size int) []byte {
+	t.Helper()
+	buf := make([]byte, size)
+	_, err := fd.ReadAt(buf, 0)
+	require.NoError(t, err)
+	return buf
+}
+
+// TestWriteZeros verifies that writeZeros zeroes exactly the requested range
+// and leaves the surrounding bytes untouched. This is the code path an
+// encrypted destination always takes (real zeros written through the device),
+// so getting the bounds right matters: an off-by-one would either leave stale
+// data inside the range or clobber data outside it.
+func TestWriteZeros(t *testing.T) {
+	const size = 4096
+	const zeroStart = 1024
+	const zeroLen = 2048
+
+	fd := newFilledTempFile(t, size)
+	require.NoError(t, writeZeros(fd, zeroStart, zeroLen))
+
+	got := readAllFrom(t, fd, size)
+	for i := 0; i < size; i++ {
+		if i >= zeroStart && i < zeroStart+zeroLen {
+			assert.Equalf(t, byte(0x00), got[i], "byte %d should be zeroed", i)
+		} else {
+			assert.Equalf(t, byte(0xFF), got[i], "byte %d outside the range must be untouched", i)
+		}
+	}
+}
+
+// TestZeroRange_ReadsBackAsZero checks the observable contract of zeroRange
+// for both destination types: after the call, the target range must read back
+// as zero. For the encrypted case this exercises the writeZeros path directly
+// (no fallocate). For the plain case it exercises the punch-hole path, with a
+// pwrite fallback on filesystems that don't support FALLOC_FL_PUNCH_HOLE;
+// either way the range must read as zero. The surrounding bytes must be
+// preserved in both cases.
+func TestZeroRange_ReadsBackAsZero(t *testing.T) {
+	const size = 4096
+	const zeroStart = 512
+	const zeroLen = 1024
+
+	for _, destEncrypted := range []bool{true, false} {
+		name := "plain"
+		if destEncrypted {
+			name = "encrypted"
+		}
+		t.Run(name, func(t *testing.T) {
+			fd := newFilledTempFile(t, size)
+			require.NoError(t, zeroRange(fd, zeroStart, zeroLen, destEncrypted))
+
+			got := readAllFrom(t, fd, size)
+			for i := zeroStart; i < zeroStart+zeroLen; i++ {
+				assert.Equalf(t, byte(0x00), got[i], "byte %d should read back as zero", i)
+			}
+			// Surrounding bytes preserved.
+			assert.Equal(t, byte(0xFF), got[zeroStart-1], "byte before range must be untouched")
+			assert.Equal(t, byte(0xFF), got[zeroStart+zeroLen], "byte after range must be untouched")
+		})
+	}
 }


### PR DESCRIPTION
## What this PR does / why we need it
vjailbreak's copy step trusted the destination was pre-zeroed (nbdcopy --target-is-zero, plus hole-punching on incremental syncs), so it skipped writing zero/sparse regions. That's fine for plain volumes, but on encrypted volumes those skipped regions were never written through the QEMU encryption layer — so they decrypt to garbage instead of zero. Real data copied fine; sparse regions like the partition table came back corrupted.

Fix: Detect when the destination volume is encrypted and do a full dense copy — no --target-is-zero, and write real zeros instead of punching holes on syncs — so every region passes through the encryption engine correctly. Unencrypted migrations are unchanged.

## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #1622 

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_