### PR TITLE
#2209: Step check marks doesnt disable if user disable the option

### DIFF
--- a/ui/src/features/migration/hooks/useFormValidation.test.ts
+++ b/ui/src/features/migration/hooks/useFormValidation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useFormValidation } from './useFormValidation'
+import type { FormValues, SelectedMigrationOptionsType } from '../types'
+
+const baseSelectedMigrationOptions: SelectedMigrationOptionsType = {
+  dataCopyMethod: false,
+  dataCopyStartTime: false,
+  cutoverOption: false,
+  cutoverStartTime: false,
+  cutoverEndTime: false,
+  postMigrationScript: false
+}
+
+const renderStep5 = (params: Partial<FormValues>, touchedTagsMetadata: boolean) =>
+  renderHook(() =>
+    useFormValidation({
+      params,
+      fieldErrors: {},
+      selectedMigrationOptions: baseSelectedMigrationOptions,
+      vmwareCredsValidated: true,
+      openstackCredsValidated: true,
+      rdmDisks: [],
+      openstackCredentials: undefined,
+      touchedSections: { options: false, tagsMetadata: touchedTagsMetadata }
+    })
+  )
+
+describe('useFormValidation - Tags & Metadata step (step5Complete)', () => {
+  it('is incomplete when untouched and nothing set', () => {
+    const { result } = renderStep5({}, false)
+    expect(result.current.step5Complete).toBe(false)
+  })
+
+  it('goes complete once preserveSourceTags is enabled', () => {
+    const { result } = renderStep5({ preserveSourceTags: true }, true)
+    expect(result.current.step5Complete).toBe(true)
+  })
+
+  it('goes back to incomplete when preserveSourceTags is disabled again, even though the section was touched', () => {
+    // Regression test for GH-2209: toggling the option off with no custom metadata
+    // rows set must clear the step checkmark, not stay "complete" from having
+    // been touched.
+    const { result } = renderStep5({ preserveSourceTags: false, customMetadata: [] }, true)
+    expect(result.current.step5Complete).toBe(false)
+  })
+
+  it('stays complete when custom metadata rows are filled even if preserveSourceTags is off', () => {
+    const { result } = renderStep5(
+      { preserveSourceTags: false, customMetadata: [{ key: 'env', value: 'prod' }] },
+      true
+    )
+    expect(result.current.step5Complete).toBe(true)
+  })
+})

--- a/ui/src/features/migration/hooks/useFormValidation.ts
+++ b/ui/src/features/migration/hooks/useFormValidation.ts
@@ -301,8 +301,7 @@ export function useFormValidation({
 
   const step5Complete = Boolean(
     params.preserveSourceTags ||
-      (params.customMetadata || []).some((row) => row.key.trim() !== '') ||
-      touchedSections.tagsMetadata
+      (params.customMetadata || []).some((row) => row.key.trim() !== '')
   )
 
   const step6HasErrors = Boolean(

--- a/ui/src/features/migration/hooks/useRollingFormValidation.ts
+++ b/ui/src/features/migration/hooks/useRollingFormValidation.ts
@@ -432,8 +432,7 @@ export function useRollingFormValidation({
         description: 'Preserve source tags and custom metadata',
         status:
           params.preserveSourceTags ||
-          (params.customMetadata || []).some((row) => row.key.trim() !== '') ||
-          touchedSections.tagsMetadata
+          (params.customMetadata || []).some((row) => row.key.trim() !== '')
             ? 'complete'
             : 'incomplete'
       },


### PR DESCRIPTION
## What this PR does / why we need it
Inserted a validation check in the Tags & Metadata step to resolve the step completion issue.

## Which issue(s) this PR fixes
fixes #2209 

## Testing done
[Screencast from 27-07-26 06:41:49 PM IST.webm](https://github.com/user-attachments/assets/7d65786c-bb8a-44df-b0c9-1f5f54389ca9)
