### PR TITLE
[2214] Fix: Controller/pod log search returns zero results for lines that exist

### DIFF
--- a/ui/src/features/migration/components/BaseLogsDrawer.test.tsx
+++ b/ui/src/features/migration/components/BaseLogsDrawer.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import BaseLogsDrawer from './BaseLogsDrawer'
+
+const MATCHING_LINE =
+  '2026-07-27T10:36:49Z\tINFO\tmigration-controller\tReconciling Migration object\t' +
+  '{"controllerKind": "Migration", "name": "migration-windows-11-vtpm-automation-2466-fb547", ' +
+  '"reconcileID": "935246a7-8480-49a2-a6f0-cbc5527d1c87"}'
+
+const OTHER_LINE =
+  '2026-07-27T12:01:11Z\tINFO\tmigration-controller\tReconciling VMwareCreds object\t' +
+  '{"controllerKind": "VMwareCreds", "name": "vcenter-pune"}'
+
+function renderDrawer(logs: string[]) {
+  return render(
+    <BaseLogsDrawer
+      open
+      onClose={vi.fn()}
+      title="Controller Logs"
+      logs={logs}
+      isLoading={false}
+      error={null}
+      isPaused={false}
+      onPausedChange={vi.fn()}
+      onReconnect={vi.fn()}
+      data-testid="controller-logs-drawer"
+    />
+  )
+}
+
+function typeSearch(value: string) {
+  const input = screen.getByTestId('logs-search-input').querySelector('input')
+  expect(input).not.toBeNull()
+  fireEvent.change(input!, { target: { value } })
+}
+
+describe('BaseLogsDrawer search', () => {
+  it('shows every line before searching', () => {
+    renderDrawer([MATCHING_LINE, OTHER_LINE])
+    expect(screen.getByText(/windows-11-vtpm-automation/)).toBeDefined()
+    expect(screen.getByText(/VMwareCreds object/)).toBeDefined()
+    expect(screen.getByText('2 / 2 lines')).toBeDefined()
+  })
+
+  it('keeps lines containing the term deep inside a long line and hides the rest', () => {
+    renderDrawer([MATCHING_LINE, OTHER_LINE])
+    typeSearch('windows-11-vtpm-automation')
+
+    expect(screen.getByText(/windows-11-vtpm-automation/)).toBeDefined()
+    expect(screen.queryByText(/VMwareCreds object/)).toBeNull()
+    expect(screen.getByText('1 / 2 lines')).toBeDefined()
+  })
+
+  it('does not match near-miss text', () => {
+    renderDrawer([MATCHING_LINE, OTHER_LINE])
+    typeSearch('windows-10-vtpm-automation')
+
+    expect(screen.getByText('0 / 2 lines')).toBeDefined()
+    expect(screen.getByText(/No lines match the current filters/)).toBeDefined()
+  })
+
+  it('explains that only the buffered tail is searched when nothing matches', () => {
+    renderDrawer([MATCHING_LINE, OTHER_LINE])
+    typeSearch('zzz-not-present')
+
+    expect(screen.getByText(/Only the most recent 2 lines are loaded/)).toBeDefined()
+  })
+
+  it('ANDs space-separated tokens', () => {
+    renderDrawer([MATCHING_LINE, OTHER_LINE])
+    typeSearch('reconciling vcenter-pune')
+
+    expect(screen.getByText(/VMwareCreds object/)).toBeDefined()
+    expect(screen.queryByText(/windows-11-vtpm-automation/)).toBeNull()
+  })
+
+  it('excludes lines with a negated token', () => {
+    renderDrawer([MATCHING_LINE, OTHER_LINE])
+    typeSearch('reconciling -vmwarecreds')
+
+    expect(screen.getByText(/windows-11-vtpm-automation/)).toBeDefined()
+    expect(screen.queryByText(/VMwareCreds object/)).toBeNull()
+  })
+
+  it('restores all lines when the search box is cleared', () => {
+    renderDrawer([MATCHING_LINE, OTHER_LINE])
+    typeSearch('vcenter-pune')
+    expect(screen.getByText('1 / 2 lines')).toBeDefined()
+
+    typeSearch('')
+    expect(screen.getByText('2 / 2 lines')).toBeDefined()
+  })
+})

--- a/ui/src/features/migration/components/BaseLogsDrawer.tsx
+++ b/ui/src/features/migration/components/BaseLogsDrawer.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
-import Fuse from 'fuse.js'
 import {
   Box,
   Typography,
@@ -20,8 +19,9 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import DownloadIcon from '@mui/icons-material/Download'
 import ReplayIcon from '@mui/icons-material/Replay'
 import { DrawerShell, DrawerHeader } from 'src/components'
-import DarkLogLine, { LOG_BG, LOG_TS, extractLevel, normalizeLevel } from './DarkLogLine'
+import DarkLogLine, { LOG_BG, LOG_TS } from './DarkLogLine'
 import { ToolbarDivider, LogsSearchField, LiveToggle, LogsMetaBar } from './LogsToolbarControls'
+import { extractLevel, filterLogLines, normalizeLevel } from '../utils/logFilter'
 
 const LOG_LEVELS = ['ALL', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE', 'SUCCESS']
 
@@ -93,29 +93,10 @@ export default function BaseLogsDrawer({
     }
   }, [])
 
-  const filteredLogs = useMemo(() => {
-    let filtered = logs
-
-    if (logLevelFilter !== 'ALL') {
-      filtered = filtered.filter((log) => {
-        const raw = extractLevel(log)
-        return !!raw && normalizeLevel(raw) === logLevelFilter
-      })
-    }
-
-    if (searchTerm.trim()) {
-      const isExactSearch = searchTerm.startsWith('"') && searchTerm.endsWith('"')
-      if (isExactSearch) {
-        const exactTerm = searchTerm.slice(1, -1).toLowerCase()
-        filtered = filtered.filter((log) => log.toLowerCase().includes(exactTerm))
-      } else {
-        const fuse = new Fuse(filtered, { threshold: 0.4, ignoreLocation: true, isCaseSensitive: false })
-        filtered = fuse.search(searchTerm).map((r) => r.item)
-      }
-    }
-
-    return filtered
-  }, [logs, searchTerm, logLevelFilter])
+  const filteredLogs = useMemo(
+    () => filterLogLines(logs, { search: searchTerm, level: logLevelFilter }),
+    [logs, searchTerm, logLevelFilter]
+  )
 
   const counts = useMemo(() => {
     const c = { ERROR: 0, WARN: 0, INFO: 0, DEBUG: 0 }
@@ -388,6 +369,19 @@ export default function BaseLogsDrawer({
                       : 'No logs available'
                     : 'No lines match the current filters.'}
                 </Typography>
+                {/* Only the buffered tail is searchable — say so, otherwise an
+                    out-of-window match reads as a broken search filter. */}
+                {logs.length > 0 && (
+                  <Typography
+                    variant="caption"
+                    component="p"
+                    sx={{ color: LOG_TS, fontFamily: 'monospace', mt: 1, opacity: 0.75 }}
+                  >
+                    Only the most recent {logs.length.toLocaleString()} lines are loaded; older
+                    lines are not searched. Search matches literal text — use spaces for AND,
+                    "quotes" for a phrase, -word to exclude.
+                  </Typography>
+                )}
               </Box>
             )}
             {filteredLogs.map((log, index) => (

--- a/ui/src/features/migration/components/DarkLogLine.tsx
+++ b/ui/src/features/migration/components/DarkLogLine.tsx
@@ -1,35 +1,15 @@
 import { Box } from '@mui/material'
 
+// Level/source parsing lives in ../utils/logFilter — this file owns rendering only.
+
 // ─── Dark log theme — shared by the Migration Details Logs tab and the log drawers ──
 export const LOG_BG = '#0d1117'
 export const LOG_TEXT = '#c9d1d9'
 export const LOG_NUM = '#484f58'
-export const LOG_TS = '#8b949e'
+export const LOG_TS = '#8b949e' 
 
 const LOG_RE =
   /^(\d{2}:\d{2}:\d{2}[.\d]*)\s+\[?(\w[\w-]*)\]?\s+(ERROR|FATAL|WARN|WARNING|INFO|DEBUG|TRACE|SUCCESS|SUCCEEDED|FAILED)\s+(.*)$/i
-
-export function extractLevel(line: string): string | null {
-  const m = line.match(
-    /\b(ERROR|FATAL|WARN|WARNING|INFO|DEBUG|TRACE|SUCCESS|SUCCEEDED|FAILED)\b/i
-  )
-  return m ? m[1].toUpperCase() : null
-}
-
-export function normalizeLevel(raw: string): 'ERROR' | 'WARN' | 'INFO' | 'DEBUG' | 'TRACE' | 'SUCCESS' | 'OTHER' {
-  if (/ERROR|FATAL|FAIL/.test(raw)) return 'ERROR'
-  if (/WARN/.test(raw)) return 'WARN'
-  if (raw === 'INFO') return 'INFO'
-  if (raw === 'DEBUG') return 'DEBUG'
-  if (raw === 'TRACE') return 'TRACE'
-  if (/SUCCESS|SUCCEED/.test(raw)) return 'SUCCESS'
-  return 'OTHER'
-}
-
-export function extractSource(line: string): string | null {
-  const m = line.match(/^\d{2}:\d{2}:\d{2}[.\d]*\s+\[?(\w[\w-]*)\]?/)
-  return m ? m[1] : null
-}
 
 // Level color for text (no badge, just colored text)
 export function levelTextColor(lvl: string): string {

--- a/ui/src/features/migration/components/LogsToolbarControls.tsx
+++ b/ui/src/features/migration/components/LogsToolbarControls.tsx
@@ -17,12 +17,16 @@ export function LogsSearchField({ value, onChange, 'data-testid': dataTestId }: 
     <TextField
       data-testid={dataTestId}
       size="small"
-      placeholder='Search logs… ("exact match" for literal)'
+      placeholder='Search logs…'
       value={value}
       onChange={(e) => onChange(e.target.value)}
       sx={{ flex: 1, minWidth: 0 }}
       InputProps={{
-        startAdornment: <SearchIcon fontSize="small" sx={{ color: 'text.disabled', mr: 1 }} />,
+        startAdornment: (
+          <Tooltip title={'Space = AND · "phrase" = exact match · -word = exclude'}>
+            <SearchIcon fontSize="small" sx={{ color: 'text.disabled', mr: 1 }} />
+          </Tooltip>
+        ),
         endAdornment: value ? (
           <IconButton size="small" onClick={() => onChange('')}>
             <ClearIcon fontSize="small" />

--- a/ui/src/features/migration/components/detail/MigrationDetailDebugLogs.tsx
+++ b/ui/src/features/migration/components/detail/MigrationDetailDebugLogs.tsx
@@ -22,14 +22,14 @@ import { useDirectPodLogs } from 'src/hooks/useDirectPodLogs'
 import { VJAILBREAK_DEFAULT_NAMESPACE } from 'src/api/constants'
 import { downloadDebugBundle } from 'src/api/migrations/debugBundle'
 import { useToast } from 'src/features/migration/hooks/useToast'
-import DarkLogLine, {
-  LOG_BG,
-  LOG_TS,
-  extractLevel,
-  normalizeLevel,
-  extractSource
-} from '../DarkLogLine'
+import DarkLogLine, { LOG_BG, LOG_TS } from '../DarkLogLine'
 import { ToolbarDivider, LogsSearchField, LiveToggle, LogsMetaBar } from '../LogsToolbarControls'
+import {
+  extractLevel,
+  extractSource,
+  filterLogLines,
+  normalizeLevel
+} from '../../utils/logFilter'
 
 const TERMINAL_PHASES: Phase[] = [Phase.Succeeded, Phase.Failed, Phase.ValidationFailed]
 const LOG_LEVELS = ['ALL', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'SUCCESS'] as const
@@ -84,22 +84,10 @@ export default function MigrationDetailDebugLogs({ migration }: MigrationDetailD
     return Array.from(s)
   }, [logs])
 
-  const filtered = useMemo(() => {
-    return logs.filter((line) => {
-      if (levelFilter !== 'ALL') {
-        const raw = extractLevel(line)
-        if (!raw || normalizeLevel(raw) !== levelFilter) return false
-      }
-      if (sourceFilter !== 'ALL') {
-        const src = extractSource(line)
-        if (src !== sourceFilter) return false
-      }
-      if (search.trim()) {
-        if (!line.toLowerCase().includes(search.toLowerCase())) return false
-      }
-      return true
-    })
-  }, [logs, levelFilter, sourceFilter, search])
+  const filtered = useMemo(
+    () => filterLogLines(logs, { search, level: levelFilter, source: sourceFilter }),
+    [logs, levelFilter, sourceFilter, search]
+  )
 
   const counts = useMemo(() => {
     const c = { ERROR: 0, WARN: 0, INFO: 0, DEBUG: 0 }

--- a/ui/src/features/migration/utils/logFilter.test.ts
+++ b/ui/src/features/migration/utils/logFilter.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractLevel,
+  extractSource,
+  filterLogLines,
+  matchesSearch,
+  normalizeLevel,
+  parseSearchQuery
+} from './logFilter'
+
+const CONTROLLER_LINE =
+  '2026-07-27T10:36:49Z\tINFO\tmigration-controller\tReconciling Migration object\t' +
+  '{"controller": "migration", "controllerGroup": "vjailbreak.k8s.pf9.io", "controllerKind": "Migration", ' +
+  '"Migration": {"name":"migration-windows-11-vtpm-automation-2466-fb547","namespace":"migration-system"}, ' +
+  '"namespace": "migration-system", "name": "migration-windows-11-vtpm-automation-2466-fb547", ' +
+  '"reconcileID": "935246a7-8480-49a2-a6f0-cbc5527d1c87"}'
+
+const CONTROLLER_ERROR_LINE =
+  '2026-07-27T10:36:50Z\tERROR\tmigration-controller\tfailed to reconcile\t' +
+  '{"error": "pods \\"v2v-helper\\" already exists", "name": "migration-windows-11-vtpm-automation-2466-fb547"}'
+
+const OTHER_LINE =
+  '2026-07-27T12:01:11Z\tINFO\tmigration-controller\tReconciling VMwareCreds object\t' +
+  '{"controllerKind": "VMwareCreds", "VMwareCreds": {"name":"vcenter-pune","namespace":"migration-system"}}'
+
+// v2v-helper style line used by the migration details logs tab.
+const HELPER_LINE = '12:04:31.221 [v2v-helper] INFO Converting disk 1 of 2'
+
+describe('parseSearchQuery', () => {
+  it('returns no terms for blank queries', () => {
+    expect(parseSearchQuery('')).toEqual([])
+    expect(parseSearchQuery('   ')).toEqual([])
+  })
+
+  it('splits on whitespace and lower-cases', () => {
+    expect(parseSearchQuery('Foo BAR')).toEqual([
+      { text: 'foo', negated: false },
+      { text: 'bar', negated: false }
+    ])
+  })
+
+  it('keeps quoted phrases intact', () => {
+    expect(parseSearchQuery('"Reconciling Migration object"')).toEqual([
+      { text: 'reconciling migration object', negated: false }
+    ])
+  })
+
+  it('supports negated tokens and phrases', () => {
+    expect(parseSearchQuery('migration -requeuing -"terminal state"')).toEqual([
+      { text: 'migration', negated: false },
+      { text: 'requeuing', negated: true },
+      { text: 'terminal state', negated: true }
+    ])
+  })
+
+  it('treats an unpaired quote and a lone dash as literal tokens', () => {
+    expect(parseSearchQuery('"foo')).toEqual([{ text: '"foo', negated: false }])
+    expect(parseSearchQuery('-')).toEqual([{ text: '-', negated: false }])
+  })
+
+  it('drops empty quoted phrases', () => {
+    expect(parseSearchQuery('""')).toEqual([])
+  })
+
+  it('is not affected by a previous call (no sticky regex state)', () => {
+    expect(parseSearchQuery('alpha')).toEqual([{ text: 'alpha', negated: false }])
+    expect(parseSearchQuery('alpha')).toEqual([{ text: 'alpha', negated: false }])
+  })
+})
+
+describe('matchesSearch', () => {
+  it('matches every line when there are no terms', () => {
+    expect(matchesSearch(CONTROLLER_LINE, [])).toBe(true)
+  })
+
+  it('requires all positive terms (AND)', () => {
+    const terms = parseSearchQuery('reconciling vtpm')
+    expect(matchesSearch(CONTROLLER_LINE, terms)).toBe(true)
+    expect(matchesSearch(OTHER_LINE, terms)).toBe(false)
+  })
+
+  it('excludes lines hitting a negated term', () => {
+    const terms = parseSearchQuery('migration-system -vmwarecreds')
+    expect(matchesSearch(CONTROLLER_LINE, terms)).toBe(true)
+    expect(matchesSearch(OTHER_LINE, terms)).toBe(false)
+  })
+
+  it('supports a negation-only query', () => {
+    const terms = parseSearchQuery('-vmwarecreds')
+    expect(matchesSearch(CONTROLLER_LINE, terms)).toBe(true)
+    expect(matchesSearch(OTHER_LINE, terms)).toBe(false)
+  })
+})
+
+describe('filterLogLines search (issue #2214 regression)', () => {
+  const logs = [CONTROLLER_LINE, CONTROLLER_ERROR_LINE, OTHER_LINE]
+
+  it('finds a literal substring buried deep inside a long line', () => {
+    // The exact term the reporter typed. Must not silently return zero lines.
+    expect(filterLogLines(logs, { search: 'windows-11-vtpm-automation' })).toEqual([
+      CONTROLLER_LINE,
+      CONTROLLER_ERROR_LINE
+    ])
+  })
+
+  it('finds a literal substring regardless of how far into the line it sits', () => {
+    const term = 'needle-9f2c'
+    for (const offset of [0, 40, 120, 400, 1200, 4000]) {
+      const line = `${'x'.repeat(offset)}${term} trailing text`
+      expect(filterLogLines([line], { search: term }), `offset ${offset}`).toEqual([line])
+    }
+  })
+
+  it('is case-insensitive in both directions', () => {
+    expect(filterLogLines(logs, { search: 'WINDOWS-11-VTPM' })).toHaveLength(2)
+    expect(filterLogLines(logs, { search: 'vmwarecreds' })).toEqual([OTHER_LINE])
+  })
+
+  it('never invents matches for text that is absent', () => {
+    // Fuzzy search used to score near-misses as hits; literal search must not.
+    expect(filterLogLines(logs, { search: 'windows-10-vtpm-automation' })).toEqual([])
+    expect(filterLogLines([OTHER_LINE], { search: 'ERROR' })).toEqual([])
+    expect(filterLogLines(logs, { search: 'zzz-not-present' })).toEqual([])
+  })
+
+  it('treats a fully quoted query as a literal phrase', () => {
+    expect(filterLogLines(logs, { search: '"Reconciling Migration object"' })).toEqual([
+      CONTROLLER_LINE
+    ])
+    expect(filterLogLines(logs, { search: '"Reconciling object Migration"' })).toEqual([])
+  })
+
+  it('matches tokens in any order', () => {
+    expect(filterLogLines(logs, { search: 'vtpm reconciling' })).toEqual([
+      filterLogLines(logs, { search: 'reconciling vtpm' })[0]
+    ])
+  })
+
+  it('matches text containing regex metacharacters literally', () => {
+    expect(filterLogLines(logs, { search: 'pods \\"v2v-helper\\" already exists' })).toEqual([
+      CONTROLLER_ERROR_LINE
+    ])
+    expect(filterLogLines(logs, { search: '(unclosed' })).toEqual([])
+  })
+
+  it('ignores whitespace-only queries and returns the input untouched', () => {
+    expect(filterLogLines(logs, { search: '   ' })).toBe(logs)
+    expect(filterLogLines(logs)).toBe(logs)
+  })
+
+  it('scales to a full buffer without dropping matches', () => {
+    const many = Array.from({ length: 5000 }, (_, i) =>
+      i % 2 === 0 ? `${CONTROLLER_LINE} seq=${i}` : `${OTHER_LINE} seq=${i}`
+    )
+    expect(filterLogLines(many, { search: 'windows-11-vtpm-automation' })).toHaveLength(2500)
+  })
+})
+
+describe('filterLogLines level filter', () => {
+  const logs = [CONTROLLER_LINE, CONTROLLER_ERROR_LINE, OTHER_LINE, HELPER_LINE]
+
+  it('passes everything through for ALL', () => {
+    expect(filterLogLines(logs, { level: 'ALL' })).toBe(logs)
+  })
+
+  it('keeps only the requested level', () => {
+    expect(filterLogLines(logs, { level: 'ERROR' })).toEqual([CONTROLLER_ERROR_LINE])
+    expect(filterLogLines(logs, { level: 'INFO' })).toEqual([
+      CONTROLLER_LINE,
+      OTHER_LINE,
+      HELPER_LINE
+    ])
+  })
+
+  it('drops lines with no detectable level', () => {
+    expect(filterLogLines(['plain text with no level'], { level: 'INFO' })).toEqual([])
+  })
+
+  it('combines with search', () => {
+    expect(filterLogLines(logs, { level: 'ERROR', search: 'windows-11-vtpm-automation' })).toEqual([
+      CONTROLLER_ERROR_LINE
+    ])
+    expect(filterLogLines(logs, { level: 'ERROR', search: 'vmwarecreds' })).toEqual([])
+  })
+})
+
+describe('filterLogLines source filter', () => {
+  it('keeps only the requested source', () => {
+    const logs = [HELPER_LINE, '12:04:32.100 [virt-v2v] INFO copying disk', CONTROLLER_LINE]
+    expect(filterLogLines(logs, { source: 'v2v-helper' })).toEqual([HELPER_LINE])
+    expect(filterLogLines(logs, { source: 'ALL' })).toBe(logs)
+  })
+})
+
+describe('level helpers', () => {
+  it('extracts the level from controller and helper line formats', () => {
+    expect(extractLevel(CONTROLLER_LINE)).toBe('INFO')
+    expect(extractLevel(CONTROLLER_ERROR_LINE)).toBe('ERROR')
+    expect(extractLevel(HELPER_LINE)).toBe('INFO')
+    expect(extractLevel('no level here')).toBeNull()
+  })
+
+  it('normalizes aliases', () => {
+    expect(normalizeLevel('FATAL')).toBe('ERROR')
+    expect(normalizeLevel('FAILED')).toBe('ERROR')
+    expect(normalizeLevel('WARNING')).toBe('WARN')
+    expect(normalizeLevel('SUCCEEDED')).toBe('SUCCESS')
+    expect(normalizeLevel('INFO')).toBe('INFO')
+    expect(normalizeLevel('NOTICE')).toBe('OTHER')
+  })
+
+  it('extracts the source only from prefixed lines', () => {
+    expect(extractSource(HELPER_LINE)).toBe('v2v-helper')
+    expect(extractSource(CONTROLLER_LINE)).toBeNull()
+  })
+})

--- a/ui/src/features/migration/utils/logFilter.ts
+++ b/ui/src/features/migration/utils/logFilter.ts
@@ -1,0 +1,100 @@
+export type LogLevel = 'ERROR' | 'WARN' | 'INFO' | 'DEBUG' | 'TRACE' | 'SUCCESS' | 'OTHER'
+
+const LEVEL_RE = /\b(ERROR|FATAL|WARN|WARNING|INFO|DEBUG|TRACE|SUCCESS|SUCCEEDED|FAILED)\b/i
+
+const SOURCE_RE = /^\d{2}:\d{2}:\d{2}[.\d]*\s+\[?(\w[\w-]*)\]?/
+
+/** First level keyword found in the line, upper-cased, or null when the line has none. */
+export function extractLevel(line: string): string | null {
+  const m = line.match(LEVEL_RE)
+  return m ? m[1].toUpperCase() : null
+}
+
+/** Collapse level aliases (FATAL, WARNING, SUCCEEDED, …) onto the filterable set. */
+export function normalizeLevel(raw: string): LogLevel {
+  if (/ERROR|FATAL|FAIL/.test(raw)) return 'ERROR'
+  if (/WARN/.test(raw)) return 'WARN'
+  if (raw === 'INFO') return 'INFO'
+  if (raw === 'DEBUG') return 'DEBUG'
+  if (raw === 'TRACE') return 'TRACE'
+  if (/SUCCESS|SUCCEED/.test(raw)) return 'SUCCESS'
+  return 'OTHER'
+}
+
+/** Component name from a `HH:MM:SS [source] …` prefixed line, or null. */
+export function extractSource(line: string): string | null {
+  const m = line.match(SOURCE_RE)
+  return m ? m[1] : null
+}
+
+export interface SearchTerm {
+  /** Already lower-cased, so callers compare against a lower-cased line. */
+  text: string
+  negated: boolean
+}
+
+// Either an optionally-negated quoted phrase, or a bare whitespace-delimited token.
+const TERM_RE = /(-?)"([^"]*)"|(\S+)/g
+
+export function parseSearchQuery(query: string): SearchTerm[] {
+  const terms: SearchTerm[] = []
+  TERM_RE.lastIndex = 0
+
+  let match: RegExpExecArray | null
+  while ((match = TERM_RE.exec(query)) !== null) {
+    const [, quoteNegation, phrase, bareToken] = match
+
+    if (phrase !== undefined) {
+      if (phrase) terms.push({ text: phrase.toLowerCase(), negated: quoteNegation === '-' })
+      continue
+    }
+
+    // A lone "-" is not a negation, it is a token.
+    const negated = bareToken.length > 1 && bareToken.startsWith('-')
+    const text = negated ? bareToken.slice(1) : bareToken
+    if (text) terms.push({ text: text.toLowerCase(), negated })
+  }
+
+  return terms
+}
+
+export function matchesSearch(line: string, terms: SearchTerm[]): boolean {
+  if (terms.length === 0) return true
+
+  const haystack = line.toLowerCase()
+  for (const term of terms) {
+    const present = haystack.includes(term.text)
+    if (term.negated === present) return false
+  }
+  return true
+}
+
+export interface LogFilterOptions {
+  /** Raw query string straight from the search box. */
+  search?: string
+  /** A LogLevel, or 'ALL' to disable the level filter. */
+  level?: string
+  /** A source name, or 'ALL' to disable the source filter. */
+  source?: string
+}
+
+/**
+ * Apply search + level + source filters. Returns the original array (same reference)
+ * when nothing is filtered, so callers can rely on referential stability.
+ */
+export function filterLogLines(
+  logs: string[],
+  { search = '', level = 'ALL', source = 'ALL' }: LogFilterOptions = {}
+): string[] {
+  const terms = parseSearchQuery(search)
+  if (terms.length === 0 && level === 'ALL' && source === 'ALL') return logs
+
+  return logs.filter((line) => {
+    if (level !== 'ALL') {
+      const raw = extractLevel(line)
+      if (!raw || normalizeLevel(raw) !== level) return false
+    }
+    if (source !== 'ALL' && extractSource(line) !== source) return false
+    return matchesSearch(line, terms)
+  })
+}

--- a/ui/src/hooks/useDeploymentLogs.ts
+++ b/ui/src/hooks/useDeploymentLogs.ts
@@ -19,6 +19,11 @@ interface UseDeploymentLogsReturn {
 
 const MAX_LOG_LINES = 5000
 
+// Fetch as much history as the client is willing to buffer. Fetching less than
+// MAX_LOG_LINES silently shrinks the window the search box can see, which reads as a
+// broken search filter when the line exists in `kubectl logs`.
+const HISTORY_TAIL_LINES = String(MAX_LOG_LINES)
+
 export const useDeploymentLogs = ({
   deploymentName,
   namespace,
@@ -59,7 +64,7 @@ export const useDeploymentLogs = ({
 
       const response = await streamPodLogs(podNamespace, podName, {
         follow: true,
-        tailLines: fetchHistory ? '2000' : undefined,
+        tailLines: fetchHistory ? HISTORY_TAIL_LINES : undefined,
         limitBytes: 8 * 1024 * 1024,
         signal: abortController.signal
       })


### PR DESCRIPTION
## What this PR does / why we need it
Log search used fuzzy matching (fuse.js) instead of literal substring match. Fuzzy scoring falsely returned 0 hits for some present terms and false-positive hits for absent ones.

## Which issue(s) this PR fixes
fixes #2214

## Testing done

<img width="1910" height="982" alt="image" src="https://github.com/user-attachments/assets/c98eeb4b-f19f-46e3-89f1-a35a92458247" />
