### PR TITLE
[2217] Fix: Remove stale network/storage mappings when VMs are deselected

### DIFF
--- a/ui/src/features/migration/hooks/useFilteredMappings.test.ts
+++ b/ui/src/features/migration/hooks/useFilteredMappings.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest'
 import { filterMappingsBySourceAndTarget, mappingsNeedReconcile } from './useFilteredMappings'
 
 describe('filterMappingsBySourceAndTarget', () => {
-  it('keeps mappings untouched when the source list is empty (VMs not selected yet)', () => {
+  it('drops all mappings when the source list is empty (all VMs deselected, so nothing is stale-safe to keep)', () => {
     const mappings = [{ source: 'VM Network', target: 'net-1' }]
-    expect(filterMappingsBySourceAndTarget(mappings, [], ['net-1'])).toEqual(mappings)
+    expect(filterMappingsBySourceAndTarget(mappings, [], ['net-1'])).toEqual([])
   })
 
   it('keeps mappings untouched when the target list is empty (destination not loaded yet)', () => {
@@ -31,6 +31,22 @@ describe('filterMappingsBySourceAndTarget', () => {
 
   it('returns an empty array when no mappings are given', () => {
     expect(filterMappingsBySourceAndTarget(undefined, ['VM Network'], ['net-1'])).toEqual([])
+  })
+
+  it('keeps a mapping still used by a remaining selected VM after another VM is deselected (#2217)', () => {
+    const mappings = [
+      { source: 'VM Network A', target: 'net-1' },
+      { source: 'VM Network B', target: 'net-2' }
+    ]
+    // VM using "VM Network B" was deselected; VM using "VM Network A" remains selected.
+    expect(
+      filterMappingsBySourceAndTarget(mappings, ['VM Network A'], ['net-1', 'net-2'])
+    ).toEqual([{ source: 'VM Network A', target: 'net-1' }])
+  })
+
+  it('drops the only mapping when the single remaining VM is deselected (#2217)', () => {
+    const mappings = [{ source: 'VM Datastore', target: 'volume-1' }]
+    expect(filterMappingsBySourceAndTarget(mappings, [], ['volume-1'])).toEqual([])
   })
 })
 

--- a/ui/src/features/migration/hooks/useFilteredMappings.ts
+++ b/ui/src/features/migration/hooks/useFilteredMappings.ts
@@ -23,11 +23,7 @@ interface UseFilteredMappingsParams {
 // sourceList (vmwareNetworks/vmWareStorage) is derived synchronously from the
 // currently selected VMs, so an empty sourceList is always the real current
 // state — no VMs selected, or none have interfaces/disks left referencing that
-// mapping — and stale entries must be dropped. targetList
-// (OpenStack networks/storage/array-creds names) comes from an async query;
-// an empty targetList can mean that data just hasn't loaded yet, so we skip
-// filtering rather than wipe valid mappings (e.g. ones prefilled from a
-// template or a retry) before it's ready.
+// mapping — and stale entries must be dropped.
 export function filterMappingsBySourceAndTarget(
   mappings: ResourceMap[] | undefined,
   sourceList: string[],

--- a/ui/src/features/migration/hooks/useFilteredMappings.ts
+++ b/ui/src/features/migration/hooks/useFilteredMappings.ts
@@ -20,16 +20,20 @@ interface UseFilteredMappingsParams {
   onChange: (key: string) => (value: unknown) => void
 }
 
-// An empty source or target list means either side's data has not loaded yet
-// (e.g. VMs not selected yet so vmwareNetworks/vmWareStorage is empty, or
-// OpenStack creds still loading) — filtering now would wipe valid mappings
-// (e.g. ones prefilled from a template or a retry) before both sides are ready.
+// sourceList (vmwareNetworks/vmWareStorage) is derived synchronously from the
+// currently selected VMs, so an empty sourceList is always the real current
+// state — no VMs selected, or none have interfaces/disks left referencing that
+// mapping — and stale entries must be dropped. targetList
+// (OpenStack networks/storage/array-creds names) comes from an async query;
+// an empty targetList can mean that data just hasn't loaded yet, so we skip
+// filtering rather than wipe valid mappings (e.g. ones prefilled from a
+// template or a retry) before it's ready.
 export function filterMappingsBySourceAndTarget(
   mappings: ResourceMap[] | undefined,
   sourceList: string[],
   targetList: string[]
 ): ResourceMap[] {
-  if (sourceList.length === 0 || targetList.length === 0) {
+  if (targetList.length === 0) {
     return mappings || []
   }
   return (mappings || []).filter(


### PR DESCRIPTION
## What this PR does / why we need it
Remove stale network/storage mappings when VMs are deselected 

## Which issue(s) this PR fixes
fixes #2217

## Testing done


https://github.com/user-attachments/assets/cf759d02-3d5d-4b7c-a8fa-4100ecb920b9

