### PR TITLE
[2212] Refactoring migration scheduling and validations

### DIFF
--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/pkg/errors"
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
 	"github.com/platform9/vjailbreak/k8s/migration/pkg/scope"
@@ -587,11 +588,27 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 		}
 	}
 
-	var validVMs []*vjailbreakv1alpha1.VMwareMachine
+	// Creds are fetched before validation because pre-flight now resolves each VM's
+	// target flavor, which needs the OpenStack endpoint.
+	// Fetch VMwareCreds CR
+	if ok, err := r.checkStatusSuccess(ctx, migrationtemplate.Namespace, migrationtemplate.Spec.Source.VMwareRef, true, vmwcreds); !ok {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to check vmwarecreds status '%s'", migrationtemplate.Spec.Source.VMwareRef)
+	}
+	// Fetch OpenStackCreds CR
+	openstackcreds := &vjailbreakv1alpha1.OpenstackCreds{}
+	if ok, err := r.checkStatusSuccess(ctx, migrationtemplate.Namespace, migrationtemplate.Spec.Destination.OpenstackRef,
+		false, openstackcreds); !ok {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to check openstackcreds status '%s'", migrationtemplate.Spec.Destination.OpenstackRef)
+	}
+
+	// Non-nil default so the no-VMs-to-validate path below can be read safely.
+	// On error validateMigrationPlanVMs returns a nil result, but every use of
+	// `validation` is downstream of the `validationErr != nil` early return.
+	validation := &migrationPlanValidation{ResolvedFlavors: map[string]string{}}
 	var validationErr error
 	if len(vmsToValidate) > 0 {
-		// Validate VM OS types before proceeding with migration
-		validVMs, _, validationErr = r.validateMigrationPlanVMs(ctx, migrationplan, migrationtemplate, vmwcreds, vmsToValidate)
+		// Validate VM OS types and resolve target flavors before proceeding
+		validation, validationErr = r.validateMigrationPlanVMs(ctx, migrationplan, migrationtemplate, vmwcreds, openstackcreds, vmsToValidate)
 	}
 
 	if validationErr != nil {
@@ -624,9 +641,22 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 		return ctrl.Result{}, validationErr
 	}
 
+	// VMs skipped for having no schedulable flavor deliberately get no Migration CR:
+	// a ValidationFailed Migration would flip the plan to PodFailed in
+	// processMigrationPhases and stop post-migration for the healthy VMs.
+	flavorSkipped := make(map[string]bool, len(validation.FlavorSkippedVMs))
+	for _, v := range validation.FlavorSkippedVMs {
+		flavorSkipped[commonutils.GetVMUniqueKey(v.Spec.VMInfo.Name, v.Spec.VMInfo.VMID)] = true
+	}
+
 	for _, vmName := range allVMNames {
 		// Skip VMs with terminal migrations
 		if terminalMigrations[vmName] {
+			continue
+		}
+
+		if flavorSkipped[vmName] {
+			r.ctxlog.Info("Skipping Migration CR creation for VM with no schedulable target flavor", "vm", vmName)
 			continue
 		}
 
@@ -643,7 +673,7 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 		}
 
 		isValid := false
-		for _, v := range validVMs {
+		for _, v := range validation.ValidVMs {
 			if commonutils.GetVMUniqueKey(v.Spec.VMInfo.Name, v.Spec.VMInfo.VMID) == vmName {
 				isValid = true
 				break
@@ -653,17 +683,6 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 		if !isValid {
 			r.markMigrationValidationFailed(ctx, migrationObj, vmName, "VM failed migration plan validation")
 		}
-	}
-
-	// Fetch VMwareCreds CR
-	if ok, err := r.checkStatusSuccess(ctx, migrationtemplate.Namespace, migrationtemplate.Spec.Source.VMwareRef, true, vmwcreds); !ok {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to check vmwarecreds status '%s'", migrationtemplate.Spec.Source.VMwareRef)
-	}
-	// Fetch OpenStackCreds CR
-	openstackcreds := &vjailbreakv1alpha1.OpenstackCreds{}
-	if ok, err := r.checkStatusSuccess(ctx, migrationtemplate.Namespace, migrationtemplate.Spec.Destination.OpenstackRef,
-		false, openstackcreds); !ok {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to check openstackcreds status '%s'", migrationtemplate.Spec.Destination.OpenstackRef)
 	}
 
 	var arraycreds *vjailbreakv1alpha1.ArrayCreds
@@ -719,9 +738,9 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 	}
 
 	// vmMachinesArr is created to maintain order in which VM migration is triggered
-	vmMachinesArr := validVMs
-	vmMachinesMap := make(map[string]*vjailbreakv1alpha1.VMwareMachine, len(validVMs))
-	for _, vmMachine := range validVMs {
+	vmMachinesArr := validation.ValidVMs
+	vmMachinesMap := make(map[string]*vjailbreakv1alpha1.VMwareMachine, len(validation.ValidVMs))
+	for _, vmMachine := range validation.ValidVMs {
 		vmMachinesMap[vmMachine.Spec.VMInfo.Name] = vmMachine
 	}
 
@@ -737,7 +756,7 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 
 	for _, parallelvms := range migrationplan.Spec.VirtualMachines {
 		migrationobjs := &vjailbreakv1alpha1.MigrationList{}
-		err := r.TriggerMigration(ctx, migrationplan, migrationobjs, openstackcreds, vmwcreds, arraycreds, migrationtemplate, vmMachinesArr, proxyVM)
+		err := r.TriggerMigration(ctx, migrationplan, migrationobjs, openstackcreds, vmwcreds, arraycreds, migrationtemplate, vmMachinesArr, proxyVM, validation.ResolvedFlavors)
 		if err != nil {
 			if strings.Contains(err.Error(), "VDDK_MISSING") {
 				r.ctxlog.Info("Requeuing due to missing VDDK files.")
@@ -1354,6 +1373,7 @@ func (r *MigrationPlanReconciler) CreateMigrationConfigMap(ctx context.Context,
 	vmwcreds *vjailbreakv1alpha1.VMwareCreds, vm string, vmMachine *vjailbreakv1alpha1.VMwareMachine,
 	arraycreds *vjailbreakv1alpha1.ArrayCreds,
 	proxyVM *vjailbreakv1alpha1.ProxyVM,
+	resolvedFlavors map[string]string,
 ) (*corev1.ConfigMap, error) {
 	vmname, err := commonutils.GetK8sCompatibleVMWareObjectName(vm, vmwcreds.Name)
 	if err != nil {
@@ -1364,7 +1384,7 @@ func (r *MigrationPlanReconciler) CreateMigrationConfigMap(ctx context.Context,
 	configMap := &corev1.ConfigMap{}
 	err = r.Get(ctx, types.NamespacedName{Name: configMapName, Namespace: migrationplan.Namespace}, configMap)
 	if err != nil && apierrors.IsNotFound(err) {
-		configMap, err = r.buildNewMigrationConfigMap(ctx, migrationplan, migrationtemplate, migrationobj, openstackcreds, vmwcreds, vm, vmname, configMapName, vmMachine, arraycreds, proxyVM)
+		configMap, err = r.buildNewMigrationConfigMap(ctx, migrationplan, migrationtemplate, migrationobj, openstackcreds, vmwcreds, vm, vmname, configMapName, vmMachine, arraycreds, proxyVM, resolvedFlavors)
 		if err != nil {
 			return nil, err
 		}
@@ -1386,6 +1406,7 @@ func (r *MigrationPlanReconciler) buildNewMigrationConfigMap(ctx context.Context
 	vmMachine *vjailbreakv1alpha1.VMwareMachine,
 	arraycreds *vjailbreakv1alpha1.ArrayCreds,
 	proxyVM *vjailbreakv1alpha1.ProxyVM,
+	resolvedFlavors map[string]string,
 ) (*corev1.ConfigMap, error) {
 	r.ctxlog.Info(fmt.Sprintf("Creating new ConfigMap '%s' for VM '%s'", configMapName, vmname))
 
@@ -1418,7 +1439,7 @@ func (r *MigrationPlanReconciler) buildNewMigrationConfigMap(ctx context.Context
 
 	r.setMigrationSpecificFields(configMapData, migrationobj)
 
-	if err := r.determineAndSetTargetFlavor(ctx, configMapData, vmMachine, migrationtemplate, openstackcreds); err != nil {
+	if err := r.determineAndSetTargetFlavor(ctx, configMapData, vmMachine, migrationtemplate, openstackcreds, resolvedFlavors); err != nil {
 		return nil, err
 	}
 
@@ -1577,48 +1598,130 @@ func (r *MigrationPlanReconciler) setMigrationSpecificFields(configMapData map[s
 	configMapData["DATA_ONLY"] = strconv.FormatBool(migrationobj.Spec.DataOnly)
 }
 
-func (r *MigrationPlanReconciler) determineAndSetTargetFlavor(ctx context.Context,
-	configMapData map[string]string,
+// candidateFlavorsForPlan returns the flavors that are eligible for a plan's
+// target, applying the PCD availability-zone restriction. This is the single
+// Nova round-trip for a whole MigrationPlan: pre-flight validation calls it once
+// and caches the per-VM result, so the previous behaviour of one ListAllFlavors
+// call per VM is gone.
+//
+// In PCD the cluster name is the availability zone, and a flavor is bound to a
+// cluster via its `availability_zone` extra_spec property. Flavors without that
+// property are global and remain eligible.
+func (r *MigrationPlanReconciler) candidateFlavorsForPlan(ctx context.Context,
+	migrationtemplate *vjailbreakv1alpha1.MigrationTemplate,
+	openstackcreds *vjailbreakv1alpha1.OpenstackCreds,
+) ([]flavors.Flavor, error) {
+	allFlavors, err := utils.ListAllFlavors(ctx, r.Client, openstackcreds)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list all flavors")
+	}
+
+	if utils.IsOpenstackPCD(*openstackcreds) {
+		allFlavors = openstackpkg.FilterFlavorsByAvailabilityZone(allFlavors, migrationtemplate.Spec.TargetPCDClusterName)
+	}
+
+	return allFlavors, nil
+}
+
+// resolveTargetFlavorID picks the target flavor for a single VM out of an
+// already-fetched candidate set. It is pure (no API calls) so that pre-flight
+// validation and the config-map build path share one implementation and cannot
+// drift apart on the GPU/AZ filtering rules.
+//
+// A shape that no candidate satisfies is returned as ErrNoSuitableFlavor, which
+// callers classify with errors.Is to decide skip-vs-fail.
+func resolveTargetFlavorID(
 	vmMachine *vjailbreakv1alpha1.VMwareMachine,
 	migrationtemplate *vjailbreakv1alpha1.MigrationTemplate,
 	openstackcreds *vjailbreakv1alpha1.OpenstackCreds,
-) error {
+	candidateFlavors []flavors.Flavor,
+) (string, error) {
+	// Explicit operator override always wins and is never second-guessed.
 	if vmMachine.Spec.TargetFlavorID != "" {
-		configMapData["TARGET_FLAVOR_ID"] = vmMachine.Spec.TargetFlavorID
-		return nil
-	}
-
-	allFlavors, err := utils.ListAllFlavors(ctx, r.Client, openstackcreds)
-	if err != nil {
-		return errors.Wrap(err, "failed to list all flavors")
-	}
-
-	// Restrict to flavors that can schedule onto the user-selected target PCD
-	// cluster. In PCD the cluster name is the availability zone, and a flavor
-	// is bound to a cluster via its `availability_zone` extra_spec property.
-	// Flavors without that property are global and remain eligible.
-	if utils.IsOpenstackPCD(*openstackcreds) {
-		allFlavors = openstackpkg.FilterFlavorsByAvailabilityZone(allFlavors, migrationtemplate.Spec.TargetPCDClusterName)
+		return vmMachine.Spec.TargetFlavorID, nil
 	}
 
 	useGPUFlavor := migrationtemplate.Spec.UseGPUFlavor && utils.IsOpenstackPCD(*openstackcreds)
 	passthroughGPUCount := vmMachine.Spec.VMInfo.GPU.PassthroughCount
 	vgpuCount := vmMachine.Spec.VMInfo.GPU.VGPUCount
 
-	flavor, err := openstackpkg.GetClosestFlavour(vmMachine.Spec.VMInfo.CPU, vmMachine.Spec.VMInfo.Memory, passthroughGPUCount, vgpuCount, allFlavors, useGPUFlavor)
+	flavor, err := openstackpkg.GetClosestFlavour(
+		vmMachine.Spec.VMInfo.CPU,
+		vmMachine.Spec.VMInfo.Memory,
+		passthroughGPUCount,
+		vgpuCount,
+		candidateFlavors,
+		useGPUFlavor,
+	)
 	if err != nil {
-		return errors.Wrap(err, "failed to get closest flavor")
+		return "", err
 	}
 
 	if flavor == nil {
+		// Defensive: GetClosestFlavour returns a non-nil error in this case today,
+		// but keep the sentinel wrapped so a future change cannot turn a nil flavor
+		// into a hard plan failure.
 		gpuInfo := " without GPU"
 		if passthroughGPUCount > 0 || vgpuCount > 0 {
 			gpuInfo = fmt.Sprintf(", %d passthrough GPU(s), and %d vGPU(s)", passthroughGPUCount, vgpuCount)
 		}
-		return errors.Errorf("no suitable flavor found for %d vCPUs, %d MB RAM%s", vmMachine.Spec.VMInfo.CPU, vmMachine.Spec.VMInfo.Memory, gpuInfo)
+		return "", fmt.Errorf("%w for %d vCPUs, %d MB RAM%s",
+			openstackpkg.ErrNoSuitableFlavor, vmMachine.Spec.VMInfo.CPU, vmMachine.Spec.VMInfo.Memory, gpuInfo)
 	}
 
-	configMapData["TARGET_FLAVOR_ID"] = flavor.ID
+	return flavor.ID, nil
+}
+
+// isNoSuitableFlavorErr reports whether err was ultimately caused by a VM shape
+// that no target flavor can satisfy. Used to keep that one condition
+// non-blocking while every other failure still aborts and requeues.
+func isNoSuitableFlavorErr(err error) bool {
+	return errors.Is(err, openstackpkg.ErrNoSuitableFlavor)
+}
+
+// shouldSkipVMForFlavor reports whether the trigger loop must skip a VM because
+// pre-flight validation did not resolve a target flavor for it.
+func shouldSkipVMForFlavor(vmMachine *vjailbreakv1alpha1.VMwareMachine, resolvedFlavors map[string]string) bool {
+	if vmMachine.Spec.TargetFlavorID != "" {
+		return false
+	}
+	flavorID, ok := resolvedFlavors[vmMachine.Name]
+	return !ok || flavorID == ""
+}
+
+func (r *MigrationPlanReconciler) determineAndSetTargetFlavor(ctx context.Context,
+	configMapData map[string]string,
+	vmMachine *vjailbreakv1alpha1.VMwareMachine,
+	migrationtemplate *vjailbreakv1alpha1.MigrationTemplate,
+	openstackcreds *vjailbreakv1alpha1.OpenstackCreds,
+	resolvedFlavors map[string]string,
+) error {
+	if vmMachine.Spec.TargetFlavorID != "" {
+		configMapData["TARGET_FLAVOR_ID"] = vmMachine.Spec.TargetFlavorID
+		return nil
+	}
+
+	// Fast path: pre-flight validation already resolved this VM, so no Nova call.
+	if flavorID, ok := resolvedFlavors[vmMachine.Name]; ok && flavorID != "" {
+		configMapData["TARGET_FLAVOR_ID"] = flavorID
+		return nil
+	}
+
+	// Slow path: no cached entry — e.g. a ConfigMap being rebuilt for a plan that
+	// was validated by an older controller version. Resolve on demand.
+	candidateFlavors, err := r.candidateFlavorsForPlan(ctx, migrationtemplate, openstackcreds)
+	if err != nil {
+		return err
+	}
+
+	flavorID, err := resolveTargetFlavorID(vmMachine, migrationtemplate, openstackcreds, candidateFlavors)
+	if err != nil {
+		// errors.Wrapf preserves the chain, so isNoSuitableFlavorErr still matches
+		// at the trigger-loop call site.
+		return errors.Wrapf(err, "failed to determine target flavor for VM %s", vmMachine.Name)
+	}
+
+	configMapData["TARGET_FLAVOR_ID"] = flavorID
 	return nil
 }
 
@@ -2061,6 +2164,7 @@ func (r *MigrationPlanReconciler) TriggerMigration(ctx context.Context,
 	migrationtemplate *vjailbreakv1alpha1.MigrationTemplate,
 	parallelvms []*vjailbreakv1alpha1.VMwareMachine,
 	proxyVM *vjailbreakv1alpha1.ProxyVM,
+	resolvedFlavors map[string]string,
 ) error {
 	ctxlog := r.ctxlog.WithValues("migrationplan", migrationplan.Name)
 	var fbcm *corev1.ConfigMap
@@ -2090,6 +2194,14 @@ func (r *MigrationPlanReconciler) TriggerMigration(ctx context.Context,
 			vm = vmMachineObj.Spec.VMInfo.Name
 		}
 
+		// Belt-and-braces: pre-flight validation resolved a flavor for every VM it
+		// put in parallelvms, so a missing entry means the VM is unschedulable. Skip
+		// it before creating a Migration CR so one bad VM cannot block the rest.
+		if shouldSkipVMForFlavor(vmMachineObj, resolvedFlavors) {
+			ctxlog.Info("Skipping VM with no schedulable target flavor", "vm", vm)
+			continue
+		}
+
 		migrationobj, err := r.CreateMigration(ctx, migrationplan, vm, vmMachineObj)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create Migration for VM %s", vm)
@@ -2106,8 +2218,29 @@ func (r *MigrationPlanReconciler) TriggerMigration(ctx context.Context,
 
 		migrationobjs.Items = append(migrationobjs.Items, *migrationobj)
 
-		_, err = r.CreateMigrationConfigMap(ctx, migrationplan, migrationtemplate, migrationobj, openstackcreds, vmwcreds, vm, vmMachineObj, arraycreds, proxyVM)
+		_, err = r.CreateMigrationConfigMap(ctx, migrationplan, migrationtemplate, migrationobj, openstackcreds, vmwcreds, vm, vmMachineObj, arraycreds, proxyVM, resolvedFlavors)
 		if err != nil {
+			// Defence in depth. The shouldSkipVMForFlavor check above means every VM
+			// reaching here has a flavor, so determineAndSetTargetFlavor takes a fast
+			// path and cannot raise this. The branch exists so that removing that
+			// check later degrades to skipping one VM rather than silently restoring
+			// the old behaviour of aborting the loop and starving every VM behind it.
+			// Every other error still aborts and requeues.
+			if isNoSuitableFlavorErr(err) {
+				ctxlog.Error(err, "Skipping VM with no schedulable target flavor", "vm", vm)
+				// Discard the Migration created moments ago rather than parking it in
+				// ValidationFailed: processMigrationPhases turns the first
+				// Failed/ValidationFailed Migration into a plan-wide PodFailed, which
+				// would stop post-migration for the healthy VMs — exactly what the
+				// no-Migration-CR invariant for unschedulable VMs exists to prevent.
+				if n := len(migrationobjs.Items); n > 0 && migrationobjs.Items[n-1].Name == migrationobj.Name {
+					migrationobjs.Items = migrationobjs.Items[:n-1]
+				}
+				if delErr := r.Delete(ctx, migrationobj); delErr != nil && !apierrors.IsNotFound(delErr) {
+					ctxlog.Error(delErr, "Failed to clean up Migration for unschedulable VM", "vm", vm)
+				}
+				continue
+			}
 			return errors.Wrapf(err, "failed to create ConfigMap for VM %s", vm)
 		}
 		fbcm, err = r.CreateFirstbootConfigMap(ctx, migrationplan, migrationobj, vm)
@@ -2456,65 +2589,164 @@ func (r *MigrationPlanReconciler) validateVMOS(vmMachine *vjailbreakv1alpha1.VMw
 		vmMachine.Spec.VMInfo.Name, osFamily)
 }
 
+// migrationPlanValidation is the outcome of pre-flight validation for a plan.
+type migrationPlanValidation struct {
+	// ValidVMs passed every pre-flight check and should be triggered.
+	ValidVMs []*vjailbreakv1alpha1.VMwareMachine
+	// OSSkippedVMs were skipped because their guest OS is unknown or unsupported.
+	OSSkippedVMs []*vjailbreakv1alpha1.VMwareMachine
+	// FlavorSkippedVMs were skipped because no target flavor can satisfy their
+	// CPU/memory/GPU shape. These deliberately get NO Migration CR: a
+	// Failed/ValidationFailed Migration would flip the whole plan to PodFailed in
+	// processMigrationPhases and stop post-migration for the healthy VMs.
+	FlavorSkippedVMs []*vjailbreakv1alpha1.VMwareMachine
+	// ResolvedFlavors maps a VMwareMachine object name to the flavor ID chosen for
+	// it, so the config-map build path does not re-query Nova per VM.
+	ResolvedFlavors map[string]string
+}
+
+// vmDisplayNames returns the VM display names of a set of machines, for logging
+// and plan status messages.
+func vmDisplayNames(vmMachines []*vjailbreakv1alpha1.VMwareMachine) []string {
+	names := make([]string, len(vmMachines))
+	for i, vm := range vmMachines {
+		names[i] = vm.Spec.VMInfo.Name
+	}
+	return names
+}
+
 // validates all VMs in the migration plan
 func (r *MigrationPlanReconciler) validateMigrationPlanVMs(
 	ctx context.Context,
 	migrationplan *vjailbreakv1alpha1.MigrationPlan,
 	migrationtemplate *vjailbreakv1alpha1.MigrationTemplate,
 	vmwcreds *vjailbreakv1alpha1.VMwareCreds,
+	openstackcreds *vjailbreakv1alpha1.OpenstackCreds,
 	vmsToValidate []string,
-) ([]*vjailbreakv1alpha1.VMwareMachine, []*vjailbreakv1alpha1.VMwareMachine, error) {
+) (*migrationPlanValidation, error) {
+	result := &migrationPlanValidation{ResolvedFlavors: map[string]string{}}
+
 	if len(vmsToValidate) == 0 {
 		r.ctxlog.Info("No VMs left to validate; all in terminal states or plan complete")
-		return nil, nil, nil
+		return result, nil
 	}
 
-	validVMs := make([]*vjailbreakv1alpha1.VMwareMachine, 0, len(vmsToValidate))
-	skippedVMs := make([]*vjailbreakv1alpha1.VMwareMachine, 0, len(vmsToValidate))
+	result.ValidVMs = make([]*vjailbreakv1alpha1.VMwareMachine, 0, len(vmsToValidate))
+	result.OSSkippedVMs = make([]*vjailbreakv1alpha1.VMwareMachine, 0, len(vmsToValidate))
+	result.FlavorSkippedVMs = make([]*vjailbreakv1alpha1.VMwareMachine, 0, len(vmsToValidate))
+
+	// At most one Nova round-trip for the whole plan, fetched lazily on the first VM
+	// that actually needs resolution. Laziness matters: a plan whose VMs are all
+	// operator-pinned via Spec.TargetFlavorID never queried Nova before this change
+	// and must not start depending on it now. A failure here is genuinely fatal
+	// (bad creds, unreachable endpoint, no flavors at all) and must requeue rather
+	// than silently skip every VM.
+	var candidateFlavors []flavors.Flavor
+	flavorsFetched := false
+	candidates := func() ([]flavors.Flavor, error) {
+		if flavorsFetched {
+			return candidateFlavors, nil
+		}
+		fetched, err := r.candidateFlavorsForPlan(ctx, migrationtemplate, openstackcreds)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to list target flavors for pre-flight validation")
+		}
+		candidateFlavors = fetched
+		flavorsFetched = true
+		return candidateFlavors, nil
+	}
 
 	for _, vm := range vmsToValidate {
 		vmMachine, err := GetVMwareMachineForVM(ctx, r, vm, migrationtemplate, vmwcreds)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get VMwareMachine for VM %s: %w", vm, err)
+			return nil, fmt.Errorf("failed to get VMwareMachine for VM %s: %w", vm, err)
 		}
 
 		_, skipped, err := r.validateVMOS(vmMachine)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if skipped {
-			skippedVMs = append(skippedVMs, vmMachine)
+			result.OSSkippedVMs = append(result.OSSkippedVMs, vmMachine)
 			continue
 		}
 
-		validVMs = append(validVMs, vmMachine)
+		// An operator-pinned flavor needs no lookup at all.
+		if vmMachine.Spec.TargetFlavorID != "" {
+			result.ResolvedFlavors[vmMachine.Name] = vmMachine.Spec.TargetFlavorID
+			result.ValidVMs = append(result.ValidVMs, vmMachine)
+			continue
+		}
+
+		planFlavors, err := candidates()
+		if err != nil {
+			return nil, err
+		}
+
+		// Pre-flight flavor resolution. An unschedulable shape is this VM's problem
+		// alone, so it is skipped instead of aborting the plan; anything else
+		// (API/auth failure) still propagates.
+		flavorID, err := resolveTargetFlavorID(vmMachine, migrationtemplate, openstackcreds, planFlavors)
+		if err != nil {
+			if isNoSuitableFlavorErr(err) {
+				r.ctxlog.Info("VM has no schedulable target flavor and will be skipped",
+					"vm", vmMachine.Spec.VMInfo.Name,
+					"cpu", vmMachine.Spec.VMInfo.CPU,
+					"memoryMB", vmMachine.Spec.VMInfo.Memory,
+					"passthroughGPUs", vmMachine.Spec.VMInfo.GPU.PassthroughCount,
+					"vGPUs", vmMachine.Spec.VMInfo.GPU.VGPUCount,
+					"reason", err.Error())
+				result.FlavorSkippedVMs = append(result.FlavorSkippedVMs, vmMachine)
+				continue
+			}
+			return nil, errors.Wrapf(err, "failed to resolve target flavor for VM %s", vm)
+		}
+
+		result.ResolvedFlavors[vmMachine.Name] = flavorID
+		result.ValidVMs = append(result.ValidVMs, vmMachine)
 	}
 
-	if len(validVMs) == 0 {
-		if len(skippedVMs) > 0 {
-			skippedVMNames := make([]string, len(skippedVMs))
-			for i, vm := range skippedVMs {
-				skippedVMNames[i] = vm.Spec.VMInfo.Name
-			}
-			msg := fmt.Sprintf("Skipped VMs due to unsupported or unknown OS: %v", skippedVMNames)
+	osSkippedMsg := ""
+	if len(result.OSSkippedVMs) > 0 {
+		osSkippedMsg = fmt.Sprintf("Skipped VMs due to unsupported or unknown OS: %v", vmDisplayNames(result.OSSkippedVMs))
+	}
+	flavorSkippedMsg := ""
+	if len(result.FlavorSkippedVMs) > 0 {
+		flavorSkippedMsg = fmt.Sprintf("Skipped VMs with no schedulable target flavor: %v", vmDisplayNames(result.FlavorSkippedVMs))
+	}
+
+	skipMsgs := make([]string, 0, 2)
+	for _, msg := range []string{osSkippedMsg, flavorSkippedMsg} {
+		if msg != "" {
+			skipMsgs = append(skipMsgs, msg)
+		}
+	}
+
+	if len(result.ValidVMs) == 0 {
+		for _, msg := range skipMsgs {
 			r.ctxlog.Info(msg)
 		}
-		return nil, skippedVMs, fmt.Errorf("all VMs have unknown or unsupported OS types; no migrations to run")
+		// Name every reason that applies, so a plan that mixes unsupported guest
+		// OSes with unschedulable shapes does not report only one of them.
+		switch {
+		case len(result.OSSkippedVMs) > 0 && len(result.FlavorSkippedVMs) > 0:
+			return nil, fmt.Errorf("no migrations to run: every VM was skipped for an unsupported OS or for having no schedulable target flavor")
+		case len(result.FlavorSkippedVMs) > 0:
+			return nil, fmt.Errorf("no VM in the plan has a schedulable target flavor; no migrations to run")
+		default:
+			return nil, fmt.Errorf("all VMs have unknown or unsupported OS types; no migrations to run")
+		}
 	}
 
-	if len(skippedVMs) > 0 {
-		skippedVMNames := make([]string, len(skippedVMs))
-		for i, vm := range skippedVMs {
-			skippedVMNames[i] = vm.Spec.VMInfo.Name
-		}
-		msg := fmt.Sprintf("Skipped VMs due to unsupported or unknown OS: %v", skippedVMNames)
+	if len(skipMsgs) > 0 {
+		msg := strings.Join(skipMsgs, "; ")
 		r.ctxlog.Info(msg)
 		if updateErr := r.UpdateMigrationPlanStatus(ctx, migrationplan, corev1.PodPending, msg); updateErr != nil {
 			r.ctxlog.Error(updateErr, "Failed to update migration plan status for skipped VMs")
 		}
 	}
 
-	return validVMs, skippedVMs, nil
+	return result, nil
 }
 
 // updateMigrationPhaseWithRetry updates a Migration's phase and condition with retry logic

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -72,6 +72,10 @@ const VDDKDirectory = "/home/ubuntu/vmware-vix-disklib-distrib"
 // StorageCopyMethod is the storage copy method value for Storage Accelerated copy
 const StorageCopyMethod = "StorageAcceleratedCopy"
 
+// targetFlavorIDKey is the migration ConfigMap key holding the OpenStack flavor ID
+// the VM will be created with. Read back by v2v-helper as TARGET_FLAVOR_ID.
+const targetFlavorIDKey = "TARGET_FLAVOR_ID"
+
 // MigrationPlanReconciler reconciles a MigrationPlan object
 type MigrationPlanReconciler struct {
 	client.Client
@@ -861,7 +865,7 @@ func (r *MigrationPlanReconciler) processMigrationPhases(
 
 		case vjailbreakv1alpha1.VMMigrationPhaseSucceeded:
 			outcome.FinishedVMs++
-			if migration.Annotations != nil && migration.Annotations[constants.PostMigrationCompleteAnnotation] == "true" {
+			if migration.Annotations != nil && migration.Annotations[constants.PostMigrationCompleteAnnotation] == constants.AnnotationValueTrue {
 				r.ctxlog.Info("Post-migration already completed for VM, skipping", "vm", migration.Spec.VMName)
 				continue
 			}
@@ -884,7 +888,7 @@ func (r *MigrationPlanReconciler) processMigrationPhases(
 			if migrationCopy.Annotations == nil {
 				migrationCopy.Annotations = make(map[string]string)
 			}
-			migrationCopy.Annotations[constants.PostMigrationCompleteAnnotation] = "true"
+			migrationCopy.Annotations[constants.PostMigrationCompleteAnnotation] = constants.AnnotationValueTrue
 			if err := r.Update(ctx, migrationCopy); err != nil {
 				r.ctxlog.Error(err, "Failed to set post-migration complete annotation", "vm", migration.Spec.VMName)
 			}
@@ -1752,33 +1756,48 @@ func (r *MigrationPlanReconciler) determineAndSetTargetFlavor(ctx context.Contex
 	openstackcreds *vjailbreakv1alpha1.OpenstackCreds,
 	resolvedFlavors map[string]string,
 ) error {
+	flavorID, err := r.targetFlavorForVM(ctx, vmMachine, migrationtemplate, openstackcreds, resolvedFlavors)
+	if err != nil {
+		return err
+	}
+
+	configMapData[targetFlavorIDKey] = flavorID
+	return nil
+}
+
+// targetFlavorForVM returns the flavor ID to migrate a VM onto, preferring an
+// operator override, then the ID pre-flight validation already resolved, and only
+// then falling back to querying Nova.
+func (r *MigrationPlanReconciler) targetFlavorForVM(ctx context.Context,
+	vmMachine *vjailbreakv1alpha1.VMwareMachine,
+	migrationtemplate *vjailbreakv1alpha1.MigrationTemplate,
+	openstackcreds *vjailbreakv1alpha1.OpenstackCreds,
+	resolvedFlavors map[string]string,
+) (string, error) {
 	if vmMachine.Spec.TargetFlavorID != "" {
-		configMapData["TARGET_FLAVOR_ID"] = vmMachine.Spec.TargetFlavorID
-		return nil
+		return vmMachine.Spec.TargetFlavorID, nil
 	}
 
 	// Fast path: pre-flight validation already resolved this VM, so no Nova call.
 	if flavorID, ok := resolvedFlavors[vmMachine.Name]; ok && flavorID != "" {
-		configMapData["TARGET_FLAVOR_ID"] = flavorID
-		return nil
+		return flavorID, nil
 	}
 
 	// Slow path: no cached entry — e.g. a ConfigMap being rebuilt for a plan that
 	// was validated by an older controller version. Resolve on demand.
 	candidateFlavors, err := r.candidateFlavorsForPlan(ctx, migrationtemplate, openstackcreds)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	flavorID, err := resolveTargetFlavorID(vmMachine, migrationtemplate, openstackcreds, candidateFlavors)
 	if err != nil {
 		// errors.Wrapf preserves the chain, so isNoSuitableFlavorErr still matches
 		// at the trigger-loop call site.
-		return errors.Wrapf(err, "failed to determine target flavor for VM %s", vmMachine.Name)
+		return "", errors.Wrapf(err, "failed to determine target flavor for VM %s", vmMachine.Name)
 	}
 
-	configMapData["TARGET_FLAVOR_ID"] = flavorID
-	return nil
+	return flavorID, nil
 }
 
 func (r *MigrationPlanReconciler) setMigrationEnv(

--- a/k8s/migration/internal/controller/migrationplan_controller.go
+++ b/k8s/migration/internal/controller/migrationplan_controller.go
@@ -601,10 +601,13 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 		return ctrl.Result{}, errors.Wrapf(err, "failed to check openstackcreds status '%s'", migrationtemplate.Spec.Destination.OpenstackRef)
 	}
 
-	// Non-nil default so the no-VMs-to-validate path below can be read safely.
-	// On error validateMigrationPlanVMs returns a nil result, but every use of
-	// `validation` is downstream of the `validationErr != nil` early return.
-	validation := &migrationPlanValidation{ResolvedFlavors: map[string]string{}}
+	// Non-nil maps so the no-VMs-to-validate path below can be read and written
+	// safely. On error validateMigrationPlanVMs returns a nil result, but every use
+	// of `validation` is downstream of the `validationErr != nil` early return.
+	validation := &migrationPlanValidation{
+		ResolvedFlavors: map[string]string{},
+		SkipReasons:     map[string]string{},
+	}
 	var validationErr error
 	if len(vmsToValidate) > 0 {
 		// Validate VM OS types and resolve target flavors before proceeding
@@ -641,22 +644,13 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 		return ctrl.Result{}, validationErr
 	}
 
-	// VMs skipped for having no schedulable flavor deliberately get no Migration CR:
-	// a ValidationFailed Migration would flip the plan to PodFailed in
-	// processMigrationPhases and stop post-migration for the healthy VMs.
-	flavorSkipped := make(map[string]bool, len(validation.FlavorSkippedVMs))
-	for _, v := range validation.FlavorSkippedVMs {
-		flavorSkipped[commonutils.GetVMUniqueKey(v.Spec.VMInfo.Name, v.Spec.VMInfo.VMID)] = true
-	}
-
+	// Every non-terminal VM in the plan gets a Migration CR, including ones that
+	// failed pre-flight validation. The UI's migrations table is built purely from
+	// Migration objects, so a VM without one is invisible there — no row, no
+	// placeholder, and no hint as to why it never migrated.
 	for _, vmName := range allVMNames {
 		// Skip VMs with terminal migrations
 		if terminalMigrations[vmName] {
-			continue
-		}
-
-		if flavorSkipped[vmName] {
-			r.ctxlog.Info("Skipping Migration CR creation for VM with no schedulable target flavor", "vm", vmName)
 			continue
 		}
 
@@ -681,7 +675,14 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 		}
 
 		if !isValid {
-			r.markMigrationValidationFailed(ctx, migrationObj, vmName, "VM failed migration plan validation")
+			// Prefer the specific pre-flight reason so the UI shows something
+			// actionable ("no target flavor can satisfy this VM…") rather than a
+			// generic validation failure.
+			reason := validation.SkipReasons[vmName]
+			if reason == "" {
+				reason = "VM failed migration plan validation"
+			}
+			r.markMigrationValidationFailed(ctx, migrationObj, vmName, reason)
 		}
 	}
 
@@ -776,13 +777,28 @@ func (r *MigrationPlanReconciler) ReconcileMigrationPlanJob(ctx context.Context,
 			return ctrl.Result{}, errors.Wrap(err, "failed to list migrations for post-migration processing")
 		}
 
-		allFinished, err := r.processMigrationPhases(ctx, scope, migrationplan, allMigrations, parallelvms)
+		outcome, err := r.processMigrationPhases(ctx, scope, migrationplan, allMigrations, parallelvms)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 
-		if !allFinished {
+		if !outcome.AllFinished {
 			// Don't requeue - rely on event-driven reconciliation when Migrations reach terminal states
+			return ctrl.Result{}, nil
+		}
+
+		// Every migration is terminal and at least one failed. Post-migration has
+		// already run for the successful ones, so the plan can now be marked failed
+		// without starving anything — a single bad VM no longer aborts the plan while
+		// its siblings are still copying.
+		if len(outcome.FailedVMs) > 0 {
+			total := outcome.FinishedVMs + len(outcome.FailedVMs)
+			msg := fmt.Sprintf("%d of %d VMs migrated successfully; %d failed: %s",
+				outcome.FinishedVMs, total, len(outcome.FailedVMs), strings.Join(outcome.FailureSummaries, "; "))
+			r.ctxlog.Info("MigrationPlan finished with failures", "migrationplan", migrationplan.Name, "failedVMs", outcome.FailedVMs)
+			if err := r.UpdateMigrationPlanStatus(ctx, migrationplan, corev1.PodFailed, msg); err != nil {
+				return ctrl.Result{}, errors.Wrap(err, "failed to update migration plan status after partial failure")
+			}
 			return ctrl.Result{}, nil
 		}
 	}
@@ -818,8 +834,8 @@ func (r *MigrationPlanReconciler) processMigrationPhases(
 	migrationplan *vjailbreakv1alpha1.MigrationPlan,
 	migrationobjs *vjailbreakv1alpha1.MigrationList,
 	parallelvms []string,
-) (bool, error) {
-	allFinished := true
+) (*migrationPhaseOutcome, error) {
+	outcome := &migrationPhaseOutcome{AllFinished: true}
 
 	r.ctxlog.Info("Processing migration phases", "migrationplan", migrationplan.Name, "totalMigrations", len(migrationobjs.Items), "currentBatch", parallelvms)
 
@@ -828,16 +844,23 @@ func (r *MigrationPlanReconciler) processMigrationPhases(
 
 		switch migration.Status.Phase {
 		case vjailbreakv1alpha1.VMMigrationPhaseFailed, vjailbreakv1alpha1.VMMigrationPhaseValidationFailed:
-			r.ctxlog.Info("Migration failed for VM", "vm", migration.Spec.VMName)
-			err := r.UpdateMigrationPlanStatus(ctx, migrationplan, corev1.PodFailed,
-				fmt.Sprintf("Migration for VM '%s' failed: %s", migration.Spec.VMName, migration.Status.Conditions[0].Message))
-			return false, err
+			// Record and keep going. Returning here would abandon post-migration for
+			// every healthy VM in the plan and, because ReconcileMigrationPlanJob
+			// skips reconciliation for a PodFailed plan, park the plan permanently on
+			// the strength of one bad VM.
+			r.ctxlog.Info("Migration failed for VM", "vm", migration.Spec.VMName, "phase", migration.Status.Phase)
+			outcome.FailedVMs = append(outcome.FailedVMs, migration.Spec.VMName)
+			outcome.FailureSummaries = append(outcome.FailureSummaries,
+				fmt.Sprintf("%s (%s)", migration.Spec.VMName, firstConditionMessage(&migration)))
+			continue
 
 		case vjailbreakv1alpha1.VMMigrationPhaseDataCopied:
 			r.ctxlog.Info("Data-only migration completed for VM, skipping post-migration actions", "vm", migration.Spec.VMName, "migrationplan", migrationplan.Name)
+			outcome.FinishedVMs++
 			continue
 
 		case vjailbreakv1alpha1.VMMigrationPhaseSucceeded:
+			outcome.FinishedVMs++
 			if migration.Annotations != nil && migration.Annotations[constants.PostMigrationCompleteAnnotation] == "true" {
 				r.ctxlog.Info("Post-migration already completed for VM, skipping", "vm", migration.Spec.VMName)
 				continue
@@ -854,7 +877,7 @@ func (r *MigrationPlanReconciler) processMigrationPhases(
 			err := r.reconcilePostMigration(ctx, scope, vmKey)
 			if err != nil {
 				r.ctxlog.Error(err, "Post-migration actions failed for VM", "vm", migration.Spec.VMName)
-				return false, errors.Wrap(err, "failed post-migration")
+				return nil, errors.Wrap(err, "failed post-migration")
 			}
 
 			migrationCopy := migration.DeepCopy()
@@ -874,10 +897,43 @@ func (r *MigrationPlanReconciler) processMigrationPhases(
 				"vm", migration.Spec.VMName,
 				"phase", migration.Status.Phase,
 				"currentBatch", parallelvms)
-			allFinished = false
+			outcome.AllFinished = false
 		}
 	}
-	return allFinished, nil
+	return outcome, nil
+}
+
+// migrationPhaseOutcome summarises one pass over a plan's Migration objects.
+type migrationPhaseOutcome struct {
+	// AllFinished is true when no migration is still in a non-terminal phase.
+	AllFinished bool
+	// FinishedVMs counts migrations that reached Succeeded or DataCopied.
+	FinishedVMs int
+	// FailedVMs names the migrations in Failed or ValidationFailed.
+	FailedVMs []string
+	// FailureSummaries pairs each failed VM with its reason, for the plan status
+	// message.
+	FailureSummaries []string
+}
+
+// firstConditionMessage returns a human-readable reason for a migration's current
+// state, preferring the most recently transitioned condition. Guards against an
+// empty Conditions slice, which would otherwise panic on Conditions[0].
+func firstConditionMessage(migration *vjailbreakv1alpha1.Migration) string {
+	if len(migration.Status.Conditions) == 0 {
+		return string(migration.Status.Phase)
+	}
+
+	newest := migration.Status.Conditions[0]
+	for _, condition := range migration.Status.Conditions[1:] {
+		if condition.LastTransitionTime.After(newest.LastTransitionTime.Time) {
+			newest = condition
+		}
+	}
+	if newest.Message == "" {
+		return string(migration.Status.Phase)
+	}
+	return newest.Message
 }
 
 // handleRDMDiskMigrationError handles errors that occur during RDM disk migration
@@ -2194,17 +2250,22 @@ func (r *MigrationPlanReconciler) TriggerMigration(ctx context.Context,
 			vm = vmMachineObj.Spec.VMInfo.Name
 		}
 
-		// Belt-and-braces: pre-flight validation resolved a flavor for every VM it
-		// put in parallelvms, so a missing entry means the VM is unschedulable. Skip
-		// it before creating a Migration CR so one bad VM cannot block the rest.
-		if shouldSkipVMForFlavor(vmMachineObj, resolvedFlavors) {
-			ctxlog.Info("Skipping VM with no schedulable target flavor", "vm", vm)
-			continue
-		}
-
 		migrationobj, err := r.CreateMigration(ctx, migrationplan, vm, vmMachineObj)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create Migration for VM %s", vm)
+		}
+
+		// Belt-and-braces: pre-flight validation resolved a flavor for every VM it
+		// put in parallelvms, so a missing entry means the VM is unschedulable. Mark
+		// it terminal instead of aborting the loop, and never leave it Pending —
+		// a Pending Migration nobody will ever advance stops the plan from ever
+		// reporting as finished.
+		if shouldSkipVMForFlavor(vmMachineObj, resolvedFlavors) {
+			ctxlog.Info("Marking VM as ValidationFailed: no schedulable target flavor", "vm", vm)
+			r.markMigrationValidationFailed(ctx, migrationobj, vm,
+				flavorSkipReason(vmMachineObj, migrationtemplate, openstackcreds))
+			migrationobjs.Items = append(migrationobjs.Items, *migrationobj)
+			continue
 		}
 
 		if migrationobj.Status.Phase == vjailbreakv1alpha1.VMMigrationPhaseSucceeded ||
@@ -2227,18 +2288,9 @@ func (r *MigrationPlanReconciler) TriggerMigration(ctx context.Context,
 			// the old behaviour of aborting the loop and starving every VM behind it.
 			// Every other error still aborts and requeues.
 			if isNoSuitableFlavorErr(err) {
-				ctxlog.Error(err, "Skipping VM with no schedulable target flavor", "vm", vm)
-				// Discard the Migration created moments ago rather than parking it in
-				// ValidationFailed: processMigrationPhases turns the first
-				// Failed/ValidationFailed Migration into a plan-wide PodFailed, which
-				// would stop post-migration for the healthy VMs — exactly what the
-				// no-Migration-CR invariant for unschedulable VMs exists to prevent.
-				if n := len(migrationobjs.Items); n > 0 && migrationobjs.Items[n-1].Name == migrationobj.Name {
-					migrationobjs.Items = migrationobjs.Items[:n-1]
-				}
-				if delErr := r.Delete(ctx, migrationobj); delErr != nil && !apierrors.IsNotFound(delErr) {
-					ctxlog.Error(delErr, "Failed to clean up Migration for unschedulable VM", "vm", vm)
-				}
+				ctxlog.Error(err, "Marking VM as ValidationFailed: no schedulable target flavor", "vm", vm)
+				r.markMigrationValidationFailed(ctx, migrationobj, vm,
+					flavorSkipReason(vmMachineObj, migrationtemplate, openstackcreds))
 				continue
 			}
 			return errors.Wrapf(err, "failed to create ConfigMap for VM %s", vm)
@@ -2596,13 +2648,44 @@ type migrationPlanValidation struct {
 	// OSSkippedVMs were skipped because their guest OS is unknown or unsupported.
 	OSSkippedVMs []*vjailbreakv1alpha1.VMwareMachine
 	// FlavorSkippedVMs were skipped because no target flavor can satisfy their
-	// CPU/memory/GPU shape. These deliberately get NO Migration CR: a
-	// Failed/ValidationFailed Migration would flip the whole plan to PodFailed in
-	// processMigrationPhases and stop post-migration for the healthy VMs.
+	// CPU/memory/GPU shape. They still get a Migration CR in ValidationFailed so
+	// they remain visible in the UI, whose migrations table is populated purely
+	// from Migration objects — a VM with no CR shows no row at all.
 	FlavorSkippedVMs []*vjailbreakv1alpha1.VMwareMachine
 	// ResolvedFlavors maps a VMwareMachine object name to the flavor ID chosen for
 	// it, so the config-map build path does not re-query Nova per VM.
 	ResolvedFlavors map[string]string
+	// SkipReasons maps a plan VM key to the operator-facing reason it was skipped.
+	// Surfaced as the Migration's condition message, which the UI renders in the
+	// progress tooltip, the events tab and the error card.
+	SkipReasons map[string]string
+}
+
+// flavorSkipReason builds the operator-facing explanation shown against a VM that
+// no target flavor can accommodate. It names the shape that could not be placed
+// and the action that fixes it, and calls out the availability-zone restriction
+// when one is in force — a mistyped or under-provisioned target PCD cluster is a
+// common cause of an otherwise puzzling "no flavor" result.
+func flavorSkipReason(
+	vmMachine *vjailbreakv1alpha1.VMwareMachine,
+	migrationtemplate *vjailbreakv1alpha1.MigrationTemplate,
+	openstackcreds *vjailbreakv1alpha1.OpenstackCreds,
+) string {
+	shape := fmt.Sprintf("%d vCPUs, %d MB RAM", vmMachine.Spec.VMInfo.CPU, vmMachine.Spec.VMInfo.Memory)
+	if vmMachine.Spec.VMInfo.GPU.HasGPU() {
+		shape += fmt.Sprintf(", %d passthrough GPU(s), %d vGPU(s)",
+			vmMachine.Spec.VMInfo.GPU.PassthroughCount, vmMachine.Spec.VMInfo.GPU.VGPUCount)
+	}
+
+	reason := fmt.Sprintf("No target flavor can satisfy this VM (%s). "+
+		"Create a suitable flavor, or set spec.targetFlavorId on the VMwareMachine to pin one, then retry.", shape)
+
+	if utils.IsOpenstackPCD(*openstackcreds) && migrationtemplate.Spec.TargetPCDClusterName != "" {
+		reason += fmt.Sprintf(" Only flavors available in PCD cluster %q were considered.",
+			migrationtemplate.Spec.TargetPCDClusterName)
+	}
+
+	return reason
 }
 
 // vmDisplayNames returns the VM display names of a set of machines, for logging
@@ -2624,7 +2707,10 @@ func (r *MigrationPlanReconciler) validateMigrationPlanVMs(
 	openstackcreds *vjailbreakv1alpha1.OpenstackCreds,
 	vmsToValidate []string,
 ) (*migrationPlanValidation, error) {
-	result := &migrationPlanValidation{ResolvedFlavors: map[string]string{}}
+	result := &migrationPlanValidation{
+		ResolvedFlavors: map[string]string{},
+		SkipReasons:     map[string]string{},
+	}
 
 	if len(vmsToValidate) == 0 {
 		r.ctxlog.Info("No VMs left to validate; all in terminal states or plan complete")
@@ -2668,6 +2754,9 @@ func (r *MigrationPlanReconciler) validateMigrationPlanVMs(
 		}
 		if skipped {
 			result.OSSkippedVMs = append(result.OSSkippedVMs, vmMachine)
+			result.SkipReasons[vm] = fmt.Sprintf(
+				"Guest OS is unknown or unsupported (OSFamily: %q). Set OSFamily explicitly on the VMwareMachine CR, then retry.",
+				vmMachine.Spec.VMInfo.OSFamily)
 			continue
 		}
 
@@ -2697,6 +2786,7 @@ func (r *MigrationPlanReconciler) validateMigrationPlanVMs(
 					"vGPUs", vmMachine.Spec.VMInfo.GPU.VGPUCount,
 					"reason", err.Error())
 				result.FlavorSkippedVMs = append(result.FlavorSkippedVMs, vmMachine)
+				result.SkipReasons[vm] = flavorSkipReason(vmMachine, migrationtemplate, openstackcreds)
 				continue
 			}
 			return nil, errors.Wrapf(err, "failed to resolve target flavor for VM %s", vm)
@@ -2738,12 +2828,12 @@ func (r *MigrationPlanReconciler) validateMigrationPlanVMs(
 		}
 	}
 
+	// Deliberately not written to the plan status. Each skipped VM now carries its
+	// own ValidationFailed Migration with a specific reason, which is what the UI
+	// actually renders; and setting the plan to PodPending here would suppress the
+	// PodRunning transition below, which only fires on an empty status.
 	if len(skipMsgs) > 0 {
-		msg := strings.Join(skipMsgs, "; ")
-		r.ctxlog.Info(msg)
-		if updateErr := r.UpdateMigrationPlanStatus(ctx, migrationplan, corev1.PodPending, msg); updateErr != nil {
-			r.ctxlog.Error(updateErr, "Failed to update migration plan status for skipped VMs")
-		}
+		r.ctxlog.Info(strings.Join(skipMsgs, "; "), "migrationplan", migrationplan.Name)
 	}
 
 	return result, nil
@@ -2796,6 +2886,12 @@ func (r *MigrationPlanReconciler) updateMigrationPhaseWithRetry(
 		r.ctxlog.Error(retryErr, "Failed to update migration phase after retries", "phase", phase, "identifier", identifier)
 		return retryErr
 	}
+
+	// Reflect the new phase back onto the caller's copy. Callers that collect these
+	// objects into a MigrationList would otherwise hold a stale phase and could
+	// mistake a terminal migration for one still in progress.
+	migrationObj.Status.Phase = phase
+	migrationObj.Status.Conditions = append(migrationObj.Status.Conditions, condition)
 
 	return nil
 }

--- a/k8s/migration/internal/controller/migrationplan_controller_test.go
+++ b/k8s/migration/internal/controller/migrationplan_controller_test.go
@@ -21,7 +21,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
@@ -32,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -376,35 +379,53 @@ func TestProcessMigrationPhases_DataCopied(t *testing.T) {
 	const ns = "migration-system"
 	const planName = "test-plan-phases"
 
+	// A failed migration is TERMINAL, so AllFinished stays true and the failure is
+	// reported via FailedVMs. processMigrationPhases no longer updates plan status
+	// itself — the caller decides, once nothing is still running.
 	tests := []struct {
-		name         string
-		phase        vjailbreakv1alpha1.VMMigrationPhase
-		wantFinished bool
-		wantPlanFail bool
+		name          string
+		phase         vjailbreakv1alpha1.VMMigrationPhase
+		withCondition bool
+		wantFinished  bool
+		wantFinishedN int
+		wantFailedN   int
 	}{
 		{
-			name:         "DataCopied phase counts as finished",
-			phase:        vjailbreakv1alpha1.VMMigrationPhaseDataCopied,
-			wantFinished: true,
-			wantPlanFail: false,
+			name:          "DataCopied phase counts as finished",
+			phase:         vjailbreakv1alpha1.VMMigrationPhaseDataCopied,
+			wantFinished:  true,
+			wantFinishedN: 1,
 		},
 		{
-			name:         "Succeeded phase counts as finished",
-			phase:        vjailbreakv1alpha1.VMMigrationPhaseSucceeded,
-			wantFinished: true,
-			wantPlanFail: false,
+			name:          "Succeeded phase counts as finished",
+			phase:         vjailbreakv1alpha1.VMMigrationPhaseSucceeded,
+			wantFinished:  true,
+			wantFinishedN: 1,
 		},
 		{
-			name:         "Failed phase causes plan failure",
+			name:          "Failed phase is terminal and recorded, not fatal",
+			phase:         vjailbreakv1alpha1.VMMigrationPhaseFailed,
+			withCondition: true,
+			wantFinished:  true,
+			wantFailedN:   1,
+		},
+		{
+			name:          "ValidationFailed phase is terminal and recorded, not fatal",
+			phase:         vjailbreakv1alpha1.VMMigrationPhaseValidationFailed,
+			withCondition: true,
+			wantFinished:  true,
+			wantFailedN:   1,
+		},
+		{
+			name:         "Failed with no conditions does not panic",
 			phase:        vjailbreakv1alpha1.VMMigrationPhaseFailed,
-			wantFinished: false,
-			wantPlanFail: true,
+			wantFinished: true,
+			wantFailedN:  1,
 		},
 		{
 			name:         "In-progress phase is not finished",
 			phase:        vjailbreakv1alpha1.VMMigrationPhaseCopying,
 			wantFinished: false,
-			wantPlanFail: false,
 		},
 	}
 
@@ -422,8 +443,7 @@ func TestProcessMigrationPhases_DataCopied(t *testing.T) {
 				Spec: vjailbreakv1alpha1.MigrationSpec{VMName: "vm-a"},
 			}
 			migration.Status.Phase = tt.phase
-			// Add a dummy condition for the failed phase check (controller reads Conditions[0].Message)
-			if tt.phase == vjailbreakv1alpha1.VMMigrationPhaseFailed || tt.phase == vjailbreakv1alpha1.VMMigrationPhaseValidationFailed {
+			if tt.withCondition {
 				migration.Status.Conditions = []corev1.PodCondition{{Message: "test failure"}}
 			}
 
@@ -452,28 +472,145 @@ func TestProcessMigrationPhases_DataCopied(t *testing.T) {
 				Items: []vjailbreakv1alpha1.Migration{*migration},
 			}
 
-			gotFinished, err := r.processMigrationPhases(
+			outcome, err := r.processMigrationPhases(
 				context.Background(),
 				migrationScope,
 				plan,
 				migrationList,
 				[]string{"vm-a"},
 			)
+			if err != nil {
+				t.Fatalf("processMigrationPhases() unexpected error = %v", err)
+			}
 
-			if tt.wantPlanFail {
-				// Failed migrations return an error (or false with a plan update)
-				if err == nil && gotFinished {
-					t.Errorf("expected plan to fail for phase %v, but allFinished=%v err=%v", tt.phase, gotFinished, err)
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("processMigrationPhases() unexpected error = %v", err)
-				}
-				if gotFinished != tt.wantFinished {
-					t.Errorf("allFinished = %v, want %v for phase %v", gotFinished, tt.wantFinished, tt.phase)
-				}
+			if outcome.AllFinished != tt.wantFinished {
+				t.Errorf("AllFinished = %v, want %v for phase %v", outcome.AllFinished, tt.wantFinished, tt.phase)
+			}
+			if outcome.FinishedVMs != tt.wantFinishedN {
+				t.Errorf("FinishedVMs = %d, want %d for phase %v", outcome.FinishedVMs, tt.wantFinishedN, tt.phase)
+			}
+			if len(outcome.FailedVMs) != tt.wantFailedN {
+				t.Errorf("FailedVMs = %v, want %d entries for phase %v", outcome.FailedVMs, tt.wantFailedN, tt.phase)
+			}
+			if len(outcome.FailedVMs) != len(outcome.FailureSummaries) {
+				t.Errorf("FailedVMs (%d) and FailureSummaries (%d) must stay in step",
+					len(outcome.FailedVMs), len(outcome.FailureSummaries))
+			}
+
+			// The plan must NOT be failed by this function — one bad VM used to abort
+			// the whole plan here, starving post-migration for its siblings.
+			updatedPlan := &vjailbreakv1alpha1.MigrationPlan{}
+			if getErr := fakeClient.Get(context.Background(),
+				types.NamespacedName{Name: planName, Namespace: ns}, updatedPlan); getErr != nil {
+				t.Fatalf("failed to re-read plan: %v", getErr)
+			}
+			if updatedPlan.Status.MigrationStatus == corev1.PodFailed {
+				t.Errorf("processMigrationPhases must not set the plan to PodFailed; got %v",
+					updatedPlan.Status.MigrationStatus)
 			}
 		})
+	}
+}
+
+// TestProcessMigrationPhases_PartialFailureDoesNotStarveSiblings is the
+// regression test for the reported symptom: with 20 VMs where one cannot be
+// placed on any flavor, the other 19 must still be processed. Previously the loop
+// returned on the first ValidationFailed, so post-migration never ran for the
+// healthy VMs and the plan was parked as PodFailed while they were still copying.
+func TestProcessMigrationPhases_PartialFailureDoesNotStarveSiblings(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = vjailbreakv1alpha1.AddToScheme(scheme)
+
+	const ns = "migration-system"
+	const planName = "test-plan-partial"
+	const totalVMs = 20
+	const badVMIndex = 6 // VM #7
+
+	plan := &vjailbreakv1alpha1.MigrationPlan{
+		ObjectMeta: metav1.ObjectMeta{Name: planName, Namespace: ns},
+	}
+
+	migrations := make([]vjailbreakv1alpha1.Migration, 0, totalVMs)
+	vmNames := make([]string, 0, totalVMs)
+	for i := 0; i < totalVMs; i++ {
+		vmName := fmt.Sprintf("vm-%02d", i)
+		vmNames = append(vmNames, vmName)
+
+		migration := vjailbreakv1alpha1.Migration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "migration-" + vmName,
+				Namespace:   ns,
+				Labels:      map[string]string{"migrationplan": planName},
+				Annotations: map[string]string{"vjailbreak.k8s.pf9.io/original-vm-name": vmName},
+			},
+			Spec: vjailbreakv1alpha1.MigrationSpec{VMName: vmName},
+		}
+
+		if i == badVMIndex {
+			migration.Status.Phase = vjailbreakv1alpha1.VMMigrationPhaseValidationFailed
+			migration.Status.Conditions = []corev1.PodCondition{
+				{Message: "No target flavor can satisfy this VM (256 vCPUs, 1048576 MB RAM)."},
+			}
+		} else {
+			migration.Status.Phase = vjailbreakv1alpha1.VMMigrationPhaseSucceeded
+		}
+		migrations = append(migrations, migration)
+	}
+
+	objs := []client.Object{plan}
+	for i := range migrations {
+		objs = append(objs, &migrations[i])
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&vjailbreakv1alpha1.MigrationPlan{}, &vjailbreakv1alpha1.Migration{}).
+		Build()
+
+	r := &MigrationPlanReconciler{Client: fakeClient, Scheme: scheme, ctxlog: logr.Discard()}
+	migrationScope, _ := scope.NewMigrationPlanScope(scope.MigrationPlanScopeParams{
+		Client:        fakeClient,
+		MigrationPlan: plan,
+	})
+
+	outcome, err := r.processMigrationPhases(context.Background(), migrationScope, plan,
+		&vjailbreakv1alpha1.MigrationList{Items: migrations}, vmNames)
+	if err != nil {
+		t.Fatalf("one unschedulable VM must not abort phase processing, got: %v", err)
+	}
+
+	if !outcome.AllFinished {
+		t.Error("AllFinished = false, want true — every migration is in a terminal phase")
+	}
+	if outcome.FinishedVMs != totalVMs-1 {
+		t.Errorf("FinishedVMs = %d, want %d — the healthy VMs must all be processed",
+			outcome.FinishedVMs, totalVMs-1)
+	}
+	if len(outcome.FailedVMs) != 1 {
+		t.Fatalf("FailedVMs = %v, want exactly 1", outcome.FailedVMs)
+	}
+	if outcome.FailedVMs[0] != fmt.Sprintf("vm-%02d", badVMIndex) {
+		t.Errorf("FailedVMs[0] = %q, want %q", outcome.FailedVMs[0], fmt.Sprintf("vm-%02d", badVMIndex))
+	}
+	if !strings.Contains(outcome.FailureSummaries[0], "No target flavor") {
+		t.Errorf("failure summary must carry the reason, got %q", outcome.FailureSummaries[0])
+	}
+
+	// Post-migration ran for every succeeded VM, evidenced by the annotation.
+	for i := 0; i < totalVMs; i++ {
+		if i == badVMIndex {
+			continue
+		}
+		vmName := fmt.Sprintf("vm-%02d", i)
+		updated := &vjailbreakv1alpha1.Migration{}
+		if getErr := fakeClient.Get(context.Background(),
+			types.NamespacedName{Name: "migration-" + vmName, Namespace: ns}, updated); getErr != nil {
+			t.Fatalf("failed to re-read migration for %s: %v", vmName, getErr)
+		}
+		if updated.Annotations[constants.PostMigrationCompleteAnnotation] != "true" {
+			t.Errorf("post-migration did not run for %s — a single failed sibling starved it", vmName)
+		}
 	}
 }
 
@@ -838,6 +975,141 @@ func TestShouldSkipVMForFlavor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := shouldSkipVMForFlavor(tt.vmMachine, tt.resolvedFlavors); got != tt.wantSkip {
 				t.Errorf("shouldSkipVMForFlavor() = %v, want %v", got, tt.wantSkip)
+			}
+		})
+	}
+}
+
+// TestFlavorSkipReason_IsActionable checks the message shown against an
+// unschedulable VM. It is the only explanation the operator gets in the UI (it
+// lands in the Migration's condition message, which the migrations table renders
+// in the progress tooltip and the detail page shows in the error card), so it must
+// name the shape that could not be placed and the action that fixes it.
+func TestFlavorSkipReason_IsActionable(t *testing.T) {
+	pcdCreds := &vjailbreakv1alpha1.OpenstackCreds{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{constants.IsPCDCredsLabel: "true"},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		vmMachine    *vjailbreakv1alpha1.VMwareMachine
+		template     *vjailbreakv1alpha1.MigrationTemplate
+		creds        *vjailbreakv1alpha1.OpenstackCreds
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name:      "plain shape names cpu and memory",
+			vmMachine: flavorTestMachine("vm-a", 8, 32768),
+			template:  &vjailbreakv1alpha1.MigrationTemplate{},
+			creds:     &vjailbreakv1alpha1.OpenstackCreds{},
+			wantContains: []string{
+				"8 vCPUs",
+				"32768 MB RAM",
+				"targetFlavorId",
+			},
+			wantAbsent: []string{"GPU", "PCD cluster"},
+		},
+		{
+			name: "GPU shape is spelled out",
+			vmMachine: func() *vjailbreakv1alpha1.VMwareMachine {
+				m := flavorTestMachine("vm-b", 16, 65536)
+				m.Spec.VMInfo.GPU.PassthroughCount = 2
+				m.Spec.VMInfo.GPU.VGPUCount = 1
+				return m
+			}(),
+			template:     &vjailbreakv1alpha1.MigrationTemplate{},
+			creds:        &vjailbreakv1alpha1.OpenstackCreds{},
+			wantContains: []string{"2 passthrough GPU(s)", "1 vGPU(s)"},
+		},
+		{
+			name:      "PCD availability-zone restriction is called out",
+			vmMachine: flavorTestMachine("vm-c", 4, 8192),
+			template: &vjailbreakv1alpha1.MigrationTemplate{
+				Spec: vjailbreakv1alpha1.MigrationTemplateSpec{TargetPCDClusterName: "cluster-b"},
+			},
+			creds:        pcdCreds,
+			wantContains: []string{"cluster-b", "Only flavors available in PCD cluster"},
+		},
+		{
+			name:      "non-PCD creds do not mention a cluster",
+			vmMachine: flavorTestMachine("vm-d", 4, 8192),
+			template: &vjailbreakv1alpha1.MigrationTemplate{
+				Spec: vjailbreakv1alpha1.MigrationTemplateSpec{TargetPCDClusterName: "cluster-b"},
+			},
+			creds:      &vjailbreakv1alpha1.OpenstackCreds{},
+			wantAbsent: []string{"PCD cluster"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := flavorSkipReason(tt.vmMachine, tt.template, tt.creds)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("reason %q does not contain %q", got, want)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("reason %q should not contain %q", got, absent)
+				}
+			}
+		})
+	}
+}
+
+// TestFirstConditionMessage guards against the Conditions[0] panic the old
+// processMigrationPhases had, and confirms the newest condition wins.
+func TestFirstConditionMessage(t *testing.T) {
+	older := metav1.NewTime(time.Now().Add(-time.Hour))
+	newer := metav1.NewTime(time.Now())
+
+	tests := []struct {
+		name      string
+		migration *vjailbreakv1alpha1.Migration
+		want      string
+	}{
+		{
+			name: "no conditions falls back to phase instead of panicking",
+			migration: &vjailbreakv1alpha1.Migration{
+				Status: vjailbreakv1alpha1.MigrationStatus{
+					Phase: vjailbreakv1alpha1.VMMigrationPhaseValidationFailed,
+				},
+			},
+			want: "ValidationFailed",
+		},
+		{
+			name: "newest condition message wins",
+			migration: &vjailbreakv1alpha1.Migration{
+				Status: vjailbreakv1alpha1.MigrationStatus{
+					Phase: vjailbreakv1alpha1.VMMigrationPhaseFailed,
+					Conditions: []corev1.PodCondition{
+						{Message: "stale reason", LastTransitionTime: older},
+						{Message: "real reason", LastTransitionTime: newer},
+					},
+				},
+			},
+			want: "real reason",
+		},
+		{
+			name: "empty message falls back to phase",
+			migration: &vjailbreakv1alpha1.Migration{
+				Status: vjailbreakv1alpha1.MigrationStatus{
+					Phase:      vjailbreakv1alpha1.VMMigrationPhaseFailed,
+					Conditions: []corev1.PodCondition{{Message: "", LastTransitionTime: newer}},
+				},
+			},
+			want: "Failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := firstConditionMessage(tt.migration); got != tt.want {
+				t.Errorf("firstConditionMessage() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/k8s/migration/internal/controller/migrationplan_controller_test.go
+++ b/k8s/migration/internal/controller/migrationplan_controller_test.go
@@ -19,12 +19,15 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	pkgerrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,6 +39,9 @@ import (
 
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
 	"github.com/platform9/vjailbreak/k8s/migration/pkg/scope"
+	"github.com/platform9/vjailbreak/pkg/common/constants"
+	openstackpkg "github.com/platform9/vjailbreak/pkg/common/openstack"
+	commonutils "github.com/platform9/vjailbreak/pkg/common/utils"
 )
 
 var _ = ginkgo.Describe("MigrationPlan Controller", func() {
@@ -643,5 +649,373 @@ func TestIsVMSucceededInPlan(t *testing.T) {
 				t.Errorf("isVMSucceededInPlan(%q) = %v, want %v", tt.vmName, got, tt.want)
 			}
 		})
+	}
+}
+
+// --- Non-blocking flavor resolution -----------------------------------------
+//
+// These cover the guarantee that a single VM whose CPU/memory/GPU shape no target
+// flavor can satisfy does not stop the rest of a MigrationPlan from being
+// scheduled.
+
+func flavorTestMachine(name string, cpu, memoryMB int) *vjailbreakv1alpha1.VMwareMachine {
+	return &vjailbreakv1alpha1.VMwareMachine{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: vjailbreakv1alpha1.VMwareMachineSpec{
+			VMInfo: vjailbreakv1alpha1.VMInfo{
+				Name:   name,
+				CPU:    cpu,
+				Memory: memoryMB,
+			},
+		},
+	}
+}
+
+func TestResolveTargetFlavorID(t *testing.T) {
+	candidates := []flavors.Flavor{
+		{ID: "f-small", VCPUs: 2, RAM: 4096},
+		{ID: "f-medium", VCPUs: 4, RAM: 16384},
+		{ID: "f-large", VCPUs: 8, RAM: 32768},
+	}
+	template := &vjailbreakv1alpha1.MigrationTemplate{}
+	creds := &vjailbreakv1alpha1.OpenstackCreds{}
+
+	tests := []struct {
+		name         string
+		vmMachine    *vjailbreakv1alpha1.VMwareMachine
+		candidates   []flavors.Flavor
+		wantFlavorID string
+		wantSkip     bool
+	}{
+		{
+			name:         "smallest fitting flavor is chosen",
+			vmMachine:    flavorTestMachine("vm-a", 2, 4096),
+			candidates:   candidates,
+			wantFlavorID: "f-small",
+		},
+		{
+			name:         "rounds up to next flavor that fits",
+			vmMachine:    flavorTestMachine("vm-b", 3, 8192),
+			candidates:   candidates,
+			wantFlavorID: "f-medium",
+		},
+		{
+			name:       "shape larger than every flavor is a skip, not a failure",
+			vmMachine:  flavorTestMachine("vm-c", 128, 999999),
+			candidates: candidates,
+			wantSkip:   true,
+		},
+		{
+			name: "explicit TargetFlavorID overrides resolution entirely",
+			vmMachine: func() *vjailbreakv1alpha1.VMwareMachine {
+				m := flavorTestMachine("vm-d", 128, 999999) // would otherwise be unschedulable
+				m.Spec.TargetFlavorID = "operator-pinned"
+				return m
+			}(),
+			candidates:   candidates,
+			wantFlavorID: "operator-pinned",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flavorID, err := resolveTargetFlavorID(tt.vmMachine, template, creds, tt.candidates)
+
+			if tt.wantSkip {
+				if err == nil {
+					t.Fatalf("expected an error, got flavorID %q", flavorID)
+				}
+				if !isNoSuitableFlavorErr(err) {
+					t.Errorf("error should be classified as no-suitable-flavor, got %v", err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if flavorID != tt.wantFlavorID {
+				t.Errorf("flavorID = %q, want %q", flavorID, tt.wantFlavorID)
+			}
+		})
+	}
+}
+
+// TestResolveTargetFlavorID_OneBadVMDoesNotStopTheRest encodes the reported
+// scenario directly: in a 20-VM plan where VM #7 cannot be placed, the other 19
+// must still resolve.
+func TestResolveTargetFlavorID_OneBadVMDoesNotStopTheRest(t *testing.T) {
+	candidates := []flavors.Flavor{{ID: "f-medium", VCPUs: 4, RAM: 16384}}
+	template := &vjailbreakv1alpha1.MigrationTemplate{}
+	creds := &vjailbreakv1alpha1.OpenstackCreds{}
+
+	const totalVMs = 20
+	const badVMIndex = 6 // zero-based, i.e. VM #7
+
+	vmMachines := make([]*vjailbreakv1alpha1.VMwareMachine, 0, totalVMs)
+	for i := 0; i < totalVMs; i++ {
+		if i == badVMIndex {
+			vmMachines = append(vmMachines, flavorTestMachine("vm-oversized", 256, 1048576))
+			continue
+		}
+		vmMachines = append(vmMachines, flavorTestMachine(fmt.Sprintf("vm-%02d", i), 2, 8192))
+	}
+
+	resolved := map[string]string{}
+	skipped := []string{}
+
+	for _, vmMachine := range vmMachines {
+		flavorID, err := resolveTargetFlavorID(vmMachine, template, creds, candidates)
+		if err != nil {
+			if !isNoSuitableFlavorErr(err) {
+				t.Fatalf("unexpected fatal error for %s: %v", vmMachine.Name, err)
+			}
+			skipped = append(skipped, vmMachine.Name)
+			continue
+		}
+		resolved[vmMachine.Name] = flavorID
+	}
+
+	if len(resolved) != totalVMs-1 {
+		t.Errorf("resolved %d VMs, want %d — a single unschedulable VM must not stop the rest",
+			len(resolved), totalVMs-1)
+	}
+	if len(skipped) != 1 {
+		t.Fatalf("skipped %d VMs, want exactly 1: %v", len(skipped), skipped)
+	}
+	if skipped[0] != "vm-oversized" {
+		t.Errorf("skipped the wrong VM: %v", skipped)
+	}
+	if _, present := resolved["vm-oversized"]; present {
+		t.Error("unschedulable VM must not appear in the resolved flavor map")
+	}
+}
+
+func TestShouldSkipVMForFlavor(t *testing.T) {
+	tests := []struct {
+		name            string
+		vmMachine       *vjailbreakv1alpha1.VMwareMachine
+		resolvedFlavors map[string]string
+		wantSkip        bool
+	}{
+		{
+			name:            "pre-resolved flavor: proceed",
+			vmMachine:       flavorTestMachine("vm-a", 2, 4096),
+			resolvedFlavors: map[string]string{"vm-a": "f-small"},
+			wantSkip:        false,
+		},
+		{
+			name:            "absent from map: skip",
+			vmMachine:       flavorTestMachine("vm-b", 2, 4096),
+			resolvedFlavors: map[string]string{"vm-a": "f-small"},
+			wantSkip:        true,
+		},
+		{
+			name:            "present but empty: skip",
+			vmMachine:       flavorTestMachine("vm-c", 2, 4096),
+			resolvedFlavors: map[string]string{"vm-c": ""},
+			wantSkip:        true,
+		},
+		{
+			name:            "nil map: skip",
+			vmMachine:       flavorTestMachine("vm-d", 2, 4096),
+			resolvedFlavors: nil,
+			wantSkip:        true,
+		},
+		{
+			name: "explicit TargetFlavorID: proceed even with empty map",
+			vmMachine: func() *vjailbreakv1alpha1.VMwareMachine {
+				m := flavorTestMachine("vm-e", 2, 4096)
+				m.Spec.TargetFlavorID = "operator-pinned"
+				return m
+			}(),
+			resolvedFlavors: nil,
+			wantSkip:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldSkipVMForFlavor(tt.vmMachine, tt.resolvedFlavors); got != tt.wantSkip {
+				t.Errorf("shouldSkipVMForFlavor() = %v, want %v", got, tt.wantSkip)
+			}
+		})
+	}
+}
+
+// TestIsNoSuitableFlavorErr_ClassifiesOnlyFlavorErrors guards the blast radius of
+// the containment gate: only an unschedulable shape may be treated as a skip.
+// Everything else (auth, connectivity, an empty flavor list) must stay fatal so
+// it is retried instead of silently burned in as a permanent per-VM failure.
+func TestIsNoSuitableFlavorErr_ClassifiesOnlyFlavorErrors(t *testing.T) {
+	_, shapeErr := openstackpkg.GetClosestFlavour(64, 2048, 0, 0,
+		[]flavors.Flavor{{ID: "f-small", VCPUs: 2, RAM: 4096}}, false)
+	_, emptyListErr := openstackpkg.GetClosestFlavour(2, 2048, 0, 0, nil, false)
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "unschedulable shape", err: shapeErr, want: true},
+		{name: "shape error wrapped twice", err: pkgerrors.Wrap(pkgerrors.Wrap(shapeErr, "outer"), "outermost"), want: true},
+		{name: "empty flavor list stays fatal", err: emptyListErr, want: false},
+		{name: "unrelated error", err: pkgerrors.New("keystone: 401 unauthorized"), want: false},
+		{name: "unrelated error mentioning flavor", err: pkgerrors.New("failed to list all flavors"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNoSuitableFlavorErr(tt.err); got != tt.want {
+				t.Errorf("isNoSuitableFlavorErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDetermineAndSetTargetFlavor_FastPaths verifies the cached-flavor and
+// operator-override paths never touch the OpenStack API. The reconciler is built
+// with a nil client on purpose: any attempt to reach Nova would panic, so a clean
+// pass proves no API call was made.
+func TestDetermineAndSetTargetFlavor_FastPaths(t *testing.T) {
+	r := &MigrationPlanReconciler{}
+	template := &vjailbreakv1alpha1.MigrationTemplate{}
+	creds := &vjailbreakv1alpha1.OpenstackCreds{}
+
+	tests := []struct {
+		name            string
+		vmMachine       *vjailbreakv1alpha1.VMwareMachine
+		resolvedFlavors map[string]string
+		want            string
+	}{
+		{
+			name:            "uses pre-resolved flavor from validation",
+			vmMachine:       flavorTestMachine("vm-a", 2, 4096),
+			resolvedFlavors: map[string]string{"vm-a": "f-cached"},
+			want:            "f-cached",
+		},
+		{
+			name: "explicit TargetFlavorID wins over cache",
+			vmMachine: func() *vjailbreakv1alpha1.VMwareMachine {
+				m := flavorTestMachine("vm-b", 2, 4096)
+				m.Spec.TargetFlavorID = "operator-pinned"
+				return m
+			}(),
+			resolvedFlavors: map[string]string{"vm-b": "f-cached"},
+			want:            "operator-pinned",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configMapData := map[string]string{}
+			err := r.determineAndSetTargetFlavor(context.Background(), configMapData,
+				tt.vmMachine, template, creds, tt.resolvedFlavors)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := configMapData["TARGET_FLAVOR_ID"]; got != tt.want {
+				t.Errorf("TARGET_FLAVOR_ID = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVMDisplayNames(t *testing.T) {
+	got := vmDisplayNames([]*vjailbreakv1alpha1.VMwareMachine{
+		flavorTestMachine("vm-a", 2, 4096),
+		flavorTestMachine("vm-b", 4, 8192),
+	})
+	want := []string{"vm-a", "vm-b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("vmDisplayNames() = %v, want %v", got, want)
+	}
+}
+
+// TestValidateMigrationPlanVMs_PinnedFlavorSkipsNovaLookup guards a regression
+// risk introduced by pre-flight validation: resolving flavors up front must stay
+// LAZY. A plan whose VMs all pin Spec.TargetFlavorID never contacted Nova before,
+// and must not start depending on it — otherwise an unrelated Nova/Keystone
+// outage would fail plans that need no flavor lookup at all.
+//
+// The fake client has no OpenStack credential secret, so any attempt to list
+// flavors returns an error. A clean pass therefore proves no lookup happened.
+func TestValidateMigrationPlanVMs_PinnedFlavorSkipsNovaLookup(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := vjailbreakv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 scheme: %v", err)
+	}
+
+	const ns = "migration-system"
+	const credsName = "vmwcreds-a"
+	const vmName = "pinned-vm"
+	const vmID = "vm-101"
+
+	vmKey := commonutils.GetVMUniqueKey(vmName, vmID)
+	vmk8sName, err := commonutils.GetK8sCompatibleVMWareObjectName(vmKey, credsName)
+	if err != nil {
+		t.Fatalf("failed to compute k8s name: %v", err)
+	}
+
+	vmMachine := &vjailbreakv1alpha1.VMwareMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vmk8sName,
+			Namespace: ns,
+			Labels:    map[string]string{constants.VMwareCredsLabel: credsName},
+		},
+		Spec: vjailbreakv1alpha1.VMwareMachineSpec{
+			TargetFlavorID: "operator-pinned",
+			VMInfo: vjailbreakv1alpha1.VMInfo{
+				Name:     vmName,
+				VMID:     vmID,
+				CPU:      4,
+				Memory:   8192,
+				OSFamily: "linuxGuest",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(vmMachine).
+		Build()
+
+	r := &MigrationPlanReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		ctxlog: logr.Discard(),
+	}
+
+	migrationplan := &vjailbreakv1alpha1.MigrationPlan{
+		ObjectMeta: metav1.ObjectMeta{Name: "plan-a", Namespace: ns},
+	}
+	migrationtemplate := &vjailbreakv1alpha1.MigrationTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "tmpl-a", Namespace: ns},
+	}
+	vmwcreds := &vjailbreakv1alpha1.VMwareCreds{
+		ObjectMeta: metav1.ObjectMeta{Name: credsName, Namespace: ns},
+	}
+	openstackcreds := &vjailbreakv1alpha1.OpenstackCreds{
+		ObjectMeta: metav1.ObjectMeta{Name: "oscreds-a", Namespace: ns},
+	}
+
+	validation, err := r.validateMigrationPlanVMs(context.Background(), migrationplan,
+		migrationtemplate, vmwcreds, openstackcreds, []string{vmKey})
+	if err != nil {
+		t.Fatalf("validation must not require a Nova lookup for a pinned flavor, got: %v", err)
+	}
+
+	if len(validation.ValidVMs) != 1 {
+		t.Fatalf("ValidVMs = %d, want 1", len(validation.ValidVMs))
+	}
+	if len(validation.FlavorSkippedVMs) != 0 {
+		t.Errorf("FlavorSkippedVMs = %d, want 0", len(validation.FlavorSkippedVMs))
+	}
+	if got := validation.ResolvedFlavors[vmk8sName]; got != "operator-pinned" {
+		t.Errorf("ResolvedFlavors[%s] = %q, want %q", vmk8sName, got, "operator-pinned")
 	}
 }

--- a/k8s/migration/internal/controller/openstackcreds_controller.go
+++ b/k8s/migration/internal/controller/openstackcreds_controller.go
@@ -650,7 +650,10 @@ func updateVMwareMachineWithFlavor(ctx context.Context, r *OpenstackCredsReconci
 	vgpuCount := vmwaremachine.Spec.VMInfo.GPU.VGPUCount
 
 	flavor, err := openstackpkg.GetClosestFlavour(cpu, memory, passthroughGPUCount, vgpuCount, flavorList, false)
-	if err != nil && !strings.Contains(err.Error(), "no suitable flavor found") {
+	// A VM whose shape no flavor can satisfy is recorded as NOT_FOUND below rather
+	// than failing the whole OpenstackCreds sync. Matched via errors.Is so the
+	// classification no longer depends on the exact wording of the message.
+	if err != nil && !errors.Is(err, openstackpkg.ErrNoSuitableFlavor) {
 		ctxlog.Info(fmt.Sprintf("Error message '%s'", vmwaremachine.Name))
 		return errors.Wrap(err, "failed to get closest flavor")
 	}

--- a/pkg/common/openstack/flavor.go
+++ b/pkg/common/openstack/flavor.go
@@ -3,6 +3,7 @@
 package openstack
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -10,6 +11,17 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/platform9/vjailbreak/pkg/common/constants"
 )
+
+// ErrNoSuitableFlavor indicates that no flavor in the candidate set can satisfy a
+// VM's CPU / memory / GPU shape. This is a property of that one VM, not of the
+// cluster, so callers may treat it as a per-VM skip rather than a fatal error —
+// match it with errors.Is instead of string-matching the message.
+//
+// Note that an empty candidate set is deliberately NOT reported as this sentinel:
+// that means Nova returned no flavors at all (a credentials, connectivity or
+// availability-zone-filter problem) and must stay fatal, because silently
+// skipping it would skip every VM in the plan.
+var ErrNoSuitableFlavor = errors.New("no suitable flavor found")
 
 // AvailabilityZoneExtraSpecKey is the flavor property PCD uses to bind a
 // flavor to a target cluster (the cluster name is the availability zone).
@@ -93,7 +105,7 @@ func GetClosestFlavour(cpu, memory, passthroughGPUCount, vgpuCount int, allFlavo
 	if passthroughGPUCount > 0 || vgpuCount > 0 {
 		gpuInfo = fmt.Sprintf(", %d passthrough GPU(s), and %d vGPU(s)", passthroughGPUCount, vgpuCount)
 	}
-	return nil, fmt.Errorf("no suitable flavor found for %d vCPU(s), %d MB RAM%s", cpu, memory, gpuInfo)
+	return nil, fmt.Errorf("%w for %d vCPU(s), %d MB RAM%s", ErrNoSuitableFlavor, cpu, memory, gpuInfo)
 }
 
 // isGPUFlavor checks if a flavor has GPU-related extra_specs

--- a/pkg/common/openstack/flavor_test.go
+++ b/pkg/common/openstack/flavor_test.go
@@ -3,9 +3,11 @@
 package openstack
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
+	pkgerrors "github.com/pkg/errors"
 )
 
 func TestGetPassthroughGPUCount(t *testing.T) {
@@ -318,5 +320,103 @@ func TestGetClosestFlavourWithGPU(t *testing.T) {
 				t.Errorf("GetClosestFlavour() = %s, want %s", flavor.ID, tt.expectedFlavorID)
 			}
 		})
+	}
+}
+
+// TestGetClosestFlavour_NoSuitableFlavorSentinel verifies that a genuine
+// CPU/memory/GPU shape mismatch is matchable with errors.Is so callers can treat
+// an unschedulable VM as a skip instead of a fatal error, while an empty flavor
+// list (an infrastructure/permissions problem, not a per-VM shape problem)
+// deliberately does NOT match the sentinel.
+func TestGetClosestFlavour_NoSuitableFlavorSentinel(t *testing.T) {
+	candidates := []flavors.Flavor{
+		{ID: "small", VCPUs: 2, RAM: 2048},
+		{ID: "medium", VCPUs: 4, RAM: 8192},
+	}
+
+	tests := []struct {
+		name         string
+		cpu          int
+		memory       int
+		allFlavors   []flavors.Flavor
+		wantErr      bool
+		wantSentinel bool
+		wantFlavorID string
+	}{
+		{
+			name:         "shape fits: no error",
+			cpu:          2,
+			memory:       2048,
+			allFlavors:   candidates,
+			wantFlavorID: "small",
+		},
+		{
+			name:         "cpu too large: sentinel",
+			cpu:          64,
+			memory:       2048,
+			allFlavors:   candidates,
+			wantErr:      true,
+			wantSentinel: true,
+		},
+		{
+			name:         "memory too large: sentinel",
+			cpu:          2,
+			memory:       1048576,
+			allFlavors:   candidates,
+			wantErr:      true,
+			wantSentinel: true,
+		},
+		{
+			name:         "empty flavor list: error but NOT sentinel",
+			cpu:          2,
+			memory:       2048,
+			allFlavors:   nil,
+			wantErr:      true,
+			wantSentinel: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flavor, err := GetClosestFlavour(tt.cpu, tt.memory, 0, 0, tt.allFlavors, false)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				if got := errors.Is(err, ErrNoSuitableFlavor); got != tt.wantSentinel {
+					t.Errorf("errors.Is(err, ErrNoSuitableFlavor) = %v, want %v (err: %v)",
+						got, tt.wantSentinel, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if flavor.ID != tt.wantFlavorID {
+				t.Errorf("flavor.ID = %q, want %q", flavor.ID, tt.wantFlavorID)
+			}
+		})
+	}
+}
+
+// TestErrNoSuitableFlavor_SurvivesWrapping is the crux of the non-blocking
+// containment gate: the controller wraps this error with github.com/pkg/errors
+// before the trigger loop inspects it, so errors.Is must still match through
+// several layers of wrapping. If this breaks, one unschedulable VM silently
+// starts aborting the whole MigrationPlan again.
+func TestErrNoSuitableFlavor_SurvivesWrapping(t *testing.T) {
+	_, err := GetClosestFlavour(64, 2048, 0, 0, []flavors.Flavor{{ID: "small", VCPUs: 2, RAM: 2048}}, false)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+
+	wrapped := pkgerrors.Wrapf(
+		pkgerrors.Wrap(err, "failed to determine target flavor for VM vm-07"),
+		"failed to create ConfigMap for VM %s", "vm-07")
+
+	if !errors.Is(wrapped, ErrNoSuitableFlavor) {
+		t.Errorf("errors.Is failed through pkg/errors wrapping; got %v", wrapped)
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it
A VM with no matching OpenStack flavor used to abort the whole MigrationPlan — every VM behind it in the list never got a ConfigMap or Job, and the plan retried forever on the same VM.

Now the failure is contained to that VM:
- Flavors are resolved in pre-flight validation, once per plan instead of once per VM (and lazily, so operator-pinned plans still never call Nova).
- `ErrNoSuitableFlavor` sentinel + `errors.Is` so only an unschedulable shape is treated as a skip; auth/connectivity errors still requeue. Replaces a `strings.Contains` check.
- The unschedulable VM gets a `Migration` in `ValidationFailed` with an actionable reason, so it stays visible in the UI (no UI changes needed).
- `processMigrationPhases` accumulates per-VM failures instead of returning on the first one; the plan is marked `PodFailed` only once nothing is still running, so post-migration still runs for the VMs that succeeded.

## Which issue(s) this PR fixes
fixes #2212

__Testing Done__

<img width="1429" height="779" alt="image" src="https://github.com/user-attachments/assets/3a1d60a0-186b-4745-8e58-a3549f176975" />
