### PR TITLE
[2195] Fix incorrect  step timings on the migration detail page

### DIFF
--- a/k8s/migration/internal/controller/migration_controller.go
+++ b/k8s/migration/internal/controller/migration_controller.go
@@ -194,13 +194,14 @@ func (r *MigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	if constants.VMMigrationStatesEnum[migration.Status.Phase] <= constants.VMMigrationStatesEnum[vjailbreakv1alpha1.VMMigrationPhaseValidating] {
-		migration.Status.Phase = vjailbreakv1alpha1.VMMigrationPhaseValidating
-	}
-	// Check if the pod is in a valid state only then continue
-	if pod.Status.Phase != corev1.PodRunning && pod.Status.Phase != corev1.PodFailed && pod.Status.Phase != corev1.PodSucceeded {
+	// Stay Pending until the pod has actually started running (or reached a terminal
+	// state).
+	if !isPodRunningOrTerminal(pod) {
 		ctxlog.Info("Pod is not in a terminal state, requeuing", "migration", migration.Name, "podStatus", pod.Status.Phase)
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+	if constants.VMMigrationStatesEnum[migration.Status.Phase] <= constants.VMMigrationStatesEnum[vjailbreakv1alpha1.VMMigrationPhaseValidating] {
+		migration.Status.Phase = vjailbreakv1alpha1.VMMigrationPhaseValidating
 	}
 
 	filteredEvents, err := r.GetEventsSorted(ctx, migrationScope)
@@ -208,9 +209,11 @@ func (r *MigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, errors.Wrap(err, "failed getting pod events")
 	}
 	// Create status conditions
+	migration.Status.Conditions = utils.CreatePodRunningCondition(migration, pod)
 	migration.Status.Conditions = utils.CreateValidatedCondition(migration, filteredEvents)
 	migration.Status.Conditions = utils.CreateStorageAcceleratedCopyCondition(migration, filteredEvents)
 	migration.Status.Conditions = utils.CreateDataCopyCondition(migration, filteredEvents)
+	migration.Status.Conditions = utils.CreateCutoverTriggeredCondition(migration, filteredEvents)
 	migration.Status.Conditions = utils.CreateMigratingCondition(migration, filteredEvents)
 	migration.Status.Conditions = utils.CreateFailedCondition(migration, filteredEvents)
 	migration.Status.Conditions = utils.CreateSucceededCondition(migration, filteredEvents)
@@ -569,6 +572,14 @@ func (r *MigrationReconciler) GetEventsSorted(ctx context.Context, scope *scope.
 		return !filteredEvents.Items[i].CreationTimestamp.Before(&filteredEvents.Items[j].CreationTimestamp)
 	})
 	return filteredEvents, nil
+}
+
+// isPodRunningOrTerminal reports whether a pod has progressed far enough to be considered
+// actively worked on - Running, Failed, or Succeeded.
+func isPodRunningOrTerminal(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodRunning ||
+		pod.Status.Phase == corev1.PodFailed ||
+		pod.Status.Phase == corev1.PodSucceeded
 }
 
 // GetPod retrieves the pod associated with a migration

--- a/k8s/migration/internal/controller/migration_controller_test.go
+++ b/k8s/migration/internal/controller/migration_controller_test.go
@@ -18,10 +18,12 @@ package controller
 
 import (
 	"context"
+	"testing"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -81,3 +83,26 @@ var _ = ginkgo.Describe("Migration Controller", func() {
 		})
 	})
 })
+
+func TestIsPodRunningOrTerminal(t *testing.T) {
+	tests := []struct {
+		name  string
+		phase corev1.PodPhase
+		want  bool
+	}{
+		{name: "pending pod is not yet running or terminal", phase: corev1.PodPending, want: false},
+		{name: "unknown pod is not yet running or terminal", phase: corev1.PodUnknown, want: false},
+		{name: "running pod counts", phase: corev1.PodRunning, want: true},
+		{name: "failed pod counts (terminal)", phase: corev1.PodFailed, want: true},
+		{name: "succeeded pod counts (terminal)", phase: corev1.PodSucceeded, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{Status: corev1.PodStatus{Phase: tt.phase}}
+			if got := isPodRunningOrTerminal(pod); got != tt.want {
+				t.Errorf("isPodRunningOrTerminal(phase=%s) = %v, want %v", tt.phase, got, tt.want)
+			}
+		})
+	}
+}

--- a/k8s/migration/pkg/utils/migrationutils.go
+++ b/k8s/migration/pkg/utils/migrationutils.go
@@ -136,7 +136,7 @@ func CreatePodRunningCondition(migration *vjailbreakv1alpha1.Migration, pod *cor
 	statuscondition := GeneratePodCondition(constants.MigrationConditionTypePodRunning,
 		corev1.ConditionTrue,
 		constants.MigrationReason,
-		"Migration pod started running",
+		"Migration started running",
 		*pod.Status.StartTime)
 
 	if idx == -1 {

--- a/k8s/migration/pkg/utils/migrationutils.go
+++ b/k8s/migration/pkg/utils/migrationutils.go
@@ -123,6 +123,73 @@ func CreateMigratingCondition(migration *vjailbreakv1alpha1.Migration, eventList
 	return existingConditions
 }
 
+// CreatePodRunningCondition creates a condition marking the instant the migration pod
+// actually started running, read directly from the pod's own Status.StartTime (a native
+// Kubernetes field) rather than from an event.
+func CreatePodRunningCondition(migration *vjailbreakv1alpha1.Migration, pod *corev1.Pod) []corev1.PodCondition {
+	existingConditions := migration.Status.Conditions
+	if pod.Status.StartTime == nil {
+		return existingConditions
+	}
+
+	idx := GetConditonIndex(existingConditions, constants.MigrationConditionTypePodRunning, constants.MigrationReason)
+	statuscondition := GeneratePodCondition(constants.MigrationConditionTypePodRunning,
+		corev1.ConditionTrue,
+		constants.MigrationReason,
+		"Migration pod started running",
+		*pod.Status.StartTime)
+
+	if idx == -1 {
+		existingConditions = append(existingConditions, *statuscondition)
+	} else {
+		existingConditions[idx] = *statuscondition
+	}
+	return existingConditions
+}
+
+// createSingleEventCondition scans eventList for the first event matching reason/messageCheck
+// and stamps it as a single fixed-message condition on the migration - the shape shared by
+// CreateCutoverTriggeredCondition and CreateSucceededCondition (only the message-match test,
+// condition type, and stored message text vary between them).
+func createSingleEventCondition(
+	existingConditions []corev1.PodCondition,
+	eventList *corev1.EventList,
+	messageMatches func(message string) bool,
+	conditionType corev1.PodConditionType,
+	conditionMessage string,
+) []corev1.PodCondition {
+	for i := 0; i < len(eventList.Items); i++ {
+		if eventList.Items[i].Reason != constants.MigrationReason || !messageMatches(eventList.Items[i].Message) {
+			continue
+		}
+
+		idx := GetConditonIndex(existingConditions, conditionType, constants.MigrationReason)
+		statuscondition := GeneratePodCondition(conditionType,
+			corev1.ConditionTrue,
+			constants.MigrationReason,
+			conditionMessage,
+			eventList.Items[i].LastTimestamp)
+
+		if idx == -1 {
+			existingConditions = append(existingConditions, *statuscondition)
+		} else {
+			existingConditions[idx] = *statuscondition
+		}
+		break
+	}
+	return existingConditions
+}
+
+// CreateCutoverTriggeredCondition creates a condition marking the instant an admin actually
+// triggered cutover for a migration (as opposed to 'AwaitingAdminCutOver', which only marks
+// that the migration is waiting for that to happen, however long it takes).
+func CreateCutoverTriggeredCondition(migration *vjailbreakv1alpha1.Migration, eventList *corev1.EventList) []corev1.PodCondition {
+	return createSingleEventCondition(migration.Status.Conditions, eventList,
+		func(message string) bool { return strings.HasPrefix(message, "Admin cutover triggered") },
+		constants.MigrationConditionTypeCutoverTriggered,
+		"Admin cutover triggered")
+}
+
 // isFailureEventMessage reports whether an event message represents a genuine terminal
 // migration failure, matched case-insensitively. Warning messages are excluded since they
 // don't represent a real failure.
@@ -182,27 +249,10 @@ func cleanFailureMessage(msg string) string {
 
 // CreateSucceededCondition creates or updates a succeeded condition for a migration based on events.
 func CreateSucceededCondition(migration *vjailbreakv1alpha1.Migration, eventList *corev1.EventList) []corev1.PodCondition {
-	existingConditions := migration.Status.Conditions
-	for i := 0; i < len(eventList.Items); i++ {
-		if eventList.Items[i].Reason != constants.MigrationReason || !strings.Contains(eventList.Items[i].Message, "VM created successfully") {
-			continue
-		}
-
-		idx := GetConditonIndex(existingConditions, constants.MigrationConditionTypeMigrated, constants.MigrationReason)
-		statuscondition := GeneratePodCondition(constants.MigrationConditionTypeMigrated,
-			corev1.ConditionTrue,
-			constants.MigrationReason,
-			"VM successfully migrated from VMware to OpenStack",
-			eventList.Items[i].LastTimestamp)
-
-		if idx == -1 {
-			existingConditions = append(existingConditions, *statuscondition)
-		} else {
-			existingConditions[idx] = *statuscondition
-		}
-		break
-	}
-	return existingConditions
+	return createSingleEventCondition(migration.Status.Conditions, eventList,
+		func(message string) bool { return strings.Contains(message, "VM created successfully") },
+		constants.MigrationConditionTypeMigrated,
+		"VM successfully migrated from VMware to OpenStack")
 }
 
 // SetCutoverLabel sets the cutover label for a migration

--- a/k8s/migration/pkg/utils/migrationutils_test.go
+++ b/k8s/migration/pkg/utils/migrationutils_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"testing"
+	"time"
 
 	vjailbreakv1alpha1 "github.com/platform9/vjailbreak/k8s/migration/api/v1alpha1"
 	"github.com/platform9/vjailbreak/pkg/common/constants"
@@ -323,6 +324,202 @@ func TestCreateDataCopiedCondition(t *testing.T) {
 			}
 			if hasCondition != tt.wantCondition {
 				t.Errorf("hasDataCopiedCondition = %v, want %v", hasCondition, tt.wantCondition)
+			}
+		})
+	}
+}
+
+func TestCreatePodRunningCondition(t *testing.T) {
+	startedAt := metav1.Now()
+
+	tests := []struct {
+		name          string
+		pod           *corev1.Pod
+		wantCondition bool
+	}{
+		{
+			name:          "pod with StartTime creates PodRunning condition",
+			pod:           &corev1.Pod{Status: corev1.PodStatus{StartTime: &startedAt}},
+			wantCondition: true,
+		},
+		{
+			name:          "pod without StartTime (still scheduled, not running) produces no condition",
+			pod:           &corev1.Pod{Status: corev1.PodStatus{StartTime: nil}},
+			wantCondition: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			migration := makeMigration()
+
+			got := CreatePodRunningCondition(migration, tt.pod)
+
+			hasCondition := false
+			for _, c := range got {
+				if c.Type == constants.MigrationConditionTypePodRunning {
+					hasCondition = true
+					if tt.pod.Status.StartTime != nil && !c.LastTransitionTime.Time.Equal(tt.pod.Status.StartTime.Time) {
+						t.Errorf("LastTransitionTime = %v, want %v", c.LastTransitionTime.Time, tt.pod.Status.StartTime.Time)
+					}
+					break
+				}
+			}
+			if hasCondition != tt.wantCondition {
+				t.Errorf("hasPodRunningCondition = %v, want %v", hasCondition, tt.wantCondition)
+			}
+		})
+	}
+}
+
+// TestCreateSingleEventCondition covers createSingleEventCondition directly - the shared
+// helper CreateCutoverTriggeredCondition and CreateSucceededCondition both delegate to - so
+// the append-vs-update and first-match-wins behavior only needs testing once instead of being
+// duplicated across every function that uses it.
+func TestCreateSingleEventCondition(t *testing.T) {
+	matchesFoo := func(message string) bool { return message == "foo happened" }
+
+	t.Run("no matching event leaves conditions unchanged", func(t *testing.T) {
+		eventList := &corev1.EventList{Items: []corev1.Event{
+			makeEvent(constants.MigrationReason, "something else"),
+		}}
+
+		got := createSingleEventCondition(nil, eventList, matchesFoo, "FooCondition", "foo done")
+
+		if len(got) != 0 {
+			t.Errorf("got %d conditions, want 0", len(got))
+		}
+	})
+
+	t.Run("wrong reason ignored even if message matches", func(t *testing.T) {
+		eventList := &corev1.EventList{Items: []corev1.Event{
+			makeEvent("OtherReason", "foo happened"),
+		}}
+
+		got := createSingleEventCondition(nil, eventList, matchesFoo, "FooCondition", "foo done")
+
+		if len(got) != 0 {
+			t.Errorf("got %d conditions, want 0", len(got))
+		}
+	})
+
+	t.Run("matching event appends a new condition with the fixed message and type", func(t *testing.T) {
+		ts := metav1.Now()
+		eventList := &corev1.EventList{Items: []corev1.Event{
+			{Reason: constants.MigrationReason, Message: "foo happened", LastTimestamp: ts},
+		}}
+
+		got := createSingleEventCondition(nil, eventList, matchesFoo, "FooCondition", "foo done")
+
+		if len(got) != 1 {
+			t.Fatalf("got %d conditions, want 1", len(got))
+		}
+		if got[0].Type != "FooCondition" || got[0].Message != "foo done" || got[0].Reason != constants.MigrationReason {
+			t.Errorf("condition = %+v, want type=FooCondition message='foo done' reason=%s", got[0], constants.MigrationReason)
+		}
+		if !got[0].LastTransitionTime.Time.Equal(ts.Time) {
+			t.Errorf("LastTransitionTime = %v, want %v", got[0].LastTransitionTime.Time, ts.Time)
+		}
+	})
+
+	t.Run("matching event updates an existing condition of the same type in place, not duplicated", func(t *testing.T) {
+		existing := []corev1.PodCondition{
+			{Type: "FooCondition", Reason: constants.MigrationReason, Message: "stale", LastTransitionTime: metav1.Now()},
+		}
+		newTs := metav1.NewTime(metav1.Now().Add(time.Minute))
+		eventList := &corev1.EventList{Items: []corev1.Event{
+			{Reason: constants.MigrationReason, Message: "foo happened", LastTimestamp: newTs},
+		}}
+
+		got := createSingleEventCondition(existing, eventList, matchesFoo, "FooCondition", "foo done")
+
+		if len(got) != 1 {
+			t.Fatalf("got %d conditions, want 1 (updated in place, not appended)", len(got))
+		}
+		if got[0].Message != "foo done" {
+			t.Errorf("Message = %q, want %q", got[0].Message, "foo done")
+		}
+		if !got[0].LastTransitionTime.Time.Equal(newTs.Time) {
+			t.Errorf("LastTransitionTime not updated: got %v, want %v", got[0].LastTransitionTime.Time, newTs.Time)
+		}
+	})
+
+	t.Run("only the first matching event is used, matching the break-on-first-match behavior", func(t *testing.T) {
+		ts1 := metav1.Now()
+		ts2 := metav1.NewTime(ts1.Add(time.Hour))
+		eventList := &corev1.EventList{Items: []corev1.Event{
+			{Reason: constants.MigrationReason, Message: "foo happened", LastTimestamp: ts1},
+			{Reason: constants.MigrationReason, Message: "foo happened", LastTimestamp: ts2},
+		}}
+
+		got := createSingleEventCondition(nil, eventList, matchesFoo, "FooCondition", "foo done")
+
+		if len(got) != 1 {
+			t.Fatalf("got %d conditions, want 1", len(got))
+		}
+		if !got[0].LastTransitionTime.Time.Equal(ts1.Time) {
+			t.Errorf("LastTransitionTime = %v, want the FIRST matching event's time %v", got[0].LastTransitionTime.Time, ts1.Time)
+		}
+	})
+}
+
+func TestCreateCutoverTriggeredCondition(t *testing.T) {
+	tests := []struct {
+		name          string
+		events        []corev1.Event
+		wantCondition bool
+	}{
+		{
+			name: "'Admin cutover triggered' creates CutoverTriggered condition",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, "Admin cutover triggered"),
+			},
+			wantCondition: true,
+		},
+		{
+			name: "'Admin cutover triggered during wait' variant also matches",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, "Admin cutover triggered during wait"),
+			},
+			wantCondition: true,
+		},
+		{
+			name: "wrong reason ignored",
+			events: []corev1.Event{
+				makeEvent("OtherReason", "Admin cutover triggered"),
+			},
+			wantCondition: false,
+		},
+		{
+			name:          "empty events produces no condition",
+			events:        []corev1.Event{},
+			wantCondition: false,
+		},
+		{
+			name: "unrelated event ignored",
+			events: []corev1.Event{
+				makeEvent(constants.MigrationReason, constants.EventMessageWaitingForAdminCutOver),
+			},
+			wantCondition: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			migration := makeMigration()
+			eventList := &corev1.EventList{Items: tt.events}
+
+			got := CreateCutoverTriggeredCondition(migration, eventList)
+
+			hasCondition := false
+			for _, c := range got {
+				if c.Type == constants.MigrationConditionTypeCutoverTriggered {
+					hasCondition = true
+					break
+				}
+			}
+			if hasCondition != tt.wantCondition {
+				t.Errorf("hasCutoverTriggeredCondition = %v, want %v", hasCondition, tt.wantCondition)
 			}
 		})
 	}

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -639,6 +639,14 @@ runcmd:
 	// MigrationConditionTypeMigrating represents the condition type for migrating phase
 	MigrationConditionTypeMigrating corev1.PodConditionType = "Migrating"
 
+	// MigrationConditionTypePodRunning represents the condition type marking the instant the
+	// migration pod actually started running.
+	MigrationConditionTypePodRunning corev1.PodConditionType = "PodRunning"
+
+	// MigrationConditionTypeCutoverTriggered represents the condition type marking the instant
+	// an admin actually triggered cutover.
+	MigrationConditionTypeCutoverTriggered corev1.PodConditionType = "CutoverTriggered"
+
 	// MigrationConditionTypeValidated represents the condition type for validated phase
 	MigrationConditionTypeValidated corev1.PodConditionType = "Validated"
 	MigrationConditionTypeFailed    corev1.PodConditionType = "Failed"
@@ -678,10 +686,10 @@ runcmd:
 		vjailbreakv1alpha1.VMMigrationPhaseAwaitingAdminCutOver:     13,
 		// Post-cutover phases: these happen after admin triggers cutover
 		vjailbreakv1alpha1.VMMigrationPhaseCopyingChangedBlocks: 14,
-		vjailbreakv1alpha1.VMMigrationPhaseConvertingDisk: 15,
-		vjailbreakv1alpha1.VMMigrationPhaseDataCopied:    16,
-		vjailbreakv1alpha1.VMMigrationPhaseSucceeded:     17,
-		vjailbreakv1alpha1.VMMigrationPhaseUnknown:       18,
+		vjailbreakv1alpha1.VMMigrationPhaseConvertingDisk:       15,
+		vjailbreakv1alpha1.VMMigrationPhaseDataCopied:           16,
+		vjailbreakv1alpha1.VMMigrationPhaseSucceeded:            17,
+		vjailbreakv1alpha1.VMMigrationPhaseUnknown:              18,
 	}
 
 	// MigrationJobTTL is the TTL for migration job

--- a/ui/src/api/migrations/model.ts
+++ b/ui/src/api/migrations/model.ts
@@ -121,7 +121,9 @@ export enum Type {
   Validated = 'Validated',
   Failed = 'Failed',
   Migrating = 'Migrating',
-  DataCopied = 'DataCopied'
+  DataCopied = 'DataCopied',
+  PodRunning = 'PodRunning',
+  CutoverTriggered = 'CutoverTriggered'
 }
 
 export enum Phase {

--- a/ui/src/features/migration/components/MigrationStatusChip.test.tsx
+++ b/ui/src/features/migration/components/MigrationStatusChip.test.tsx
@@ -24,4 +24,10 @@ describe('MigrationStatusChip', () => {
     const label = screen.getByText('Unknown')
     expect(label).not.toHaveClass('MuiChip-label')
   })
+
+  it('renders a Pending chip when phase is not yet available, not Unknown', () => {
+    render(<MigrationStatusChip phase={undefined} />)
+    expect(screen.getByText('Pending')).toHaveClass('MuiChip-label')
+    expect(screen.queryByText('Unknown')).not.toBeInTheDocument()
+  })
 })

--- a/ui/src/features/migration/components/MigrationStatusChip.tsx
+++ b/ui/src/features/migration/components/MigrationStatusChip.tsx
@@ -12,7 +12,7 @@ export default function MigrationStatusChip({ phase }: MigrationStatusChipProps)
   const colorKey = getPhaseColorKey(phase as Phase)
   const label = getPhaseLabel(phase as Phase)
 
-  if (colorKey === 'default' && phase !== Phase.Pending) {
+  if (colorKey === 'default' && phase && phase !== Phase.Pending) {
     return (
       <Typography variant="body2" color="text.secondary">
         {label}

--- a/ui/src/features/migration/components/detail/MigrationDetailHeader.test.tsx
+++ b/ui/src/features/migration/components/detail/MigrationDetailHeader.test.tsx
@@ -1,0 +1,67 @@
+import type { ReactElement } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Migration, Phase } from '../../api/migrations'
+import MigrationDetailHeader from './MigrationDetailHeader'
+
+const baseMigration = {
+  metadata: { name: 'migration-2k19-vj-test', namespace: 'migration-system' },
+  spec: { vmName: '2k19-vj-test' },
+  status: { phase: Phase.Succeeded },
+} as unknown as Migration
+
+// DeleteMigrationDialog (rendered unconditionally, closed) needs a QueryClient in scope.
+function renderHeader(ui: ReactElement) {
+  const queryClient = new QueryClient()
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
+
+describe('MigrationDetailHeader — source label', () => {
+  it('shows the real datacenter from the VMwareMachine annotation, not the VMwareCreds name', () => {
+    renderHeader(
+      <MigrationDetailHeader
+        migration={baseMigration}
+        onBack={vi.fn()}
+        resources={{
+          vmwareMachine: {
+            metadata: { annotations: { 'vjailbreak.k8s.pf9.io/datacenter': 'Datacenter1' } },
+          },
+          vmwareCredsRef: 'vmware',
+        } as any}
+      />
+    )
+
+    expect(screen.getByText('Datacenter1')).toBeInTheDocument()
+    expect(screen.queryByText('vmware')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the migration template\'s source datacenter when the VM annotation is missing', () => {
+    renderHeader(
+      <MigrationDetailHeader
+        migration={baseMigration}
+        onBack={vi.fn()}
+        resources={{
+          vmwareMachine: { metadata: {} },
+          migrationTemplate: { spec: { source: { datacenter: 'Datacenter2' } } },
+          vmwareCredsRef: 'vmware',
+        } as any}
+      />
+    )
+
+    expect(screen.getByText('Datacenter2')).toBeInTheDocument()
+  })
+
+  it('does not fall back to the VMwareCreds name when no datacenter is available', () => {
+    renderHeader(
+      <MigrationDetailHeader
+        migration={baseMigration}
+        onBack={vi.fn()}
+        resources={{ vmwareCredsRef: 'vmware' } as any}
+      />
+    )
+
+    expect(screen.queryByText('vmware')).not.toBeInTheDocument()
+    expect(screen.queryByText(/from/)).not.toBeInTheDocument()
+  })
+})

--- a/ui/src/features/migration/components/detail/MigrationDetailHeader.tsx
+++ b/ui/src/features/migration/components/detail/MigrationDetailHeader.tsx
@@ -16,7 +16,6 @@ import { getPhaseColorKey, getPhaseLabel } from '../../utils/phaseUtils'
 import { TriggerAdminCutoverButton } from '../TriggerAdminCutover/TriggerAdminCutoverButton'
 import { VJAILBREAK_DEFAULT_NAMESPACE } from 'src/api/constants'
 import { MigrationDetailResources } from 'src/hooks/api/useMigrationDetailResourcesQuery'
-import { VMwareCreds } from 'src/api/vmware-creds/model'
 import { OpenstackCreds } from 'src/api/openstack-creds/model'
 import DeleteMigrationDialog from '../DeleteMigrationDialog'
 
@@ -57,11 +56,12 @@ export default function MigrationDetailHeader({
   const namespace =
     (migration.metadata?.namespace as string | undefined) ?? VJAILBREAK_DEFAULT_NAMESPACE
 
-  const vmwareCreds = resources?.vmwareCreds as VMwareCreds | null | undefined
+  // Matches MigrationDetailsTab's sourceDatacenter
+  const vmMeta = resources?.vmwareMachine?.metadata as any
+  const templateSpec = resources?.migrationTemplate?.spec as any
   const sourceLabel =
-    vmwareCreds?.spec?.hostName ||
-    vmwareCreds?.spec?.datacenter ||
-    resources?.vmwareCredsRef ||
+    (vmMeta?.annotations?.['vjailbreak.k8s.pf9.io/datacenter'] as string) ||
+    (templateSpec?.source?.datacenter as string) ||
     null
 
   const openstackCreds = resources?.openstackCreds as OpenstackCreds | null | undefined

--- a/ui/src/features/migration/components/detail/MigrationEventsTab.test.tsx
+++ b/ui/src/features/migration/components/detail/MigrationEventsTab.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Migration } from '../../api/migrations'
+import MigrationEventsTab from './MigrationEventsTab'
+
+const condition = (type: string, isoTime: string, message = '', reason = '') => ({
+  type,
+  status: 'True',
+  reason,
+  message,
+  lastTransitionTime: isoTime,
+})
+
+const buildMigration = (creationTimestamp: string, conditions: unknown[]): Migration =>
+  ({
+    metadata: { creationTimestamp },
+    status: { conditions },
+  }) as unknown as Migration
+
+describe('MigrationEventsTab', () => {
+  it('always shows a Created row from the migration creation timestamp, even with no conditions yet', () => {
+    render(<MigrationEventsTab migration={buildMigration('2026-01-01T00:00:00Z', [])} />)
+
+    expect(screen.getByText('Created')).toBeInTheDocument()
+  })
+
+  it('shows the real PodRunning condition as "Migration Started"', () => {
+    render(
+      <MigrationEventsTab
+        migration={buildMigration('2026-01-01T00:00:00Z', [
+          condition('PodRunning', '2026-01-01T00:50:00Z', 'Migration pod started running'),
+        ])}
+      />
+    )
+
+    expect(screen.getByText('Migration Started')).toBeInTheDocument()
+    expect(screen.queryByText('PodRunning')).not.toBeInTheDocument()
+  })
+
+  it('shows the real CutoverTriggered condition as "Cutover", and does not also synthesize one', () => {
+    render(
+      <MigrationEventsTab
+        migration={buildMigration('2026-01-01T00:00:00Z', [
+          { ...condition('DataCopy', '2026-01-01T00:10:00Z'), reason: 'Copying disk 0' },
+          condition('CutoverTriggered', '2026-01-01T05:00:00Z', 'Admin cutover triggered'),
+          condition('Migrating', '2026-01-01T05:01:00Z'),
+        ])}
+      />
+    )
+
+    expect(screen.getAllByText('Cutover')).toHaveLength(1)
+    expect(screen.getByText('Admin cutover triggered')).toBeInTheDocument()
+  })
+
+  it('synthesizes a Cutover entry from the last disk copy when there is no admin cutover trigger, once conversion has started', () => {
+    render(
+      <MigrationEventsTab
+        migration={buildMigration('2026-01-01T00:00:00Z', [
+          { ...condition('DataCopy', '2026-01-01T00:10:00Z'), reason: 'Copying disk 0' },
+          { ...condition('DataCopy', '2026-01-01T00:13:00Z'), reason: 'Copying disk 1' },
+          condition('Migrating', '2026-01-01T00:14:00Z'),
+        ])}
+      />
+    )
+
+    expect(screen.getByText('Cutover')).toBeInTheDocument()
+    expect(screen.getByText('Cutover started immediately after data copy')).toBeInTheDocument()
+  })
+
+  it('does not show a Cutover entry before conversion has actually started (cutover has not happened yet)', () => {
+    render(
+      <MigrationEventsTab
+        migration={buildMigration('2026-01-01T00:00:00Z', [
+          { ...condition('DataCopy', '2026-01-01T00:10:00Z'), reason: 'Copying disk 0' },
+        ])}
+      />
+    )
+
+    expect(screen.queryByText('Cutover')).not.toBeInTheDocument()
+  })
+
+  it('still shows real conditions unchanged - Validated, DataCopy, Migrating, Migrated', () => {
+    render(
+      <MigrationEventsTab
+        migration={buildMigration('2026-01-01T00:00:00Z', [
+          condition('Validated', '2026-01-01T00:02:00Z'),
+          { ...condition('DataCopy', '2026-01-01T00:10:00Z'), reason: 'Copying disk 0' },
+          condition('Migrating', '2026-01-01T00:14:00Z'),
+          condition('Migrated', '2026-01-01T00:20:00Z'),
+        ])}
+      />
+    )
+
+    expect(screen.getByText('Validated')).toBeInTheDocument()
+    expect(screen.getByText('DataCopy')).toBeInTheDocument()
+    expect(screen.getByText('Migrating')).toBeInTheDocument()
+    expect(screen.getByText('Migrated')).toBeInTheDocument()
+  })
+})

--- a/ui/src/features/migration/components/detail/MigrationEventsTab.test.tsx
+++ b/ui/src/features/migration/components/detail/MigrationEventsTab.test.tsx
@@ -28,7 +28,7 @@ describe('MigrationEventsTab', () => {
     render(
       <MigrationEventsTab
         migration={buildMigration('2026-01-01T00:00:00Z', [
-          condition('PodRunning', '2026-01-01T00:50:00Z', 'Migration pod started running'),
+          condition('PodRunning', '2026-01-01T00:50:00Z', 'Migration started running'),
         ])}
       />
     )

--- a/ui/src/features/migration/components/detail/MigrationEventsTab.tsx
+++ b/ui/src/features/migration/components/detail/MigrationEventsTab.tsx
@@ -35,6 +35,55 @@ function formatFullTs(ts: Date | string | undefined): string {
   })
 }
 
+const DISPLAY_TYPE: Record<string, string> = {
+  PodRunning: 'Migration Started',
+  CutoverTriggered: 'Cutover',
+}
+
+function displayType(type: string | undefined): string {
+  if (!type) return '—'
+  return DISPLAY_TYPE[type] ?? type
+}
+
+
+function buildCreatedEntry(creationTimestamp: string | Date | undefined): Condition | null {
+  if (!creationTimestamp) return null
+  return {
+    type: 'Created',
+    status: 'True',
+    reason: '',
+    message: 'Migration created',
+    lastTransitionTime: creationTimestamp,
+  } as unknown as Condition
+}
+
+// 'Cutover' has a real backend timestamp only for admin-gated migrations (CutoverTriggered
+// condition, fires the instant an admin actually clicks cutover). For immediate/automatic
+// cutover migrations there's no such event - cutover starts the moment the last disk's data
+// copy finishes, so that's what's synthesized here as a stand-in, once conversion (Migrating)
+// has actually started (i.e. cutover has definitely already happened by then).
+function buildSyntheticCutoverEntry(conditions: Condition[]): Condition | null {
+  const hasRealCutoverTrigger = conditions.some((c) => c.type === 'CutoverTriggered')
+  if (hasRealCutoverTrigger) return null
+
+  const hasStartedConverting = conditions.some((c) => c.type === 'Migrating')
+  if (!hasStartedConverting) return null
+
+  const dataCopyEntries = conditions.filter((c) => c.type === 'DataCopy' && c.lastTransitionTime)
+  if (dataCopyEntries.length === 0) return null
+  const lastDataCopy = dataCopyEntries.reduce((a, b) =>
+    new Date(String(a.lastTransitionTime)).getTime() > new Date(String(b.lastTransitionTime)).getTime() ? a : b
+  )
+
+  return {
+    type: 'Cutover',
+    status: 'True',
+    reason: '',
+    message: 'Cutover started immediately after data copy',
+    lastTransitionTime: lastDataCopy.lastTransitionTime,
+  } as unknown as Condition
+}
+
 interface MigrationEventsTabProps {
   migration: Migration
 }
@@ -44,7 +93,14 @@ export default function MigrationEventsTab({ migration }: MigrationEventsTabProp
   const [sort, setSort] = useState<SortOrder>('oldest')
   const [search, setSearch] = useState('')
 
-  const conditions = migration.status?.conditions ?? []
+  const rawConditions = migration.status?.conditions ?? []
+  const createdEntry = buildCreatedEntry(migration.metadata?.creationTimestamp)
+  const syntheticCutoverEntry = buildSyntheticCutoverEntry(rawConditions)
+  const conditions = [
+    ...(createdEntry ? [createdEntry] : []),
+    ...rawConditions,
+    ...(syntheticCutoverEntry ? [syntheticCutoverEntry] : []),
+  ]
 
   const counts = useMemo(
     () => ({
@@ -219,7 +275,7 @@ export default function MigrationEventsTab({ migration }: MigrationEventsTabProp
                     }}
                   >
                     <Typography variant="body2" fontWeight={600} sx={{ flex: 1 }}>
-                      {condition.type ?? '—'}
+                      {displayType(condition.type)}
                     </Typography>
                     <Chip
                       label={condition.status ?? 'Unknown'}

--- a/ui/src/features/migration/components/detail/MigrationPhaseDetail.test.tsx
+++ b/ui/src/features/migration/components/detail/MigrationPhaseDetail.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Migration, Phase } from '../../api/migrations'
+import MigrationPhaseDetail from './MigrationPhaseDetail'
+
+const buildSucceededMigration = (creationTimestamp: string, lastConditionTime: string): Migration =>
+  ({
+    metadata: { creationTimestamp },
+    status: {
+      phase: Phase.Succeeded,
+      conditions: [
+        { type: 'Validated', status: 'True', reason: '', message: '', lastTransitionTime: creationTimestamp },
+        { type: 'Migrated', status: 'True', reason: '', message: '', lastTransitionTime: lastConditionTime },
+      ],
+    },
+  }) as unknown as Migration
+
+describe('MigrationPhaseDetail — success banner total duration', () => {
+  it('includes seconds for a sub-hour total, matching the "Total Elapsed" stat elsewhere (not trimmed)', () => {
+    const { container } = render(
+      <MigrationPhaseDetail
+        migration={buildSucceededMigration('2026-01-01T00:00:00Z', '2026-01-01T00:50:21Z')}
+      />
+    )
+
+    // Case-sensitive: h/m/s must stay lowercase in the actual text content, even though
+    // the surrounding "Migration complete ... total" label is uppercased via CSS
+    // textTransform. Checking full textContent since the duration renders in its own
+    // nested span (to isolate it from that CSS rule), splitting the text across nodes.
+    expect(container.textContent).toContain('Migration complete · 50m 21s total')
+    expect(screen.getByText('50m 21s')).toBeInTheDocument()
+  })
+
+  it('shows hours and minutes (no seconds) for an over-an-hour total', () => {
+    const { container } = render(
+      <MigrationPhaseDetail
+        migration={buildSucceededMigration('2026-01-01T00:00:00Z', '2026-01-01T05:25:00Z')}
+      />
+    )
+
+    expect(container.textContent).toContain('Migration complete · 5h 25m total')
+    expect(screen.getByText('5h 25m')).toBeInTheDocument()
+  })
+})

--- a/ui/src/features/migration/components/detail/MigrationPhaseDetail.tsx
+++ b/ui/src/features/migration/components/detail/MigrationPhaseDetail.tsx
@@ -9,6 +9,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import { Migration, Phase } from '../../api/migrations'
 import { TriggerAdminCutoverButton } from '../TriggerAdminCutover/TriggerAdminCutoverButton'
 import { VJAILBREAK_DEFAULT_NAMESPACE } from 'src/api/constants'
+import { durationBetween } from '../../utils/phaseUtils'
 
 // ─── Copying Disk Blocks ─────────────────────────────────────────────────────
 
@@ -222,17 +223,9 @@ function AwaitingCutoverDetail({
 
 // ─── Success ──────────────────────────────────────────────────────────────────
 
-function calcMigrationElapsed(
-  start: Date | string | undefined,
-  endMs: number
-): string {
+function calcMigrationElapsed(start: Date | string | undefined, endMs: number): string {
   if (!start || !endMs) return ''
-  const diffMs = endMs - new Date(start).getTime()
-  if (diffMs <= 0) return ''
-  const hours = Math.floor(diffMs / 3_600_000)
-  const mins = Math.floor((diffMs % 3_600_000) / 60_000)
-  if (hours > 0) return `${hours}h ${mins}m total`
-  return `${mins}m total`
+  return durationBetween(start, new Date(endMs).toISOString()) ?? ''
 }
 
 function SuccessStatBox({
@@ -315,7 +308,14 @@ function SuccessDetail({ migration }: { migration: Migration }) {
             mb: 0.75,
           }}
         >
-          Migration complete{elapsed ? ` · ${elapsed.toUpperCase()}` : ''}
+          Migration complete
+          {elapsed && (
+            <>
+              {' · '}
+              <Box component="span" sx={{ textTransform: 'none' }}>{elapsed}</Box>
+              {' total'}
+            </>
+          )}
         </Typography>
         <Typography variant="subtitle1" fontWeight={700} sx={{ mb: 0.5 }}>
           {vmName} is running in PCD

--- a/ui/src/features/migration/utils/phaseUtils.test.ts
+++ b/ui/src/features/migration/utils/phaseUtils.test.ts
@@ -71,6 +71,19 @@ describe('derivePhaseStates — Pending/Validating split via PodRunning conditio
     expect(states[0].elapsed).toBe('50m 0s') // Pending: creation -> PodRunning
     expect(states[1].elapsed).toBe('2m 0s') // Validating: PodRunning -> Validated, NOT creation -> Validated (52m)
   })
+
+  it('excludes the Pending wait from Done\'s total - "how long the migration actually took", not since object creation', () => {
+    const conditions = [
+      condition('PodRunning', 50),
+      condition('Validated', 52),
+      { ...condition('DataCopy', 60), reason: 'Copying disk 0' },
+      condition('Migrating', 65),
+      condition('Migrated', 70)
+    ]
+    const states = derivePhaseStates(buildMigration(Phase.Succeeded, conditions))
+
+    expect(states[5].elapsed).toBe('20m 0s') // Done: PodRunning(50) -> Migrated(70), NOT creation(0) -> Migrated(70) (70m)
+  })
 })
 
 describe('derivePhaseStates — admin-initiated cutover via CutoverTriggered condition', () => {
@@ -171,7 +184,7 @@ describe('derivePhaseStates — active migration', () => {
     expect(states[4].status).toBe('pending')
   })
 
-  it('keeps showing total time since creation while paused awaiting admin - unchanged by the Cutover-step fixes', () => {
+  it('shows time elapsed since data copy finished while paused awaiting admin, not cumulative since creation', () => {
     vi.useFakeTimers()
     try {
       vi.setSystemTime(new Date(at(45))) // "now" = 45 minutes after creation
@@ -180,7 +193,7 @@ describe('derivePhaseStates — active migration', () => {
       )
 
       expect(states[3].status).toBe('paused')
-      expect(states[3].elapsed).toBe('45m 0s') // total since creation(0) -> now(45), NOT since DataCopy(30) -> now (15m)
+      expect(states[3].elapsed).toBe('15m 0s') // DataCopy(30) -> now(45): how long cutover has been waiting, NOT creation(0) -> now (45m)
     } finally {
       vi.useRealTimers()
     }
@@ -242,6 +255,18 @@ describe('derivePhaseStates — no phase yet', () => {
 
     expect(states[0].status).toBe('active')
     expect(states.slice(1).every((s) => s.status === 'pending')).toBe(true)
+  })
+
+  it('shows live elapsed time for the queued Pending step, not a blank dash', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date(at(29))) // "now" = 29 minutes after creation
+      const states = derivePhaseStates(buildMigration(undefined, []))
+
+      expect(states[0].elapsed).toBe('29m 0s') // creation(0) -> now(29), same as a running migration's active step
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/ui/src/features/migration/utils/phaseUtils.test.ts
+++ b/ui/src/features/migration/utils/phaseUtils.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest'
-import { derivePhaseStates, getActivePhasIndex, isMigrationFailed } from './phaseUtils'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  derivePhaseStates,
+  getActivePhasIndex,
+  getPhaseColorKey,
+  getPhaseLabel,
+  isMigrationFailed,
+} from './phaseUtils'
 import { Migration, Phase } from '../api/migrations'
 
 // Timeline: creation at T0, then each condition marks the end of a step.
@@ -23,8 +29,8 @@ const buildMigration = (phase: string | undefined, conditions: unknown[]): Migra
 const fullConditions = [
   condition('Validated', 2),
   condition('DataCopy', 30),
-  condition('Migrating', 40), // set when "Converting disk" fires = cutover complete
-  condition('Migrated', 60)
+  condition('Migrating', 40), // set when "Converting disk" fires = cutover complete, conversion starts
+  condition('Migrated', 60) // set when "VM created successfully" fires = conversion + VM creation complete
 ]
 
 describe('derivePhaseStates — succeeded', () => {
@@ -34,18 +40,102 @@ describe('derivePhaseStates — succeeded', () => {
     expect(states.map((s) => s.status)).toEqual(['done', 'done', 'done', 'done', 'done', 'done'])
   })
 
-  it('maps each step to its completion condition', () => {
-    expect(states[1].elapsed).toBe('2m 0s') // Validated
-    expect(states[2].elapsed).toBe('30m 0s') // DataCopy
-    expect(states[3].elapsed).toBe('40m 0s') // Migrating = conversion started = cutover done
-    // Step 4 (converting) also uses Migrating — no condition marks the end of
-    // conversion, so its start is the closest available signal (PR #2092 review).
-    expect(states[4].elapsed).toBe('40m 0s')
-    expect(states[5].elapsed).toBe('1h 0m') // Migrated
+  it('shows each step\'s own duration, not cumulative time since creation (GH #2195)', () => {
+    expect(states[0].elapsed).toBeNull() // Pending: no PodRunning condition (pre-fix migration) -> "-"
+    expect(states[1].elapsed).toBe('2m 0s') // Validating: creation -> Validated (falls back since no PodRunning)
+    expect(states[2].elapsed).toBe('28m 0s') // CopyingBlocks: Validated -> DataCopy
+    expect(states[3].elapsed).toBe('10m 0s') // Cutover: DataCopy -> Migrating
+    expect(states[4].elapsed).toBe('20m 0s') // ConvertingDisk: Migrating -> Migrated
+    expect(states[5].elapsed).toBe('1h 0m') // Done: total time, creation -> Migrated
   })
 
-  it('shows the done step completing after conversion started', () => {
-    expect(states[5].elapsed).not.toBe(states[4].elapsed)
+  it('shows the converting-disk step with its own distinct duration from cutover', () => {
+    expect(states[4].elapsed).not.toBe(states[3].elapsed)
+  })
+})
+
+describe('derivePhaseStates — Pending/Validating split via PodRunning condition', () => {
+  it('measures real Pending wait and real Validating work separately, not bundled together', () => {
+    // Pod object existed from creation, but didn't actually start running until t=50
+    // (e.g. queued behind another migration on the same agent) - that's the real Pending
+    // wait. Validation itself only took 2 more minutes after that.
+    const conditions = [
+      condition('PodRunning', 50),
+      condition('Validated', 52),
+      { ...condition('DataCopy', 60), reason: 'Copying disk 0' },
+      condition('Migrating', 65),
+      condition('Migrated', 70)
+    ]
+    const states = derivePhaseStates(buildMigration(Phase.Succeeded, conditions))
+
+    expect(states[0].elapsed).toBe('50m 0s') // Pending: creation -> PodRunning
+    expect(states[1].elapsed).toBe('2m 0s') // Validating: PodRunning -> Validated, NOT creation -> Validated (52m)
+  })
+})
+
+describe('derivePhaseStates — admin-initiated cutover via CutoverTriggered condition', () => {
+  it('measures Cutover from when admin actually triggered it, not from DataCopy end', () => {
+    // DataCopy finishes at t=13, but admin doesn't click cutover until t=250 (a long
+    // "awaiting admin" wait). The real cutover work (VM power-off, final changed-block
+    // copy) only takes 1 minute after that, until conversion starts at t=251.
+    const conditions = [
+      condition('Validated', 2),
+      { ...condition('DataCopy', 13), reason: 'Copying disk 0' },
+      condition('CutoverTriggered', 250),
+      condition('Migrating', 251),
+      condition('Migrated', 260)
+    ]
+    const states = derivePhaseStates(buildMigration(Phase.Succeeded, conditions))
+
+    expect(states[2].elapsed).toBe('11m 0s') // CopyingBlocks: Validated(2) -> DataCopy(13), unaffected
+    expect(states[3].elapsed).toBe('1m 0s') // Cutover: CutoverTriggered(250) -> Migrating(251), NOT DataCopy(13) -> Migrating(251) (238m)
+  })
+
+  it('falls back to DataCopy end when cutover is not admin-gated (no CutoverTriggered condition)', () => {
+    const states = derivePhaseStates(buildMigration(Phase.Succeeded, fullConditions))
+    // fullConditions has no CutoverTriggered - same as a cold/automatic-cutover migration
+    expect(states[3].elapsed).toBe('10m 0s') // Cutover: DataCopy(30) -> Migrating(40), the existing fallback
+  })
+})
+
+describe('derivePhaseStates — multi-disk DataCopy conditions', () => {
+  it('uses the latest disk-copy completion, not whichever DataCopy entry is first in the array', () => {
+    // 'DataCopy' has one condition entry per disk (reason "Copying disk N"); the array's
+    // storage order is not guaranteed to be chronological. Disk 0 finishes at t=8, disk 1
+    // finishes later at t=13 - here they're stored in chronological (insertion) order, the
+    // case that broke the old `.find()`-first-match code (confirmed live on a real
+    // migration where this exact ordering understated Copying Blocks by 5+ minutes).
+    const conditions = [
+      condition('Validated', 2),
+      { ...condition('DataCopy', 8), reason: 'Copying disk 0' },
+      { ...condition('DataCopy', 13), reason: 'Copying disk 1' },
+      condition('Migrating', 14)
+    ]
+    const states = derivePhaseStates(buildMigration(Phase.ConvertingDisk, conditions))
+
+    expect(states[2].elapsed).toBe('11m 0s') // CopyingBlocks: Validated(2) -> latest DataCopy(13), not the first entry(8)
+    expect(states[3].elapsed).toBe('1m 0s') // Cutover: latest DataCopy(13) -> Migrating(14)
+  })
+})
+
+describe('derivePhaseStates — succeeded DataOnly migration', () => {
+  it('bounds the converting-disk step with DataCopied instead of Migrated, and skips cutover', () => {
+    const dataOnlyConditions = [
+      condition('Validated', 2),
+      condition('DataCopy', 30),
+      condition('Migrating', 40),
+      condition('DataCopied', 50)
+    ]
+    const migration = {
+      metadata: { creationTimestamp: T0 },
+      spec: { dataOnly: true },
+      status: { phase: Phase.DataCopied, conditions: dataOnlyConditions }
+    } as unknown as Migration
+    const states = derivePhaseStates(migration)
+
+    expect(states[3].status).toBe('pending') // cutover skipped for DataOnly
+    expect(states[4].elapsed).toBe('10m 0s') // ConvertingDisk: Migrating -> DataCopied
+    expect(states[5].elapsed).toBe('50m 0s') // Done: total time, creation -> DataCopied
   })
 })
 
@@ -55,9 +145,9 @@ describe('derivePhaseStates — active migration', () => {
 
     expect(states[3].status).toBe('done')
     // Regression: cutover previously mapped to '' and always showed null.
-    expect(states[3].elapsed).toBe('40m 0s')
+    expect(states[3].elapsed).toBe('10m 0s') // DataCopy -> Migrating
     expect(states[1].elapsed).toBe('2m 0s')
-    expect(states[2].elapsed).toBe('30m 0s')
+    expect(states[2].elapsed).toBe('28m 0s') // Validated -> DataCopy
     expect(states[4].status).toBe('active')
     expect(states[5].status).toBe('pending')
   })
@@ -81,6 +171,21 @@ describe('derivePhaseStates — active migration', () => {
     expect(states[4].status).toBe('pending')
   })
 
+  it('keeps showing total time since creation while paused awaiting admin - unchanged by the Cutover-step fixes', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date(at(45))) // "now" = 45 minutes after creation
+      const states = derivePhaseStates(
+        buildMigration(Phase.AwaitingAdminCutOver, [condition('Validated', 2), { ...condition('DataCopy', 30), reason: 'Copying disk 0' }])
+      )
+
+      expect(states[3].status).toBe('paused')
+      expect(states[3].elapsed).toBe('45m 0s') // total since creation(0) -> now(45), NOT since DataCopy(30) -> now (15m)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('treats cutoverTriggered as active, not paused', () => {
     const states = derivePhaseStates(
       buildMigration(Phase.AwaitingAdminCutOver, [condition('Validated', 2)]),
@@ -88,6 +193,24 @@ describe('derivePhaseStates — active migration', () => {
     )
 
     expect(states[3].status).toBe('active')
+  })
+
+  it('measures the currently-active step from its own start boundary, not cumulative since creation', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date(at(45))) // "now" = 45 minutes after creation
+      const conditions = [
+        condition('Validated', 2),
+        { ...condition('DataCopy', 30), reason: 'Copying disk 0' },
+        condition('Migrating', 40)
+      ]
+      const states = derivePhaseStates(buildMigration(Phase.ConvertingDisk, conditions))
+
+      expect(states[4].status).toBe('active')
+      expect(states[4].elapsed).toBe('5m 0s') // ConvertingDisk: Migrating(40) -> now(45), not creation(0) -> now(45) (45m)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 
@@ -97,8 +220,9 @@ describe('derivePhaseStates — failed migration', () => {
     const states = derivePhaseStates(buildMigration(Phase.Failed, conditions))
 
     expect(states[3].status).toBe('done')
-    expect(states[3].elapsed).toBe('40m 0s') // Migrating
+    expect(states[3].elapsed).toBe('10m 0s') // DataCopy -> Migrating
     expect(states[4].status).toBe('failed')
+    expect(states[4].elapsed).toBe('5m 0s') // ConvertingDisk: Migrating(40) -> Failed(45), not creation(0) -> Failed(45) (45m)
     expect(states[5].status).toBe('pending')
   })
 
@@ -118,6 +242,32 @@ describe('derivePhaseStates — no phase yet', () => {
 
     expect(states[0].status).toBe('active')
     expect(states.slice(1).every((s) => s.status === 'pending')).toBe(true)
+  })
+})
+
+describe('getPhaseLabel / getPhaseColorKey', () => {
+  it('reads a falsy phase as Pending, not Unknown (backend never assigns Phase.Unknown)', () => {
+    expect(getPhaseLabel(undefined)).toBe('Pending')
+    expect(getPhaseLabel('')).toBe('Pending')
+    expect(getPhaseColorKey(undefined)).toBe('default')
+    expect(getPhaseColorKey('')).toBe('default')
+  })
+
+  it('still surfaces the real Phase.Unknown value distinctly from a missing phase', () => {
+    expect(getPhaseLabel(Phase.Unknown)).toBe('Unknown')
+    expect(getPhaseColorKey(Phase.Unknown)).toBe('default')
+  })
+
+  it('maps known phases to their labels and colors', () => {
+    expect(getPhaseLabel(Phase.Pending)).toBe('Pending')
+    expect(getPhaseLabel(Phase.Succeeded)).toBe('Succeeded')
+    expect(getPhaseColorKey(Phase.Succeeded)).toBe('success')
+    expect(getPhaseColorKey(Phase.Failed)).toBe('error')
+  })
+
+  it('falls back to showing an unrecognized non-empty phase string as-is', () => {
+    expect(getPhaseLabel('SomeFuturePhase')).toBe('SomeFuturePhase')
+    expect(getPhaseColorKey('SomeFuturePhase')).toBe('info')
   })
 })
 

--- a/ui/src/features/migration/utils/phaseUtils.ts
+++ b/ui/src/features/migration/utils/phaseUtils.ts
@@ -257,9 +257,10 @@ export function derivePhaseStates(
   const creationTs = migration.metadata?.creationTimestamp
 
   if (!phase) {
+    const queuedElapsed = durationBetween(creationTs?.toString(), new Date().toISOString())
     return DESIGN_PHASE_DEFS.map((_, i) =>
       i === 0
-        ? { status: 'active', elapsed: null, detail: 'Queued for agent.', eta: null }
+        ? { status: 'active', elapsed: queuedElapsed, detail: 'Queued for agent.', eta: null }
         : { status: 'pending', elapsed: null, detail: pendingDetail(i), eta: null }
     )
   }
@@ -278,10 +279,15 @@ export function derivePhaseStates(
       if (dataOnly && i === 3) {
         return { status: 'pending', elapsed: null, detail: 'Skipped — no cutover in data-only migration.', eta: null }
       }
+      // Done's total intentionally excludes Pending time (agent-queue wait before the pod
+      // even started running) - it should read as "how long the actual migration work took",
+      // not "how long since the object was created". Falls back to creationTs for migrations
+      // from before the PodRunning condition existed.
+      const doneStart = stepEndTimestamp(conditions, 0, dataOnly) ?? creationTs?.toString()
       const elapsed = i >= 0 && i <= 4
         ? stepElapsed(i, creationTs, conditions, dataOnly)
         : i === 5
-          ? conditionElapsed(creationTs?.toString(), conditions, dataOnly ? 'DataCopied' : 'Migrated')
+          ? conditionElapsed(doneStart, conditions, dataOnly ? 'DataCopied' : 'Migrated')
           : null
       const detail = (dataOnly && i === 5) ? 'Disk copy and conversion complete.' : doneDetail(i, conditions)
       return { status: 'done', elapsed, detail, eta: null }
@@ -319,16 +325,12 @@ export function derivePhaseStates(
       const isPaused =
         (phase === Phase.AwaitingAdminCutOver || phase === Phase.AwaitingCutOverStartTime) &&
         !options?.cutoverTriggered
-      const now = new Date().toISOString()
-      // While paused awaiting admin cutover, keep showing total time elapsed since the
-      // migration began (not just since data copy finished) - this is the "how long has
-      // this whole migration been running" figure users expect to watch tick up while
-      // waiting, and it's what's been shown here all along. Once cutover is actually
-      // triggered (no longer paused), switch to this step's own elapsed like every other
-      // active step.
-      const elapsed = isPaused
-        ? durationBetween(creationTs?.toString(), now)
-        : stepElapsedUntil(i, creationTs, conditions, dataOnly, now)
+      // While paused awaiting admin cutover, this counts up from when data copy actually
+      // finished (i.e. how long cutover has been waiting to be triggered) - not cumulative
+      // since the whole migration began. Once cutover is actually triggered, this naturally
+      // switches basis to CutoverTriggered's own timestamp via stepStartTimestamp's fallback,
+      // same as every other active step's elapsed.
+      const elapsed = stepElapsedUntil(i, creationTs, conditions, dataOnly, new Date().toISOString())
       return {
         status: isPaused ? 'paused' : 'active',
         elapsed,

--- a/ui/src/features/migration/utils/phaseUtils.ts
+++ b/ui/src/features/migration/utils/phaseUtils.ts
@@ -1,5 +1,4 @@
 import { Migration, Phase, Condition } from '../api/migrations'
-import { calculateTimeElapsed } from 'src/utils'
 
 export type PhaseStatus = 'done' | 'active' | 'paused' | 'pending' | 'failed'
 
@@ -70,18 +69,7 @@ function isFailed(phase: Phase): boolean {
   return phase === Phase.Failed || phase === Phase.ValidationFailed
 }
 
-// Extract elapsed duration for a condition type (time from creation to condition transition)
-function conditionElapsed(
-  creationTimestamp: string | Date | undefined,
-  conditions: Condition[],
-  type: string
-): string | null {
-  if (!creationTimestamp) return null
-  const cond = conditions.find((c) => c.type === type)
-  if (!cond?.lastTransitionTime) return null
-  const start = new Date(creationTimestamp).getTime()
-  const end = new Date(cond.lastTransitionTime).getTime()
-  const diffMs = end - start
+function formatDuration(diffMs: number): string | null {
   if (diffMs < 0) return null
   const s = Math.floor(diffMs / 1000)
   const m = Math.floor(s / 60)
@@ -89,6 +77,110 @@ function conditionElapsed(
   if (h > 0) return `${h}h ${m % 60}m`
   if (m > 0) return `${m}m ${s % 60}s`
   return `${s}s`
+}
+
+export function durationBetween(
+  startTimestamp: string | Date | undefined,
+  endTimestamp: string | Date | undefined
+): string | null {
+  if (!startTimestamp || !endTimestamp) return null
+  const start = new Date(startTimestamp).getTime()
+  const end = new Date(endTimestamp).getTime()
+  return formatDuration(end - start)
+}
+
+// Extract elapsed duration for a condition type (time from creation to condition transition).
+// Used for the terminal "Done" step, which intentionally shows total migration time rather
+// than a single step's own duration.
+function conditionElapsed(
+  creationTimestamp: string | Date | undefined,
+  conditions: Condition[],
+  type: string
+): string | null {
+  if (!creationTimestamp) return null
+  const cond = conditions.find((c) => c.type === type)
+  return durationBetween(creationTimestamp, cond?.lastTransitionTime)
+}
+
+// The condition whose lastTransitionTime marks the END of each design-phase step (0-4).
+// Step 0 (Pending) ends on 'PodRunning' - read from the pod's own Status.StartTime - so
+// Pending's real wait (queued for agent capacity) can be measured separately from
+// Validating's real work, instead of Pending always showing nothing and Validating silently
+// absorbing the wait. Step 4 (Converting Disk) ends on 'Migrated' (or 'DataCopied' for
+// DataOnly migrations) - the next condition to fire after 'Migrating' - rather than reusing
+// 'Migrating' itself (which only marks when conversion *started*).
+function stepEndType(step: number, dataOnly: boolean): string | undefined {
+  switch (step) {
+    case 0: return 'PodRunning'
+    case 1: return 'Validated'
+    case 2: return 'DataCopy'
+    case 3: return 'Migrating'
+    case 4: return dataOnly ? 'DataCopied' : 'Migrated'
+    default: return undefined
+  }
+}
+
+// A condition type can have more than one entry - e.g. 'DataCopy' gets one entry per disk
+// (matched by (type, reason) with reason "Copying disk N"), and the array's storage order
+// is not guaranteed to be chronological. Taking the max lastTransitionTime across all
+// matching entries (rather than the first array match) ensures a multi-disk copy's end
+// boundary is really the last disk to finish, not whichever disk happened to be recorded
+// first.
+function stepEndTimestamp(conditions: Condition[], step: number, dataOnly: boolean): string | undefined {
+  const type = stepEndType(step, dataOnly)
+  if (!type) return undefined
+  const matches = conditions.filter((c) => c.type === type && c.lastTransitionTime)
+  if (matches.length === 0) return undefined
+  const latest = matches.reduce((a, b) =>
+    new Date(String(a.lastTransitionTime)).getTime() > new Date(String(b.lastTransitionTime)).getTime() ? a : b
+  )
+  return String(latest.lastTransitionTime)
+}
+
+function stepStartTimestamp(
+  step: number,
+  creationTimestamp: string | Date | undefined,
+  conditions: Condition[],
+  dataOnly: boolean
+): string | undefined {
+  if (step <= 0) return creationTimestamp?.toString()
+  if (step === 3) {
+    // Cutover's real start is when an admin actually triggered it, not when data copy
+    // finished - there can be an arbitrary "awaiting admin" wait in between. Falls back to
+    // DataCopy's end for migrations where cutover isn't admin-gated (no CutoverTriggered
+    // condition ever fires there), or for migrations from before this condition existed.
+    const triggered = conditions.find((c) => c.type === 'CutoverTriggered')
+    if (triggered?.lastTransitionTime) return String(triggered.lastTransitionTime)
+  }
+  return stepEndTimestamp(conditions, step - 1, dataOnly) ?? creationTimestamp?.toString()
+}
+
+// Duration of a single design-phase step: end-of-this-step minus end-of-previous-step
+// (or migration creation time for the first tracked step), not cumulative-since-creation.
+function stepElapsed(
+  step: number,
+  creationTimestamp: string | Date | undefined,
+  conditions: Condition[],
+  dataOnly: boolean
+): string | null {
+  const end = stepEndTimestamp(conditions, step, dataOnly)
+  const start = stepStartTimestamp(step, creationTimestamp, conditions, dataOnly)
+  return durationBetween(start, end)
+}
+
+// Duration of the step currently in progress (active/paused), or the step where a failure
+// occurred: from this step's own start boundary to `until` (now, or the failure time) - not
+// cumulative since the whole migration began. Mirrors stepElapsed's start-boundary logic but
+// takes an explicit end instead of a condition, since the step isn't done yet.
+function stepElapsedUntil(
+  step: number,
+  creationTimestamp: string | Date | undefined,
+  conditions: Condition[],
+  dataOnly: boolean,
+  until: string
+): string | null {
+  const start = stepStartTimestamp(step, creationTimestamp, conditions, dataOnly)
+  return durationBetween(start, until)
 }
 
 function doneDetail(designIndex: number, conditions: Condition[]): string {
@@ -186,34 +278,28 @@ export function derivePhaseStates(
       if (dataOnly && i === 3) {
         return { status: 'pending', elapsed: null, detail: 'Skipped — no cutover in data-only migration.', eta: null }
       }
-      const condType =
-        i === 1 ? 'Validated' :
-        i === 2 ? 'DataCopy' :
-        i === 3 ? 'Migrating' :
-        i === 4 ? 'Migrating' :
-        i === 5 ? (dataOnly ? 'DataCopied' : 'Migrated') : ''
-      const elapsed = conditionElapsed(creationTs?.toString(), conditions, condType) ?? null
+      const elapsed = i >= 0 && i <= 4
+        ? stepElapsed(i, creationTs, conditions, dataOnly)
+        : i === 5
+          ? conditionElapsed(creationTs?.toString(), conditions, dataOnly ? 'DataCopied' : 'Migrated')
+          : null
       const detail = (dataOnly && i === 5) ? 'Disk copy and conversion complete.' : doneDetail(i, conditions)
       return { status: 'done', elapsed, detail, eta: null }
     }
 
     if (failed) {
       if (i < currentIndex) {
-        const condType =
-          i === 1 ? 'Validated' :
-          i === 2 ? 'DataCopy' :
-          i === 3 ? 'Migrating' : ''
         return {
           status: 'done',
-          elapsed: conditionElapsed(creationTs?.toString(), conditions, condType) ?? null,
+          elapsed: stepElapsed(i, creationTs, conditions, dataOnly),
           detail: doneDetail(i, conditions),
           eta: null,
         }
       }
       if (i === currentIndex) {
         const cond = conditions.find((c) => c.type === 'Failed')
-        const elapsed = cond?.lastTransitionTime && creationTs
-          ? calculateTimeElapsed(creationTs.toString(), migration.status)
+        const elapsed = cond?.lastTransitionTime
+          ? stepElapsedUntil(i, creationTs, conditions, dataOnly, String(cond.lastTransitionTime))
           : null
         return { status: 'failed', elapsed, detail: failedDetail(migration, i), eta: null }
       }
@@ -222,13 +308,9 @@ export function derivePhaseStates(
 
     // Active migration
     if (i < currentIndex) {
-      const condType =
-        i === 1 ? 'Validated' :
-        i === 2 ? 'DataCopy' :
-        i === 3 ? 'Migrating' : ''
       return {
         status: 'done',
-        elapsed: conditionElapsed(creationTs?.toString(), conditions, condType) ?? null,
+        elapsed: stepElapsed(i, creationTs, conditions, dataOnly),
         detail: doneDetail(i, conditions),
         eta: null,
       }
@@ -237,9 +319,19 @@ export function derivePhaseStates(
       const isPaused =
         (phase === Phase.AwaitingAdminCutOver || phase === Phase.AwaitingCutOverStartTime) &&
         !options?.cutoverTriggered
+      const now = new Date().toISOString()
+      // While paused awaiting admin cutover, keep showing total time elapsed since the
+      // migration began (not just since data copy finished) - this is the "how long has
+      // this whole migration been running" figure users expect to watch tick up while
+      // waiting, and it's what's been shown here all along. Once cutover is actually
+      // triggered (no longer paused), switch to this step's own elapsed like every other
+      // active step.
+      const elapsed = isPaused
+        ? durationBetween(creationTs?.toString(), now)
+        : stepElapsedUntil(i, creationTs, conditions, dataOnly, now)
       return {
         status: isPaused ? 'paused' : 'active',
-        elapsed: creationTs ? calculateTimeElapsed(creationTs.toString(), migration.status) : null,
+        elapsed,
         detail: activeDetail(migration, i),
         eta: null,
       }
@@ -271,6 +363,11 @@ export function isMigrationFailed(migration: Migration): boolean {
  * Maps K8s Phase to a human-readable status label and semantic color key.
  */
 export function getPhaseLabel(phase: Phase | string | undefined): string {
+  // A Migration's Status.Phase is set to "Pending" the instant it's created (before any
+  // worker pod exists) - the backend never actually assigns Phase.Unknown. A falsy phase
+  // here just means the frontend hasn't received status yet, not a distinct backend state,
+  // so it should read the same as a fresh migration: "Pending".
+  if (!phase) return 'Pending'
   switch (phase) {
     case Phase.Pending:               return 'Pending'
     case Phase.Validating:            return 'Validating'
@@ -290,13 +387,14 @@ export function getPhaseLabel(phase: Phase | string | undefined): string {
     case Phase.DataCopied:            return 'Data Copied'
     case Phase.Failed:                return 'Failed'
     case Phase.Unknown:               return 'Unknown'
-    default:                          return String(phase ?? 'Unknown')
+    default:                          return String(phase)
   }
 }
 
 export type PhaseColorKey = 'info' | 'success' | 'error' | 'warning' | 'default'
 
 export function getPhaseColorKey(phase: Phase | string | undefined): PhaseColorKey {
+  if (!phase) return 'default'
   switch (phase) {
     case Phase.Succeeded:
     case Phase.DataCopied:            return 'success'


### PR DESCRIPTION
## What this PR does / why we need it

- Each stepper step now shows its own duration (delta between boundary conditions), not cumulative time since migration creation.
- Converting Disk no longer reuses the same Migrating condition as Cutover (was producing identical, wrong durations for both) — now bounded by Migrated/DataCopied.
- Multi-disk DataCopy boundary now takes the max lastTransitionTime across all per-disk entries instead of an arbitrary first-array-match, which could silently pick an earlier disk's timestamp.
- Backend: Pending→Validating phase transition now gates on the pod actually being Running/terminal, so Pending reflects real agent-queue wait time instead of bleeding into Validating.
- Backend: added PodRunning condition (from the pod's native Status.StartTime) so Pending/Validating durations split correctly, including after the migration finishes.
- Backend: added CutoverTriggered condition (matches "Admin cutover triggered" events) so Cutover shows real trigger→conversion-start time for admin-gated migrations instead of the entire admin-wait period.
- Active/paused/failed step elapsed now uses each step's own start boundary instead of always cumulative-since-creation; paused (awaiting admin, not yet triggered) intentionally kept showing total-since-creation.
- Status badge no longer shows "Unknown" for a freshly-created migration before status populates — defaults to "Pending" (backend never actually assigns Phase Unknown).
- "Migration Complete" success banner duration formatting fixed — was dropping seconds under an hour and forcing all-caps h/m/s; now reuses the shared formatter with correct casing.
- Detail page subtitle now shows the real vSphere datacenter instead of the VMwareCreds object's name (e.g. "vmware").
- Events tab timeline now includes Created, Migration Started, and Cutover entries (previously only Validated/DataCopy/Migrating/Migrated).
- Added unit test coverage for all of the above.

## Which issue(s) this PR fixes
fixes #2195

## Testing done
<img width="1435" height="808" alt="image" src="https://github.com/user-attachments/assets/1c1fab57-2bb3-41b0-bc6c-4666dc319465" />
<img width="1435" height="813" alt="image" src="https://github.com/user-attachments/assets/01fbe68f-d757-4f7f-9a22-6a0340ae7df2" />
<img width="1436" height="816" alt="image" src="https://github.com/user-attachments/assets/0ea51d1d-eb6c-4884-b86b-67d79acfd32e" />
<img width="1430" height="807" alt="image" src="https://github.com/user-attachments/assets/5a3e5352-1113-42e9-9b70-6356373293a6" />
<img width="1439" height="811" alt="image" src="https://github.com/user-attachments/assets/f4e6d7d1-a218-4344-81ed-b08426d8e82f" />
<img width="1440" height="814" alt="image" src="https://github.com/user-attachments/assets/f88034fc-b82b-4556-adef-83799d541c49" />
<img width="1440" height="716" alt="image" src="https://github.com/user-attachments/assets/0a9f622d-4741-4de8-905e-997a9d803cb0" />
<img width="1437" height="806" alt="image" src="https://github.com/user-attachments/assets/8bebd184-3f8d-43de-861d-049fbd637e72" />
