### PR TITLE
[2213] Fix: Migration phase permanently frozen at Failed from transient kubelet events

### DIFF
--- a/k8s/migration/internal/controller/migration_controller.go
+++ b/k8s/migration/internal/controller/migration_controller.go
@@ -408,6 +408,9 @@ func (r *MigrationReconciler) SetupMigrationPhase(ctx context.Context, scope *sc
 
 loop:
 	for i := range events.Items {
+		if !isMigrationAppEvent(events.Items[i]) {
+			continue
+		}
 		switch {
 		// In reverse order, because the events are sorted by timestamp latest to oldest
 		case strings.Contains(events.Items[i].Message, constants.EventMessageMigrationSucessful) &&
@@ -580,6 +583,11 @@ func isPodRunningOrTerminal(pod *corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodRunning ||
 		pod.Status.Phase == corev1.PodFailed ||
 		pod.Status.Phase == corev1.PodSucceeded
+}
+
+// isMigrationAppEvent reports whether an event was emitted by v2v-helper itself.
+func isMigrationAppEvent(event corev1.Event) bool {
+	return event.Reason == constants.MigrationReason
 }
 
 // GetPod retrieves the pod associated with a migration

--- a/k8s/migration/internal/controller/migration_controller_test.go
+++ b/k8s/migration/internal/controller/migration_controller_test.go
@@ -106,3 +106,34 @@ func TestIsPodRunningOrTerminal(t *testing.T) {
 		})
 	}
 }
+
+func TestIsMigrationAppEvent(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		want   bool
+	}{
+		{name: "v2v-helper's own event is accepted", reason: "Migration", want: true},
+		{
+			// A kubelet image-pull-retry event's Reason is "Failed",
+			// not "Migration" — even though its Message text can coincidentally contain
+			// "Failed to pull image...", which SetupMigrationPhase's keyword matching would
+			// otherwise mistake for a real migration failure.
+			name:   "kubelet image-pull-failure event is rejected",
+			reason: "Failed",
+			want:   false,
+		},
+		{name: "kubelet scheduling-backoff event is rejected", reason: "FailedScheduling", want: false},
+		{name: "kubelet image-pull-backoff event is rejected", reason: "BackOff", want: false},
+		{name: "empty reason is rejected", reason: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := corev1.Event{Reason: tt.reason}
+			if got := isMigrationAppEvent(event); got != tt.want {
+				t.Errorf("isMigrationAppEvent(reason=%q) = %v, want %v", tt.reason, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it
`SetupMigrationPhase` scanned every Kubernetes Event attached to a migration's pod for keywords like "Failed to", without checking who wrote the event. Kubelet's own routine events (image pull retries, scheduling backoff) can contain that same text ("Failed to pull image...") — got mistaken for a real migration failure, permanently locking Status.`Phase = Failed` before the migration even started real work. Once locked, the controller stops reconciling that object entirely — so even a later, genuine failure (or a successful migration) never gets reflected.

Added filters on event.Reason == "Migration" before trusting the text to know who is sending this event.

## Which issue(s) this PR fixes
fixes #2213 

## Testing done
<img width="1440" height="497" alt="image" src="https://github.com/user-attachments/assets/4f23d143-c81e-4e33-9caa-9f5d423dca3c" />
<img width="1436" height="836" alt="image" src="https://github.com/user-attachments/assets/7bf4b862-710b-4a27-b291-1a0ed95c6a4f" />
<img width="1440" height="813" alt="image" src="https://github.com/user-attachments/assets/68be71b5-4bc4-4b21-af2e-de1d5ce87be7" />
<img width="1436" height="866" alt="image" src="https://github.com/user-attachments/assets/1c438590-e279-46ed-a779-c2d7cf5fa55e" />
