### PR TITLE
[2257] Fix migration failure when the guest root filesystem spans multiple disks

### DIFF
--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1174,18 +1174,6 @@ func (migobj *Migrate) LiveReplicateDisks(ctx context.Context, vminfo vm.VMInfo)
 	return vminfo, nil
 }
 
-// getBootCommand returns the appropriate command to detect boot volume based on OS type
-func (migobj *Migrate) getBootCommand(osType string) string {
-	switch strings.ToLower(osType) {
-	case constants.OSFamilyWindows:
-		return "ls /Windows"
-	case constants.OSFamilyLinux:
-		return "ls /boot"
-	default:
-		return "inspect-os"
-	}
-}
-
 // attachAllVolumes attaches all volumes and updates their paths in vminfo
 func (migobj *Migrate) attachAllVolumes(ctx context.Context, vminfo *vm.VMInfo) error {
 	for idx, vmdisk := range vminfo.VMDisks {
@@ -1196,43 +1184,6 @@ func (migobj *Migrate) attachAllVolumes(ctx context.Context, vminfo *vm.VMInfo) 
 		vminfo.VMDisks[idx].Path = path
 	}
 	return nil
-}
-
-// detectBootVolume confirms the guest is inspectable with every disk attached and
-// returns whatever the boot-detection command reported.
-//
-// All disks are attached for a single probe. Probing them one at a time cannot
-// work when the root filesystem spans several disks - a multi-device btrfs, an
-// LVM VG across two PVs, or mdraid - because none of the disks is individually
-// mountable. That used to surface as a bare "No boot volume detected" warning
-// with the real cause discarded.
-//
-// The concrete boot disk index is always re-derived afterwards by
-// handleLinuxOSDetection or handleWindowsBootDetection, so this function does not
-// try to guess it.
-func (migobj *Migrate) detectBootVolume(vminfo vm.VMInfo, getBootCommand string) (bootVolumeIndex int, osPath string, err error) {
-	bootVolumeIndex = -1
-
-	utils.PrintLog(fmt.Sprintf("Detecting boot volume (UEFI: %t)", vminfo.UEFI))
-
-	if len(vminfo.VMDisks) == 0 {
-		utils.PrintLog("WARNING: No disks attached; cannot detect boot volume")
-		return -1, "", nil
-	}
-
-	ans, cmdErr := virtv2v.RunCommandInGuestAllVolumes(vminfo.VMDisks, getBootCommand, false)
-	if cmdErr != nil {
-		// Not fatal - the OS-specific handlers re-derive the boot disk and will
-		// fail with a more specific error if the guest is genuinely unusable.
-		utils.PrintLog(fmt.Sprintf("WARNING: No boot volume detected: %v", cmdErr))
-		return -1, "", nil
-	}
-
-	osPath = strings.TrimSpace(ans)
-	utils.PrintLog(fmt.Sprintf("Guest inspected successfully across %d disk(s); boot disk index is resolved during OS detection",
-		len(vminfo.VMDisks)))
-
-	return bootVolumeIndex, osPath, nil
 }
 
 // handleLinuxOSDetection handles OS detection and validation for Linux systems
@@ -1681,9 +1632,6 @@ func blockDriverFromMetadata(metadata map[string]string) string {
 func (migobj *Migrate) ConvertVolumes(ctx context.Context, vminfo vm.VMInfo) (int, error) {
 	migobj.logMessage("Converting disk")
 
-	// Step 1: Determine boot command based on OS type
-	getBootCommand := migobj.getBootCommand(vminfo.OSType)
-
 	// Step 2: Attach all volumes
 	if err := migobj.attachAllVolumes(ctx, &vminfo); err != nil {
 		return -1, err
@@ -1700,11 +1648,12 @@ func (migobj *Migrate) ConvertVolumes(ctx context.Context, vminfo vm.VMInfo) (in
 		return -1, errors.Wrap(err, "failed to get vjailbreak settings")
 	}
 
-	// Step 4: Detect boot volume
-	bootVolumeIndex, osPath, err := migobj.detectBootVolume(vminfo, getBootCommand)
-	if err != nil {
-		return -1, err
-	}
+	// Step 4: The boot disk index and OS path are both derived by the OS-specific
+	// handlers in step 5. There used to be a probe here that ran a guestfish
+	// command per disk, but every one of its results was overwritten below, so it
+	// only cost appliance boots.
+	bootVolumeIndex, osPath := -1, ""
+	utils.PrintLog(fmt.Sprintf("Detecting boot volume (UEFI: %t)", vminfo.UEFI))
 
 	// Step 5: Handle OS-specific detection and validation
 	var osRelease string

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1648,10 +1648,9 @@ func (migobj *Migrate) ConvertVolumes(ctx context.Context, vminfo vm.VMInfo) (in
 		return -1, errors.Wrap(err, "failed to get vjailbreak settings")
 	}
 
-	// Step 4: The boot disk index and OS path are both derived by the OS-specific
-	// handlers in step 5. There used to be a probe here that ran a guestfish
-	// command per disk, but every one of its results was overwritten below, so it
-	// only cost appliance boots.
+	// Step 4: both values are derived by the OS-specific handlers in step 5. A
+	// per-disk guestfish probe used to run here, but everything it returned was
+	// overwritten below, so it only cost appliance boots.
 	bootVolumeIndex, osPath := -1, ""
 	utils.PrintLog(fmt.Sprintf("Detecting boot volume (UEFI: %t)", vminfo.UEFI))
 

--- a/v2v-helper/migrate/migrate.go
+++ b/v2v-helper/migrate/migrate.go
@@ -1198,27 +1198,39 @@ func (migobj *Migrate) attachAllVolumes(ctx context.Context, vminfo *vm.VMInfo) 
 	return nil
 }
 
-// detectBootVolume identifies which volume contains the boot partition
+// detectBootVolume confirms the guest is inspectable with every disk attached and
+// returns whatever the boot-detection command reported.
+//
+// All disks are attached for a single probe. Probing them one at a time cannot
+// work when the root filesystem spans several disks - a multi-device btrfs, an
+// LVM VG across two PVs, or mdraid - because none of the disks is individually
+// mountable. That used to surface as a bare "No boot volume detected" warning
+// with the real cause discarded.
+//
+// The concrete boot disk index is always re-derived afterwards by
+// handleLinuxOSDetection or handleWindowsBootDetection, so this function does not
+// try to guess it.
 func (migobj *Migrate) detectBootVolume(vminfo vm.VMInfo, getBootCommand string) (bootVolumeIndex int, osPath string, err error) {
 	bootVolumeIndex = -1
 
 	utils.PrintLog(fmt.Sprintf("Detecting boot volume (UEFI: %t)", vminfo.UEFI))
 
-	for idx := range vminfo.VMDisks {
-		ans, cmdErr := virtv2v.RunCommandInGuest(vminfo.VMDisks[idx].Path, getBootCommand, false)
-		if cmdErr != nil || ans == "" {
-			continue
-		}
-
-		utils.PrintLog(fmt.Sprintf("Boot volume detected: Disk %d (%s)", idx, vminfo.VMDisks[idx].Name))
-		osPath = strings.TrimSpace(ans)
-		bootVolumeIndex = idx
-		break
+	if len(vminfo.VMDisks) == 0 {
+		utils.PrintLog("WARNING: No disks attached; cannot detect boot volume")
+		return -1, "", nil
 	}
 
-	if bootVolumeIndex < 0 {
-		utils.PrintLog("WARNING: No boot volume detected")
+	ans, cmdErr := virtv2v.RunCommandInGuestAllVolumes(vminfo.VMDisks, getBootCommand, false)
+	if cmdErr != nil {
+		// Not fatal - the OS-specific handlers re-derive the boot disk and will
+		// fail with a more specific error if the guest is genuinely unusable.
+		utils.PrintLog(fmt.Sprintf("WARNING: No boot volume detected: %v", cmdErr))
+		return -1, "", nil
 	}
+
+	osPath = strings.TrimSpace(ans)
+	utils.PrintLog(fmt.Sprintf("Guest inspected successfully across %d disk(s); boot disk index is resolved during OS detection",
+		len(vminfo.VMDisks)))
 
 	return bootVolumeIndex, osPath, nil
 }

--- a/v2v-helper/virtv2v/guestfish.go
+++ b/v2v-helper/virtv2v/guestfish.go
@@ -4,18 +4,15 @@ package virtv2v
 
 // Mount-plan resolution for guestfish.
 //
-// guestfish's -i option aborts with "multi-boot operating systems are not
-// supported" whenever inspect_os() returns more than one root (libguestfs
-// common/options/inspect.c). It counts roots; it does not compare operating
-// systems. A btrfs filesystem spanning several devices trips it, because every
-// member carries a full superblock and libblkid has no "btrfs_member" type for
-// libguestfs' "_member" filter to catch (libguestfs daemon/listfs.ml).
+// guestfish's -i aborts with "multi-boot operating systems are not supported"
+// whenever inspect_os() returns more than one root (common/options/inspect.c).
+// It counts roots, it does not compare them, so a btrfs filesystem spanning
+// several devices trips it: every member carries a full superblock and libblkid
+// has no "btrfs_member" type for libguestfs' "_member" filter (daemon/listfs.ml).
 //
-// So we resolve the mounts ourselves: enumerate roots without -i, collapse roots
-// that are members of one filesystem by UUID, then mount explicitly. The mount
-// sequence mirrors inspect_mount_root() - shortest mount point first, a failed
-// "/" is fatal, everything else best effort - so a single-root guest gets
-// exactly what -i was already doing.
+// Instead we enumerate roots without -i, collapse members of one filesystem by
+// UUID, and mount explicitly, mirroring inspect_mount_root: shortest mount point
+// first, a failed "/" fatal, everything else best effort.
 
 import (
 	"bytes"
@@ -42,14 +39,10 @@ const (
 // guestfishCmd is one command in a batch. Tolerate prefixes it with "-" so a
 // failure does not abort the rest of the batch.
 //
-// Batched commands must NOT be ones libguestfs declares as RBufferOut: those
-// print with full_write(1, ...), writing straight to fd 1 and bypassing the
-// stdio buffer that `echo` uses (generator/fish.ml). With stdout on a pipe that
-// buffer is not flushed per line, so an RBufferOut result overtakes the markers
-// still sitting in it and splitGuestfishBatchOutput attributes output to the
-// wrong command. Everything used here (RString, RBool, RInt, RStringList,
-// RHashtable, RErr) goes through printf, so ordering holds. Watch out for
-// "read-file", which is RBufferOut - use "cat" (RString) instead.
+// Never batch an RBufferOut command: those write straight to fd 1 with
+// full_write(), bypassing the stdio buffer `echo` uses (generator/fish.ml), so
+// their output overtakes the markers and lands in the wrong slot. "read-file" is
+// RBufferOut; "cat" is RString and is safe.
 type guestfishCmd struct {
 	Name     string
 	Args     []string
@@ -87,9 +80,8 @@ func parseInspectOSOutput(out string) []string {
 	return roots
 }
 
-// parseMountpointsOutput parses `inspect-get-mountpoints`. guestfish renders a
-// hashtable as "key: value" per line and this one is keyed by mount point, so a
-// line reads "/boot: /dev/sda2". The value may contain a colon of its own.
+// parseMountpointsOutput parses `inspect-get-mountpoints`, which guestfish
+// renders as "mountpoint: device" per line. The device may contain a colon.
 func parseMountpointsOutput(out string) []mountSpec {
 	var specs []mountSpec
 	for _, line := range strings.Split(out, "\n") {
@@ -112,8 +104,7 @@ func parseMountpointsOutput(out string) []mountSpec {
 }
 
 // quoteGuestfishArg double-quotes an argument for guestfish's stdin parser.
-// Backslash is escaped first, or a path containing "\n" would be reinterpreted
-// as a newline.
+// Backslash is escaped first, or "\n" in a path becomes a newline.
 func quoteGuestfishArg(s string) string {
 	var b strings.Builder
 	b.Grow(len(s) + 2)
@@ -163,9 +154,8 @@ func buildGuestfishMountScript(plan mountPlan, write bool) string {
 	var b strings.Builder
 	b.WriteString("run\n")
 	for _, spec := range plan.Mounts {
-		// A "-" prefix stops guestfish exiting if that one command fails.
-		// inspect-get-mountpoints may return absent or unmountable filesystems,
-		// and inspect_mount_root ignores those for everything except "/".
+		// "-" stops guestfish exiting if that one command fails; fstab can name
+		// filesystems that are absent, and inspect_mount_root tolerates those.
 		if spec.MountPoint != "/" {
 			b.WriteString("- ")
 		}
@@ -175,10 +165,9 @@ func buildGuestfishMountScript(plan mountPlan, write bool) string {
 	return b.String()
 }
 
-// buildGuestfishBatchScript renders several commands into one script, separated
-// by echo markers so the outputs can be split apart again. Every guestfish
-// invocation boots the supermin appliance, so batching independent commands is
-// the difference between one boot and N.
+// buildGuestfishBatchScript renders several commands into one script separated by
+// echo markers. Each guestfish invocation boots the appliance (~25s), so batching
+// independent commands is the difference between one boot and N.
 func buildGuestfishBatchScript(plan mountPlan, write bool, cmds []guestfishCmd) string {
 	var b strings.Builder
 	b.WriteString(buildGuestfishMountScript(plan, write))
@@ -230,17 +219,15 @@ func splitGuestfishBatchOutput(out string, n int) []string {
 	return results
 }
 
-// buildPlanProbeScript asks each candidate root for its UUID and mount points.
-// Both are error tolerant so one unusable root cannot abort the probe, and both
-// are wrapped in markers so interleaved output can be attributed back.
+// buildPlanProbeScript asks each candidate root for its UUID and mount points,
+// error tolerant so one unusable root cannot abort the probe.
 func buildPlanProbeScript(roots []string) string {
 	var b strings.Builder
 	b.WriteString("run\n")
-	// inspect-get-mountpoints reads the inspection data that only inspect-os
-	// populates (daemon/inspect.ml search_for_root), and that state does not
-	// survive across guestfish processes - so it has to be re-run here or every
-	// mountpoints query fails with "no inspection data". Its output lands before
-	// the first marker and is discarded by parsePlanProbeOutput.
+	// Required: inspect-get-mountpoints reads state only inspect-os populates, and
+	// that state does not survive across guestfish processes. Without this every
+	// mountpoints query fails with "no inspection data" and plans lose /boot.
+	// Output lands before the first marker, so the parser discards it.
 	b.WriteString("inspect-os\n")
 	for _, root := range roots {
 		fmt.Fprintf(&b, "echo %s %s\n", planProbeUUIDMarker, quoteGuestfishArg(root))
@@ -327,9 +314,9 @@ func groupRootsByUUID(roots []string, uuids map[string]string) [][]string {
 	return groups
 }
 
-// rootPreferenceRank ranks representatives of one filesystem, lower being
-// better. Any member mounts the same filesystem, but downstream part-to-dev,
-// device-index and fstab handling assume a partition.
+// rootPreferenceRank ranks representatives of one filesystem, lower being better.
+// Any member mounts the same filesystem, but downstream part-to-dev and
+// device-index assume a partition.
 func rootPreferenceRank(root string) int {
 	switch {
 	case strings.Contains(root, ":"): // a mountable such as btrfsvol:...
@@ -506,10 +493,8 @@ func resolveMountPlan(disks []vm.VMDisk) (mountPlan, error) {
 }
 
 // runCommandsInGuestAllVolumes runs several commands in ONE appliance boot and
-// returns their outputs in order, verbatim. Unlike RunCommandInGuestAllVolumes
-// the output is NOT lowercased, because some of it is device paths that may
-// legitimately contain upper case (e.g. an LVM volume group named VolGroup00).
-// The returned slice always has one entry per command, even on error.
+// returns one output per command, in order and verbatim. Not lowercased, unlike
+// RunCommandInGuestAllVolumes: device paths can be upper case (VolGroup00).
 func runCommandsInGuestAllVolumes(disks []vm.VMDisk, write bool, cmds ...guestfishCmd) ([]string, error) {
 	if len(cmds) == 0 {
 		return nil, nil

--- a/v2v-helper/virtv2v/guestfish.go
+++ b/v2v-helper/virtv2v/guestfish.go
@@ -4,42 +4,18 @@ package virtv2v
 
 // Mount-plan resolution for guestfish.
 //
-// Why this file exists
-// -------------------
-// Every guest operation used to run `guestfish -a ... -i`, where -i is
-// libguestfs' "inspector" option. -i calls guestfs_inspect_os() and then aborts
-// outright if more than one root is returned:
+// guestfish's -i option aborts with "multi-boot operating systems are not
+// supported" whenever inspect_os() returns more than one root (libguestfs
+// common/options/inspect.c). It counts roots; it does not compare operating
+// systems. A btrfs filesystem spanning several devices trips it, because every
+// member carries a full superblock and libblkid has no "btrfs_member" type for
+// libguestfs' "_member" filter to catch (libguestfs daemon/listfs.ml).
 //
-//	if (roots[1] != NULL) {
-//	    fprintf (stderr, _("%s: multi-boot operating systems are not supported\n" ...
-//	    exit (EXIT_FAILURE);
-//	}
-//	                                   -- libguestfs common/options/inspect.c
-//
-// That check counts roots; it does not compare operating systems. A btrfs
-// filesystem spanning several devices therefore trips it, because btrfs writes a
-// complete superblock (same fsid, different device UUID) to every member device
-// and libblkid has no "btrfs_member" type to distinguish a member from a
-// standalone filesystem. libguestfs' own guard against container devices is a
-// string test on the blkid type:
-//
-//	else if String.ends_with "_member" vfs_type then ()
-//	                                   -- libguestfs daemon/listfs.ml
-//
-// which catches LVM2_member, linux_raid_member and zfs_member but structurally
-// cannot catch btrfs. So `btrfs device add /dev/sdb /` on an otherwise ordinary
-// guest makes inspect_os() report the same root twice - once per member - and
-// every guestfish call in the migration fails.
-//
-// What we do instead
-// ------------------
-// Resolve the mount plan ourselves: enumerate roots without -i (so nothing can
-// abort), collapse roots that are members of one filesystem by comparing the
-// filesystem UUID, then mount explicitly. The mount sequence deliberately
-// mirrors inspect_mount_root() in common/options/inspect.c - shortest mount
-// point first, a failed "/" is fatal, every other mount point is best effort -
-// so that for the common single-root guest the result is byte-for-byte what -i
-// was already doing.
+// So we resolve the mounts ourselves: enumerate roots without -i, collapse roots
+// that are members of one filesystem by UUID, then mount explicitly. The mount
+// sequence mirrors inspect_mount_root() - shortest mount point first, a failed
+// "/" is fatal, everything else best effort - so a single-root guest gets
+// exactly what -i was already doing.
 
 import (
 	"bytes"
@@ -49,52 +25,47 @@ import (
 	"os"
 	"os/exec"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/platform9/vjailbreak/v2v-helper/vm"
 )
 
-// Markers used to delimit per-root sections in the probe script's output. They
-// are emitted with guestfish's `echo` builtin, which simply prints its
-// arguments (fish/echo.c), so they arrive on stdout interleaved with the
-// command output in a predictable order.
+// Section markers, emitted with guestfish's `echo` builtin.
 const (
-	planProbeUUIDMarker = "---VJB-UUID---"
-	planProbeMPMarker   = "---VJB-MP---"
+	planProbeUUIDMarker  = "---VJB-UUID---"
+	planProbeMPMarker    = "---VJB-MP---"
+	guestfishBatchMarker = "---VJB-CMD---"
 )
 
-// mountSpec is a single filesystem to mount inside the guestfish appliance.
-type mountSpec struct {
-	// Device is a libguestfs mountable: usually a device such as "/dev/sda6",
-	// but possibly a subvolume mountable such as "btrfsvol:/dev/sda6/@/home".
-	Device string
-	// MountPoint is the guest path, e.g. "/" or "/boot".
-	MountPoint string
-	// Options are mount options, empty in almost all cases.
-	Options string
+// guestfishCmd is one command in a batch. Tolerate prefixes it with "-" so a
+// failure does not abort the rest of the batch.
+type guestfishCmd struct {
+	Name     string
+	Args     []string
+	Tolerate bool
 }
 
-// mountPlan is what `guestfish -i` would have mounted, computed explicitly.
+type mountSpec struct {
+	// Device is a libguestfs mountable: "/dev/sda6", or "btrfsvol:/dev/sda6/@/home".
+	Device     string
+	MountPoint string
+	Options    string
+}
+
 type mountPlan struct {
-	// Root is the mountable chosen to represent the guest's root filesystem.
-	Root string
-	// Mounts is ordered shortest mount point first.
+	Root   string
 	Mounts []mountSpec
 }
 
-// mountPlanCache memoises the plan per set of disks. Resolving it costs two
-// appliance boots, and the disks do not change identity within a migration.
+// Resolving a plan costs two appliance boots and the disks do not change
+// identity within a migration, so memoise per disk set.
 var (
 	mountPlanCacheMu sync.Mutex
 	mountPlanCache   = map[string]mountPlan{}
 )
 
-// ---------------------------------------------------------------------------
-// Pure helpers
-// ---------------------------------------------------------------------------
-
-// parseInspectOSOutput turns `inspect-os` output into a list of roots.
 func parseInspectOSOutput(out string) []string {
 	var roots []string
 	for _, line := range strings.Split(out, "\n") {
@@ -107,10 +78,9 @@ func parseInspectOSOutput(out string) []string {
 	return roots
 }
 
-// parseMountpointsOutput parses `inspect-get-mountpoints` output. guestfish
-// renders a hashtable as "key: value" per line (print_table in fish/fish.c) and
-// this hashtable is keyed by mount point, so a line reads "/boot: /dev/sda2".
-// The value may itself contain a colon, hence the split on the first ": ".
+// parseMountpointsOutput parses `inspect-get-mountpoints`. guestfish renders a
+// hashtable as "key: value" per line and this one is keyed by mount point, so a
+// line reads "/boot: /dev/sda2". The value may contain a colon of its own.
 func parseMountpointsOutput(out string) []mountSpec {
 	var specs []mountSpec
 	for _, line := range strings.Split(out, "\n") {
@@ -133,9 +103,8 @@ func parseMountpointsOutput(out string) []mountSpec {
 }
 
 // quoteGuestfishArg double-quotes an argument for guestfish's stdin parser.
-// Inside double quotes guestfish interprets backslash escapes (\n, \t, \", \\ -
-// see the QUOTING section of guestfish(1)), so the backslash itself has to be
-// escaped first or a Windows-style path would be mangled.
+// Backslash is escaped first, or a path containing "\n" would be reinterpreted
+// as a newline.
 func quoteGuestfishArg(s string) string {
 	var b strings.Builder
 	b.Grow(len(s) + 2)
@@ -152,8 +121,6 @@ func quoteGuestfishArg(s string) string {
 	return b.String()
 }
 
-// formatGuestfishCommand renders one guestfish command line, quoting every
-// argument so that an argument containing spaces stays a single token.
 func formatGuestfishCommand(command string, args ...string) string {
 	var b strings.Builder
 	b.WriteString(command)
@@ -164,8 +131,8 @@ func formatGuestfishCommand(command string, args ...string) string {
 	return b.String()
 }
 
-// mountCommandLine renders the guestfish command that mounts one filesystem.
-// Read-only callers must use mount-ro because the drives were added with --ro.
+// mountCommandLine renders one mount. Read-only callers must use mount-ro
+// because the drives were added with --ro.
 func mountCommandLine(spec mountSpec, write bool) string {
 	if spec.Options != "" {
 		options := spec.Options
@@ -181,18 +148,15 @@ func mountCommandLine(spec mountSpec, write bool) string {
 	return formatGuestfishCommand(command, spec.Device, spec.MountPoint)
 }
 
-// buildGuestfishMountScript renders the preamble every guestfish invocation
-// needs: launch the appliance, then mount the plan. Callers append their own
-// command lines to the result.
+// buildGuestfishMountScript renders the preamble every invocation needs. Callers
+// append their own command lines.
 func buildGuestfishMountScript(plan mountPlan, write bool) string {
 	var b strings.Builder
 	b.WriteString("run\n")
 	for _, spec := range plan.Mounts {
-		// Prefixing a command with "-" tells guestfish not to exit if that one
-		// command fails (guestfish(1), EXIT ON ERROR BEHAVIOUR). inspect-get-
-		// mountpoints is explicitly documented as possibly returning
-		// filesystems that are absent or unmountable, and inspect_mount_root
-		// ignores those failures for everything except "/", so we do the same.
+		// A "-" prefix stops guestfish exiting if that one command fails.
+		// inspect-get-mountpoints may return absent or unmountable filesystems,
+		// and inspect_mount_root ignores those for everything except "/".
 		if spec.MountPoint != "/" {
 			b.WriteString("- ")
 		}
@@ -202,10 +166,64 @@ func buildGuestfishMountScript(plan mountPlan, write bool) string {
 	return b.String()
 }
 
-// buildPlanProbeScript asks, for every candidate root, its filesystem UUID and
-// its mount points. Both queries are error tolerant so that one unusable root
-// cannot abort the whole probe, and both are wrapped in echo markers so the
-// interleaved output can be attributed back to the right root.
+// buildGuestfishBatchScript renders several commands into one script, separated
+// by echo markers so the outputs can be split apart again. Every guestfish
+// invocation boots the supermin appliance, so batching independent commands is
+// the difference between one boot and N.
+func buildGuestfishBatchScript(plan mountPlan, write bool, cmds []guestfishCmd) string {
+	var b strings.Builder
+	b.WriteString(buildGuestfishMountScript(plan, write))
+	for i, c := range cmds {
+		fmt.Fprintf(&b, "echo %s %d\n", guestfishBatchMarker, i)
+		if c.Tolerate {
+			b.WriteString("- ")
+		}
+		b.WriteString(formatGuestfishCommand(c.Name, c.Args...))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// splitGuestfishBatchOutput returns one entry per command, in order. Commands
+// that produced nothing - including tolerated failures - come back empty.
+func splitGuestfishBatchOutput(out string, n int) []string {
+	results := make([]string, n)
+	idx := -1
+	var buf []string
+
+	flush := func() {
+		if idx >= 0 && idx < n {
+			results[idx] = strings.TrimSpace(strings.Join(buf, "\n"))
+		}
+		buf = nil
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, guestfishBatchMarker) {
+			flush()
+			v, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(trimmed, guestfishBatchMarker)))
+			if err != nil {
+				idx = -1
+			} else {
+				idx = v
+			}
+			continue
+		}
+		// Keep the line verbatim: this may be file contents, where blank lines
+		// and indentation matter. Only the joined result gets trimmed.
+		if idx >= 0 {
+			buf = append(buf, line)
+		}
+	}
+	flush()
+
+	return results
+}
+
+// buildPlanProbeScript asks each candidate root for its UUID and mount points.
+// Both are error tolerant so one unusable root cannot abort the probe, and both
+// are wrapped in markers so interleaved output can be attributed back.
 func buildPlanProbeScript(roots []string) string {
 	var b strings.Builder
 	b.WriteString("run\n")
@@ -218,9 +236,6 @@ func buildPlanProbeScript(roots []string) string {
 	return b.String()
 }
 
-// parsePlanProbeOutput splits probe output back into per-root UUIDs and mount
-// points. A root whose UUID query failed maps to "", which groupRootsByUUID
-// treats as "identity unknown" rather than "same as other unknowns".
 func parsePlanProbeOutput(out string) (map[string]string, map[string][]mountSpec) {
 	uuids := make(map[string]string)
 	mounts := make(map[string][]mountSpec)
@@ -262,7 +277,6 @@ func parsePlanProbeOutput(out string) (map[string]string, map[string][]mountSpec
 			section = sectionMountpoints
 			current = strings.TrimSpace(strings.TrimPrefix(trimmed, planProbeMPMarker))
 		case trimmed == "":
-			// Ignore blank lines inside a section.
 		default:
 			if current != "" {
 				buf = append(buf, trimmed)
@@ -274,10 +288,8 @@ func parsePlanProbeOutput(out string) (map[string]string, map[string][]mountSpec
 	return uuids, mounts
 }
 
-// groupRootsByUUID groups roots that are the same physical filesystem. For
-// btrfs the filesystem UUID is the fsid, identical on every member device, so
-// two members of one filesystem land in one group while a genuine dual-boot
-// guest keeps its roots apart. First-appearance order is preserved.
+// groupRootsByUUID groups roots that are the same physical filesystem. For btrfs
+// the filesystem UUID is the fsid, identical on every member device.
 func groupRootsByUUID(roots []string, uuids map[string]string) [][]string {
 	var groups [][]string
 	indexByUUID := make(map[string]int)
@@ -285,8 +297,7 @@ func groupRootsByUUID(roots []string, uuids map[string]string) [][]string {
 	for _, root := range roots {
 		uuid := strings.ToLower(strings.TrimSpace(uuids[root]))
 		if uuid == "" {
-			// Identity unknown: we cannot prove this is the same filesystem as
-			// anything else, so never merge it.
+			// Identity unknown, so never merge it.
 			groups = append(groups, []string{root})
 			continue
 		}
@@ -301,15 +312,12 @@ func groupRootsByUUID(roots []string, uuids map[string]string) [][]string {
 	return groups
 }
 
-// rootPreferenceRank ranks candidate representatives of one filesystem, lower
-// being better. Any member mounts the same filesystem so guestfish is
-// indifferent, but downstream part-to-dev, device-index and fstab handling all
-// assume a partition, so a partition beats a bare member disk.
+// rootPreferenceRank ranks representatives of one filesystem, lower being
+// better. Any member mounts the same filesystem, but downstream part-to-dev,
+// device-index and fstab handling assume a partition.
 func rootPreferenceRank(root string) int {
 	switch {
-	case strings.Contains(root, ":"):
-		// A mountable such as "btrfsvol:/dev/sda6/@/home": usable, but a plain
-		// device is a better representative.
+	case strings.Contains(root, ":"): // a mountable such as btrfsvol:...
 		return 2
 	case isBareDisk(root):
 		return 1
@@ -318,7 +326,6 @@ func rootPreferenceRank(root string) int {
 	}
 }
 
-// chooseRootFromGroup picks a stable representative for one filesystem.
 func chooseRootFromGroup(group []string) string {
 	best := ""
 	bestRank := 0
@@ -333,7 +340,6 @@ func chooseRootFromGroup(group []string) string {
 }
 
 // sortMountsShortestFirst orders mounts so parents are mounted before children.
-// Mirrors compare_keys_len in libguestfs common/options/inspect.c.
 func sortMountsShortestFirst(mounts []mountSpec) {
 	sort.SliceStable(mounts, func(i, j int) bool {
 		if len(mounts[i].MountPoint) != len(mounts[j].MountPoint) {
@@ -343,7 +349,6 @@ func sortMountsShortestFirst(mounts []mountSpec) {
 	})
 }
 
-// hasRootMount reports whether the plan already mounts "/".
 func hasRootMount(mounts []mountSpec) bool {
 	for _, spec := range mounts {
 		if spec.MountPoint == "/" {
@@ -353,8 +358,6 @@ func hasRootMount(mounts []mountSpec) bool {
 	return false
 }
 
-// describeRootGroups renders groups for an error message, e.g.
-// "[/dev/sda1] and [/dev/sdb1]".
 func describeRootGroups(groups [][]string) string {
 	parts := make([]string, 0, len(groups))
 	for _, group := range groups {
@@ -363,7 +366,6 @@ func describeRootGroups(groups [][]string) string {
 	return strings.Join(parts, " and ")
 }
 
-// describeMounts renders a plan for logging.
 func describeMounts(mounts []mountSpec) string {
 	parts := make([]string, 0, len(mounts))
 	for _, spec := range mounts {
@@ -372,8 +374,8 @@ func describeMounts(mounts []mountSpec) string {
 	return strings.Join(parts, ",")
 }
 
-// planFromProbe is the whole reduction from probe results to a mount plan. Kept
-// free of process execution so the interesting logic is unit testable.
+// planFromProbe is the reduction from probe results to a mount plan, kept free of
+// process execution so it can be unit tested.
 func planFromProbe(roots []string, uuids map[string]string, mounts map[string][]mountSpec) (mountPlan, error) {
 	if len(roots) == 0 {
 		return mountPlan{}, errors.New("no operating system was found on the supplied disks")
@@ -390,8 +392,7 @@ func planFromProbe(roots []string, uuids map[string]string, mounts map[string][]
 			len(groups), describeRootGroups(groups))
 	}
 
-	group := groups[0]
-	root := chooseRootFromGroup(group)
+	root := chooseRootFromGroup(groups[0])
 	if root == "" {
 		return mountPlan{}, errors.New("could not choose a root filesystem for the guest")
 	}
@@ -399,8 +400,7 @@ func planFromProbe(roots []string, uuids map[string]string, mounts map[string][]
 	plan := mountPlan{Root: root}
 	plan.Mounts = append(plan.Mounts, mounts[root]...)
 	if !hasRootMount(plan.Mounts) {
-		// No fstab (Windows), or an fstab that never named "/". Mounting the
-		// root mountable itself is what inspect_get_mountpoints falls back to.
+		// No fstab (Windows), or an fstab that never named "/".
 		plan.Mounts = append(plan.Mounts, mountSpec{Device: root, MountPoint: "/"})
 	}
 	sortMountsShortestFirst(plan.Mounts)
@@ -408,11 +408,6 @@ func planFromProbe(roots []string, uuids map[string]string, mounts map[string][]
 	return plan, nil
 }
 
-// ---------------------------------------------------------------------------
-// Resolution (runs guestfish)
-// ---------------------------------------------------------------------------
-
-// diskSetKey identifies a set of disks for the plan cache.
 func diskSetKey(disks []vm.VMDisk) string {
 	paths := make([]string, 0, len(disks))
 	for _, disk := range disks {
@@ -421,9 +416,8 @@ func diskSetKey(disks []vm.VMDisk) string {
 	return strings.Join(paths, "|")
 }
 
-// runGuestfishScript runs a script with no -i and nothing pre-mounted. This is
-// the only guestfish entry point that must not depend on a mount plan, because
-// it is what resolves the plan in the first place.
+// runGuestfishScript runs a script with no -i and nothing pre-mounted. It is the
+// one entry point that cannot depend on a mount plan, since it resolves them.
 func runGuestfishScript(disks []vm.VMDisk, script string) (string, error) {
 	os.Setenv("LIBGUESTFS_BACKEND", "direct")
 
@@ -448,8 +442,6 @@ func runGuestfishScript(disks []vm.VMDisk, script string) (string, error) {
 	return stdoutBuf.String(), nil
 }
 
-// resolveMountPlan works out what to mount for these disks, memoising the
-// result. Two appliance boots: one to enumerate roots, one to identify them.
 func resolveMountPlan(disks []vm.VMDisk) (mountPlan, error) {
 	if len(disks) == 0 {
 		return mountPlan{}, errors.New("no disks supplied; cannot resolve a guest mount plan")
@@ -464,8 +456,8 @@ func resolveMountPlan(disks []vm.VMDisk) (mountPlan, error) {
 		return plan, nil
 	}
 
-	// Boot 1: enumerate roots. No -i, so a root filesystem spanning several
-	// devices cannot abort this.
+	// Boot 1: enumerate roots. No -i, so a root spanning several devices cannot
+	// abort this.
 	out, err := runGuestfishScript(disks, "run\ninspect-os\n")
 	if err != nil {
 		return mountPlan{}, fmt.Errorf("failed to enumerate guest root filesystems: %w", err)
@@ -475,8 +467,8 @@ func resolveMountPlan(disks []vm.VMDisk) (mountPlan, error) {
 		return mountPlan{}, errors.New("no operating system was found on the supplied disks")
 	}
 
-	// Boot 2: identity and mount points for every candidate root at once, so
-	// that the multi-root case does not need a third boot.
+	// Boot 2: identity and mount points for every root at once, so the multi-root
+	// case needs no third boot.
 	probeOut, err := runGuestfishScript(disks, buildPlanProbeScript(roots))
 	if err != nil {
 		return mountPlan{}, fmt.Errorf("failed to probe guest root filesystems %v: %w", roots, err)
@@ -496,4 +488,54 @@ func resolveMountPlan(disks []vm.VMDisk) (mountPlan, error) {
 
 	mountPlanCache[key] = plan
 	return plan, nil
+}
+
+// runCommandsInGuestAllVolumes runs several commands in ONE appliance boot and
+// returns their outputs in order, verbatim. Unlike RunCommandInGuestAllVolumes
+// the output is NOT lowercased, because some of it is device paths that may
+// legitimately contain upper case (e.g. an LVM volume group named VolGroup00).
+// The returned slice always has one entry per command, even on error.
+func runCommandsInGuestAllVolumes(disks []vm.VMDisk, write bool, cmds ...guestfishCmd) ([]string, error) {
+	if len(cmds) == 0 {
+		return nil, nil
+	}
+	os.Setenv("LIBGUESTFS_BACKEND", "direct")
+
+	plan, err := resolveMountPlan(disks)
+	if err != nil {
+		return make([]string, len(cmds)), fmt.Errorf("failed to run guest commands: %w", err)
+	}
+
+	option := "--ro"
+	if write {
+		option = "--rw"
+	}
+	cmd := exec.Command("guestfish", option)
+	for _, disk := range disks {
+		cmd.Args = append(cmd.Args, "-a", disk.Path)
+	}
+	cmd.Stdin = strings.NewReader(buildGuestfishBatchScript(plan, write, cmds))
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	names := make([]string, 0, len(cmds))
+	for _, c := range cmds {
+		names = append(names, c.Name)
+	}
+	log.Printf("Executing %s with %d batched command(s): %s", cmd.String(), len(cmds), strings.Join(names, ", "))
+
+	runErr := cmd.Run()
+	if stderrBuf.Len() > 0 {
+		log.Printf("guestfish stderr (batch): %s", strings.TrimSpace(stderrBuf.String()))
+	}
+
+	outputs := splitGuestfishBatchOutput(stdoutBuf.String(), len(cmds))
+
+	if runErr != nil {
+		return outputs, fmt.Errorf("failed to run batched guest commands (%s): %v: %s",
+			strings.Join(names, ", "), runErr, strings.TrimSpace(stderrBuf.String()))
+	}
+	return outputs, nil
 }

--- a/v2v-helper/virtv2v/guestfish.go
+++ b/v2v-helper/virtv2v/guestfish.go
@@ -41,6 +41,15 @@ const (
 
 // guestfishCmd is one command in a batch. Tolerate prefixes it with "-" so a
 // failure does not abort the rest of the batch.
+//
+// Batched commands must NOT be ones libguestfs declares as RBufferOut: those
+// print with full_write(1, ...), writing straight to fd 1 and bypassing the
+// stdio buffer that `echo` uses (generator/fish.ml). With stdout on a pipe that
+// buffer is not flushed per line, so an RBufferOut result overtakes the markers
+// still sitting in it and splitGuestfishBatchOutput attributes output to the
+// wrong command. Everything used here (RString, RBool, RInt, RStringList,
+// RHashtable, RErr) goes through printf, so ordering holds. Watch out for
+// "read-file", which is RBufferOut - use "cat" (RString) instead.
 type guestfishCmd struct {
 	Name     string
 	Args     []string
@@ -227,6 +236,12 @@ func splitGuestfishBatchOutput(out string, n int) []string {
 func buildPlanProbeScript(roots []string) string {
 	var b strings.Builder
 	b.WriteString("run\n")
+	// inspect-get-mountpoints reads the inspection data that only inspect-os
+	// populates (daemon/inspect.ml search_for_root), and that state does not
+	// survive across guestfish processes - so it has to be re-run here or every
+	// mountpoints query fails with "no inspection data". Its output lands before
+	// the first marker and is discarded by parsePlanProbeOutput.
+	b.WriteString("inspect-os\n")
 	for _, root := range roots {
 		fmt.Fprintf(&b, "echo %s %s\n", planProbeUUIDMarker, quoteGuestfishArg(root))
 		fmt.Fprintf(&b, "- vfs-uuid %s\n", quoteGuestfishArg(root))

--- a/v2v-helper/virtv2v/guestfish.go
+++ b/v2v-helper/virtv2v/guestfish.go
@@ -1,0 +1,499 @@
+// Copyright © 2024 The vjailbreak authors
+
+package virtv2v
+
+// Mount-plan resolution for guestfish.
+//
+// Why this file exists
+// -------------------
+// Every guest operation used to run `guestfish -a ... -i`, where -i is
+// libguestfs' "inspector" option. -i calls guestfs_inspect_os() and then aborts
+// outright if more than one root is returned:
+//
+//	if (roots[1] != NULL) {
+//	    fprintf (stderr, _("%s: multi-boot operating systems are not supported\n" ...
+//	    exit (EXIT_FAILURE);
+//	}
+//	                                   -- libguestfs common/options/inspect.c
+//
+// That check counts roots; it does not compare operating systems. A btrfs
+// filesystem spanning several devices therefore trips it, because btrfs writes a
+// complete superblock (same fsid, different device UUID) to every member device
+// and libblkid has no "btrfs_member" type to distinguish a member from a
+// standalone filesystem. libguestfs' own guard against container devices is a
+// string test on the blkid type:
+//
+//	else if String.ends_with "_member" vfs_type then ()
+//	                                   -- libguestfs daemon/listfs.ml
+//
+// which catches LVM2_member, linux_raid_member and zfs_member but structurally
+// cannot catch btrfs. So `btrfs device add /dev/sdb /` on an otherwise ordinary
+// guest makes inspect_os() report the same root twice - once per member - and
+// every guestfish call in the migration fails.
+//
+// What we do instead
+// ------------------
+// Resolve the mount plan ourselves: enumerate roots without -i (so nothing can
+// abort), collapse roots that are members of one filesystem by comparing the
+// filesystem UUID, then mount explicitly. The mount sequence deliberately
+// mirrors inspect_mount_root() in common/options/inspect.c - shortest mount
+// point first, a failed "/" is fatal, every other mount point is best effort -
+// so that for the common single-root guest the result is byte-for-byte what -i
+// was already doing.
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/platform9/vjailbreak/v2v-helper/vm"
+)
+
+// Markers used to delimit per-root sections in the probe script's output. They
+// are emitted with guestfish's `echo` builtin, which simply prints its
+// arguments (fish/echo.c), so they arrive on stdout interleaved with the
+// command output in a predictable order.
+const (
+	planProbeUUIDMarker = "---VJB-UUID---"
+	planProbeMPMarker   = "---VJB-MP---"
+)
+
+// mountSpec is a single filesystem to mount inside the guestfish appliance.
+type mountSpec struct {
+	// Device is a libguestfs mountable: usually a device such as "/dev/sda6",
+	// but possibly a subvolume mountable such as "btrfsvol:/dev/sda6/@/home".
+	Device string
+	// MountPoint is the guest path, e.g. "/" or "/boot".
+	MountPoint string
+	// Options are mount options, empty in almost all cases.
+	Options string
+}
+
+// mountPlan is what `guestfish -i` would have mounted, computed explicitly.
+type mountPlan struct {
+	// Root is the mountable chosen to represent the guest's root filesystem.
+	Root string
+	// Mounts is ordered shortest mount point first.
+	Mounts []mountSpec
+}
+
+// mountPlanCache memoises the plan per set of disks. Resolving it costs two
+// appliance boots, and the disks do not change identity within a migration.
+var (
+	mountPlanCacheMu sync.Mutex
+	mountPlanCache   = map[string]mountPlan{}
+)
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+// parseInspectOSOutput turns `inspect-os` output into a list of roots.
+func parseInspectOSOutput(out string) []string {
+	var roots []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		roots = append(roots, line)
+	}
+	return roots
+}
+
+// parseMountpointsOutput parses `inspect-get-mountpoints` output. guestfish
+// renders a hashtable as "key: value" per line (print_table in fish/fish.c) and
+// this hashtable is keyed by mount point, so a line reads "/boot: /dev/sda2".
+// The value may itself contain a colon, hence the split on the first ": ".
+func parseMountpointsOutput(out string) []mountSpec {
+	var specs []mountSpec
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		idx := strings.Index(line, ": ")
+		if idx <= 0 {
+			continue
+		}
+		mountPoint := strings.TrimSpace(line[:idx])
+		device := strings.TrimSpace(line[idx+len(": "):])
+		if mountPoint == "" || device == "" {
+			continue
+		}
+		specs = append(specs, mountSpec{Device: device, MountPoint: mountPoint})
+	}
+	return specs
+}
+
+// quoteGuestfishArg double-quotes an argument for guestfish's stdin parser.
+// Inside double quotes guestfish interprets backslash escapes (\n, \t, \", \\ -
+// see the QUOTING section of guestfish(1)), so the backslash itself has to be
+// escaped first or a Windows-style path would be mangled.
+func quoteGuestfishArg(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; c == '\\' || c == '"' {
+			b.WriteByte('\\')
+			b.WriteByte(c)
+		} else {
+			b.WriteByte(c)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// formatGuestfishCommand renders one guestfish command line, quoting every
+// argument so that an argument containing spaces stays a single token.
+func formatGuestfishCommand(command string, args ...string) string {
+	var b strings.Builder
+	b.WriteString(command)
+	for _, arg := range args {
+		b.WriteByte(' ')
+		b.WriteString(quoteGuestfishArg(arg))
+	}
+	return b.String()
+}
+
+// mountCommandLine renders the guestfish command that mounts one filesystem.
+// Read-only callers must use mount-ro because the drives were added with --ro.
+func mountCommandLine(spec mountSpec, write bool) string {
+	if spec.Options != "" {
+		options := spec.Options
+		if !write {
+			options = "ro," + options
+		}
+		return formatGuestfishCommand("mount-options", options, spec.Device, spec.MountPoint)
+	}
+	command := "mount-ro"
+	if write {
+		command = "mount"
+	}
+	return formatGuestfishCommand(command, spec.Device, spec.MountPoint)
+}
+
+// buildGuestfishMountScript renders the preamble every guestfish invocation
+// needs: launch the appliance, then mount the plan. Callers append their own
+// command lines to the result.
+func buildGuestfishMountScript(plan mountPlan, write bool) string {
+	var b strings.Builder
+	b.WriteString("run\n")
+	for _, spec := range plan.Mounts {
+		// Prefixing a command with "-" tells guestfish not to exit if that one
+		// command fails (guestfish(1), EXIT ON ERROR BEHAVIOUR). inspect-get-
+		// mountpoints is explicitly documented as possibly returning
+		// filesystems that are absent or unmountable, and inspect_mount_root
+		// ignores those failures for everything except "/", so we do the same.
+		if spec.MountPoint != "/" {
+			b.WriteString("- ")
+		}
+		b.WriteString(mountCommandLine(spec, write))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// buildPlanProbeScript asks, for every candidate root, its filesystem UUID and
+// its mount points. Both queries are error tolerant so that one unusable root
+// cannot abort the whole probe, and both are wrapped in echo markers so the
+// interleaved output can be attributed back to the right root.
+func buildPlanProbeScript(roots []string) string {
+	var b strings.Builder
+	b.WriteString("run\n")
+	for _, root := range roots {
+		fmt.Fprintf(&b, "echo %s %s\n", planProbeUUIDMarker, quoteGuestfishArg(root))
+		fmt.Fprintf(&b, "- vfs-uuid %s\n", quoteGuestfishArg(root))
+		fmt.Fprintf(&b, "echo %s %s\n", planProbeMPMarker, quoteGuestfishArg(root))
+		fmt.Fprintf(&b, "- inspect-get-mountpoints %s\n", quoteGuestfishArg(root))
+	}
+	return b.String()
+}
+
+// parsePlanProbeOutput splits probe output back into per-root UUIDs and mount
+// points. A root whose UUID query failed maps to "", which groupRootsByUUID
+// treats as "identity unknown" rather than "same as other unknowns".
+func parsePlanProbeOutput(out string) (map[string]string, map[string][]mountSpec) {
+	uuids := make(map[string]string)
+	mounts := make(map[string][]mountSpec)
+
+	const (
+		sectionNone = iota
+		sectionUUID
+		sectionMountpoints
+	)
+
+	section := sectionNone
+	current := ""
+	var buf []string
+
+	flush := func() {
+		if current == "" {
+			buf = nil
+			return
+		}
+		text := strings.Join(buf, "\n")
+		switch section {
+		case sectionUUID:
+			uuids[current] = strings.ToLower(strings.TrimSpace(text))
+		case sectionMountpoints:
+			mounts[current] = parseMountpointsOutput(text)
+		}
+		buf = nil
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, planProbeUUIDMarker):
+			flush()
+			section = sectionUUID
+			current = strings.TrimSpace(strings.TrimPrefix(trimmed, planProbeUUIDMarker))
+		case strings.HasPrefix(trimmed, planProbeMPMarker):
+			flush()
+			section = sectionMountpoints
+			current = strings.TrimSpace(strings.TrimPrefix(trimmed, planProbeMPMarker))
+		case trimmed == "":
+			// Ignore blank lines inside a section.
+		default:
+			if current != "" {
+				buf = append(buf, trimmed)
+			}
+		}
+	}
+	flush()
+
+	return uuids, mounts
+}
+
+// groupRootsByUUID groups roots that are the same physical filesystem. For
+// btrfs the filesystem UUID is the fsid, identical on every member device, so
+// two members of one filesystem land in one group while a genuine dual-boot
+// guest keeps its roots apart. First-appearance order is preserved.
+func groupRootsByUUID(roots []string, uuids map[string]string) [][]string {
+	var groups [][]string
+	indexByUUID := make(map[string]int)
+
+	for _, root := range roots {
+		uuid := strings.ToLower(strings.TrimSpace(uuids[root]))
+		if uuid == "" {
+			// Identity unknown: we cannot prove this is the same filesystem as
+			// anything else, so never merge it.
+			groups = append(groups, []string{root})
+			continue
+		}
+		if i, ok := indexByUUID[uuid]; ok {
+			groups[i] = append(groups[i], root)
+			continue
+		}
+		indexByUUID[uuid] = len(groups)
+		groups = append(groups, []string{root})
+	}
+
+	return groups
+}
+
+// rootPreferenceRank ranks candidate representatives of one filesystem, lower
+// being better. Any member mounts the same filesystem so guestfish is
+// indifferent, but downstream part-to-dev, device-index and fstab handling all
+// assume a partition, so a partition beats a bare member disk.
+func rootPreferenceRank(root string) int {
+	switch {
+	case strings.Contains(root, ":"):
+		// A mountable such as "btrfsvol:/dev/sda6/@/home": usable, but a plain
+		// device is a better representative.
+		return 2
+	case isBareDisk(root):
+		return 1
+	default:
+		return 0
+	}
+}
+
+// chooseRootFromGroup picks a stable representative for one filesystem.
+func chooseRootFromGroup(group []string) string {
+	best := ""
+	bestRank := 0
+	for i, candidate := range group {
+		rank := rootPreferenceRank(candidate)
+		if i == 0 || rank < bestRank || (rank == bestRank && candidate < best) {
+			best = candidate
+			bestRank = rank
+		}
+	}
+	return best
+}
+
+// sortMountsShortestFirst orders mounts so parents are mounted before children.
+// Mirrors compare_keys_len in libguestfs common/options/inspect.c.
+func sortMountsShortestFirst(mounts []mountSpec) {
+	sort.SliceStable(mounts, func(i, j int) bool {
+		if len(mounts[i].MountPoint) != len(mounts[j].MountPoint) {
+			return len(mounts[i].MountPoint) < len(mounts[j].MountPoint)
+		}
+		return mounts[i].MountPoint < mounts[j].MountPoint
+	})
+}
+
+// hasRootMount reports whether the plan already mounts "/".
+func hasRootMount(mounts []mountSpec) bool {
+	for _, spec := range mounts {
+		if spec.MountPoint == "/" {
+			return true
+		}
+	}
+	return false
+}
+
+// describeRootGroups renders groups for an error message, e.g.
+// "[/dev/sda1] and [/dev/sdb1]".
+func describeRootGroups(groups [][]string) string {
+	parts := make([]string, 0, len(groups))
+	for _, group := range groups {
+		parts = append(parts, "["+strings.Join(group, " ")+"]")
+	}
+	return strings.Join(parts, " and ")
+}
+
+// describeMounts renders a plan for logging.
+func describeMounts(mounts []mountSpec) string {
+	parts := make([]string, 0, len(mounts))
+	for _, spec := range mounts {
+		parts = append(parts, spec.MountPoint+"="+spec.Device)
+	}
+	return strings.Join(parts, ",")
+}
+
+// planFromProbe is the whole reduction from probe results to a mount plan. Kept
+// free of process execution so the interesting logic is unit testable.
+func planFromProbe(roots []string, uuids map[string]string, mounts map[string][]mountSpec) (mountPlan, error) {
+	if len(roots) == 0 {
+		return mountPlan{}, errors.New("no operating system was found on the supplied disks")
+	}
+
+	groups := groupRootsByUUID(roots, uuids)
+	if len(groups) == 0 {
+		return mountPlan{}, errors.New("no operating system was found on the supplied disks")
+	}
+	if len(groups) > 1 {
+		return mountPlan{}, fmt.Errorf(
+			"guest looks genuinely multi-boot: found %d separate root filesystems %s. "+
+				"vJailbreak cannot pick one automatically",
+			len(groups), describeRootGroups(groups))
+	}
+
+	group := groups[0]
+	root := chooseRootFromGroup(group)
+	if root == "" {
+		return mountPlan{}, errors.New("could not choose a root filesystem for the guest")
+	}
+
+	plan := mountPlan{Root: root}
+	plan.Mounts = append(plan.Mounts, mounts[root]...)
+	if !hasRootMount(plan.Mounts) {
+		// No fstab (Windows), or an fstab that never named "/". Mounting the
+		// root mountable itself is what inspect_get_mountpoints falls back to.
+		plan.Mounts = append(plan.Mounts, mountSpec{Device: root, MountPoint: "/"})
+	}
+	sortMountsShortestFirst(plan.Mounts)
+
+	return plan, nil
+}
+
+// ---------------------------------------------------------------------------
+// Resolution (runs guestfish)
+// ---------------------------------------------------------------------------
+
+// diskSetKey identifies a set of disks for the plan cache.
+func diskSetKey(disks []vm.VMDisk) string {
+	paths := make([]string, 0, len(disks))
+	for _, disk := range disks {
+		paths = append(paths, disk.Path)
+	}
+	return strings.Join(paths, "|")
+}
+
+// runGuestfishScript runs a script with no -i and nothing pre-mounted. This is
+// the only guestfish entry point that must not depend on a mount plan, because
+// it is what resolves the plan in the first place.
+func runGuestfishScript(disks []vm.VMDisk, script string) (string, error) {
+	os.Setenv("LIBGUESTFS_BACKEND", "direct")
+
+	cmd := exec.Command("guestfish", "--ro")
+	for _, disk := range disks {
+		cmd.Args = append(cmd.Args, "-a", disk.Path)
+	}
+	cmd.Stdin = strings.NewReader(script)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	log.Printf("Executing %s with script:\n%s", cmd.String(), script)
+	err := cmd.Run()
+	if stderrBuf.Len() > 0 {
+		log.Printf("guestfish stderr (mount plan): %s", strings.TrimSpace(stderrBuf.String()))
+	}
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(stderrBuf.String()))
+	}
+	return stdoutBuf.String(), nil
+}
+
+// resolveMountPlan works out what to mount for these disks, memoising the
+// result. Two appliance boots: one to enumerate roots, one to identify them.
+func resolveMountPlan(disks []vm.VMDisk) (mountPlan, error) {
+	if len(disks) == 0 {
+		return mountPlan{}, errors.New("no disks supplied; cannot resolve a guest mount plan")
+	}
+
+	key := diskSetKey(disks)
+
+	mountPlanCacheMu.Lock()
+	defer mountPlanCacheMu.Unlock()
+
+	if plan, ok := mountPlanCache[key]; ok {
+		return plan, nil
+	}
+
+	// Boot 1: enumerate roots. No -i, so a root filesystem spanning several
+	// devices cannot abort this.
+	out, err := runGuestfishScript(disks, "run\ninspect-os\n")
+	if err != nil {
+		return mountPlan{}, fmt.Errorf("failed to enumerate guest root filesystems: %w", err)
+	}
+	roots := parseInspectOSOutput(out)
+	if len(roots) == 0 {
+		return mountPlan{}, errors.New("no operating system was found on the supplied disks")
+	}
+
+	// Boot 2: identity and mount points for every candidate root at once, so
+	// that the multi-root case does not need a third boot.
+	probeOut, err := runGuestfishScript(disks, buildPlanProbeScript(roots))
+	if err != nil {
+		return mountPlan{}, fmt.Errorf("failed to probe guest root filesystems %v: %w", roots, err)
+	}
+	uuids, mounts := parsePlanProbeOutput(probeOut)
+
+	plan, err := planFromProbe(roots, uuids, mounts)
+	if err != nil {
+		return mountPlan{}, err
+	}
+
+	if len(roots) > 1 {
+		log.Printf("Root filesystem spans %d devices (%s); using %s to represent it",
+			len(roots), strings.Join(roots, ", "), plan.Root)
+	}
+	log.Printf("Resolved guest mount plan: root=%s mounts=%s", plan.Root, describeMounts(plan.Mounts))
+
+	mountPlanCache[key] = plan
+	return plan, nil
+}

--- a/v2v-helper/virtv2v/guestfish_test.go
+++ b/v2v-helper/virtv2v/guestfish_test.go
@@ -1,0 +1,536 @@
+// Copyright © 2024 The vjailbreak authors
+
+package virtv2v
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// parseInspectOSOutput
+// ---------------------------------------------------------------------------
+
+func TestParseInspectOSOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want []string
+	}{
+		{
+			name: "no roots",
+			out:  "",
+			want: nil,
+		},
+		{
+			name: "single root",
+			out:  "/dev/sda2\n",
+			want: []string{"/dev/sda2"},
+		},
+		{
+			// The multi-device btrfs case. Whole devices are enumerated before
+			// partitions in libguestfs (daemon/listfs.ml), so the bare member
+			// disk comes first.
+			name: "two roots, btrfs spanning two disks",
+			out:  "/dev/sdb\n/dev/sda6\n",
+			want: []string{"/dev/sdb", "/dev/sda6"},
+		},
+		{
+			name: "blank lines and padding are ignored",
+			out:  "\n  /dev/sda6  \n\n",
+			want: []string{"/dev/sda6"},
+		},
+		{
+			name: "btrfs subvolume mountable",
+			out:  "btrfsvol:/dev/sda6/@/.snapshots/1/snapshot\n",
+			want: []string{"btrfsvol:/dev/sda6/@/.snapshots/1/snapshot"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseInspectOSOutput(tt.out))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseMountpointsOutput
+// ---------------------------------------------------------------------------
+
+func TestParseMountpointsOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want []mountSpec
+	}{
+		{
+			name: "empty",
+			out:  "",
+			want: nil,
+		},
+		{
+			// guestfish prints hashtables as "key: value" (fish/fish.c print_table),
+			// and inspect-get-mountpoints is keyed by mount point.
+			name: "root and boot",
+			out:  "/: /dev/sda6\n/boot: /dev/sda2\n",
+			want: []mountSpec{
+				{Device: "/dev/sda6", MountPoint: "/"},
+				{Device: "/dev/sda2", MountPoint: "/boot"},
+			},
+		},
+		{
+			name: "value containing a colon is preserved",
+			out:  "/home: btrfsvol:/dev/sda6/@/home\n",
+			want: []mountSpec{
+				{Device: "btrfsvol:/dev/sda6/@/home", MountPoint: "/home"},
+			},
+		},
+		{
+			name: "malformed lines are skipped",
+			out:  "garbage\n/: /dev/sda6\n: /dev/sdc\n/var:\n",
+			want: []mountSpec{
+				{Device: "/dev/sda6", MountPoint: "/"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseMountpointsOutput(tt.out))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parsePlanProbeOutput
+// ---------------------------------------------------------------------------
+
+func TestParsePlanProbeOutput(t *testing.T) {
+	// Exactly the shape buildPlanProbeScript produces for the failing
+	// openSUSE 15.5 guest: two roots that are two members of one btrfs
+	// filesystem, so both report the same UUID (the btrfs fsid).
+	out := strings.Join([]string{
+		planProbeUUIDMarker + " /dev/sdb",
+		"b1f0a2c4-1111-4222-8333-444455556666",
+		planProbeMPMarker + " /dev/sdb",
+		"/: /dev/sdb",
+		"/boot: /dev/sda2",
+		planProbeUUIDMarker + " /dev/sda6",
+		"b1f0a2c4-1111-4222-8333-444455556666",
+		planProbeMPMarker + " /dev/sda6",
+		"/: /dev/sda6",
+		"/boot: /dev/sda2",
+		"",
+	}, "\n")
+
+	uuids, mounts := parsePlanProbeOutput(out)
+
+	assert.Equal(t, map[string]string{
+		"/dev/sdb":  "b1f0a2c4-1111-4222-8333-444455556666",
+		"/dev/sda6": "b1f0a2c4-1111-4222-8333-444455556666",
+	}, uuids)
+
+	assert.Equal(t, []mountSpec{
+		{Device: "/dev/sda6", MountPoint: "/"},
+		{Device: "/dev/sda2", MountPoint: "/boot"},
+	}, mounts["/dev/sda6"])
+}
+
+func TestParsePlanProbeOutputToleratesMissingUUID(t *testing.T) {
+	// "- vfs-uuid" is error tolerant, so a root can come back with no UUID at
+	// all. That must not be silently treated as "same filesystem as everything
+	// else with no UUID".
+	out := strings.Join([]string{
+		planProbeUUIDMarker + " /dev/sda2",
+		planProbeMPMarker + " /dev/sda2",
+		"/: /dev/sda2",
+		"",
+	}, "\n")
+
+	uuids, mounts := parsePlanProbeOutput(out)
+
+	assert.Equal(t, "", uuids["/dev/sda2"])
+	assert.Equal(t, []mountSpec{{Device: "/dev/sda2", MountPoint: "/"}}, mounts["/dev/sda2"])
+}
+
+// ---------------------------------------------------------------------------
+// groupRootsByUUID
+// ---------------------------------------------------------------------------
+
+func TestGroupRootsByUUID(t *testing.T) {
+	tests := []struct {
+		name  string
+		roots []string
+		uuids map[string]string
+		want  [][]string
+	}{
+		{
+			name:  "single root",
+			roots: []string{"/dev/sda2"},
+			uuids: map[string]string{"/dev/sda2": "aaaa"},
+			want:  [][]string{{"/dev/sda2"}},
+		},
+		{
+			// THE regression this whole change exists for.
+			name:  "two members of one btrfs filesystem collapse to one group",
+			roots: []string{"/dev/sdb", "/dev/sda6"},
+			uuids: map[string]string{"/dev/sdb": "aaaa", "/dev/sda6": "aaaa"},
+			want:  [][]string{{"/dev/sdb", "/dev/sda6"}},
+		},
+		{
+			name:  "genuine dual boot stays two groups",
+			roots: []string{"/dev/sda1", "/dev/sdb1"},
+			uuids: map[string]string{"/dev/sda1": "aaaa", "/dev/sdb1": "bbbb"},
+			want:  [][]string{{"/dev/sda1"}, {"/dev/sdb1"}},
+		},
+		{
+			name:  "uuid comparison is case insensitive",
+			roots: []string{"/dev/sdb", "/dev/sda6"},
+			uuids: map[string]string{"/dev/sdb": "AAAA", "/dev/sda6": "aaaa"},
+			want:  [][]string{{"/dev/sdb", "/dev/sda6"}},
+		},
+		{
+			name:  "unknown uuid is never merged",
+			roots: []string{"/dev/sda1", "/dev/sdb1"},
+			uuids: map[string]string{},
+			want:  [][]string{{"/dev/sda1"}, {"/dev/sdb1"}},
+		},
+		{
+			name:  "three members one filesystem",
+			roots: []string{"/dev/sdb", "/dev/sdc", "/dev/sda6"},
+			uuids: map[string]string{"/dev/sdb": "aaaa", "/dev/sdc": "aaaa", "/dev/sda6": "aaaa"},
+			want:  [][]string{{"/dev/sdb", "/dev/sdc", "/dev/sda6"}},
+		},
+		{
+			name:  "no roots",
+			roots: nil,
+			uuids: nil,
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, groupRootsByUUID(tt.roots, tt.uuids))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// chooseRootFromGroup
+// ---------------------------------------------------------------------------
+
+func TestChooseRootFromGroup(t *testing.T) {
+	tests := []struct {
+		name  string
+		group []string
+		want  string
+	}{
+		{
+			// A partition beats a bare member disk: downstream part-to-dev,
+			// device-index and fstab handling all assume a partition.
+			name:  "partition preferred over bare disk",
+			group: []string{"/dev/sdb", "/dev/sda6"},
+			want:  "/dev/sda6",
+		},
+		{
+			name:  "bare disk is fine when it is the only member",
+			group: []string{"/dev/sdb"},
+			want:  "/dev/sdb",
+		},
+		{
+			name:  "deterministic lexical tie break between partitions",
+			group: []string{"/dev/sda7", "/dev/sda6"},
+			want:  "/dev/sda6",
+		},
+		{
+			name:  "plain device preferred over a btrfsvol mountable",
+			group: []string{"btrfsvol:/dev/sda6/@/.snapshots/1/snapshot", "/dev/sda6"},
+			want:  "/dev/sda6",
+		},
+		{
+			name:  "lvm path counts as a partition",
+			group: []string{"/dev/sdb", "/dev/vg0/lv_root"},
+			want:  "/dev/vg0/lv_root",
+		},
+		{
+			name:  "empty group",
+			group: nil,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, chooseRootFromGroup(tt.group))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// sortMountsShortestFirst
+// ---------------------------------------------------------------------------
+
+func TestSortMountsShortestFirst(t *testing.T) {
+	// Mirrors compare_keys_len in libguestfs common/options/inspect.c: shortest
+	// mount point first so "/" is mounted before anything nested under it.
+	mounts := []mountSpec{
+		{Device: "/dev/sda9", MountPoint: "/var/log"},
+		{Device: "/dev/sda2", MountPoint: "/boot"},
+		{Device: "/dev/sda6", MountPoint: "/"},
+		{Device: "/dev/sda8", MountPoint: "/var"},
+	}
+
+	sortMountsShortestFirst(mounts)
+
+	got := make([]string, 0, len(mounts))
+	for _, m := range mounts {
+		got = append(got, m.MountPoint)
+	}
+	assert.Equal(t, []string{"/", "/var", "/boot", "/var/log"}, got)
+}
+
+// ---------------------------------------------------------------------------
+// quoteGuestfishArg
+// ---------------------------------------------------------------------------
+
+func TestQuoteGuestfishArg(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "plain path", in: "/tmp/x.sh", want: `"/tmp/x.sh"`},
+		{name: "space is protected", in: "/tmp/x.sh --flag", want: `"/tmp/x.sh --flag"`},
+		{name: "double quote escaped", in: `a"b`, want: `"a\"b"`},
+		{name: "backslash escaped", in: `a\b`, want: `"a\\b"`},
+		// Escaping the backslash first is what stops "\n" in a path from being
+		// reinterpreted as a newline by guestfish's double-quote parser.
+		{name: "backslash n is not a newline", in: `a\nb`, want: `"a\\nb"`},
+		{name: "empty", in: "", want: `""`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, quoteGuestfishArg(tt.in))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// mountCommandLine / buildGuestfishMountScript
+// ---------------------------------------------------------------------------
+
+func TestMountCommandLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		spec  mountSpec
+		write bool
+		want  string
+	}{
+		{
+			name:  "read only uses mount-ro",
+			spec:  mountSpec{Device: "/dev/sda6", MountPoint: "/"},
+			write: false,
+			want:  `mount-ro "/dev/sda6" "/"`,
+		},
+		{
+			name:  "writable uses mount",
+			spec:  mountSpec{Device: "/dev/sda6", MountPoint: "/"},
+			write: true,
+			want:  `mount "/dev/sda6" "/"`,
+		},
+		{
+			name:  "options use mount-options and gain ro when read only",
+			spec:  mountSpec{Device: "/dev/sda6", MountPoint: "/", Options: "subvol=@"},
+			write: false,
+			want:  `mount-options "ro,subvol=@" "/dev/sda6" "/"`,
+		},
+		{
+			name:  "options are passed through when writable",
+			spec:  mountSpec{Device: "/dev/sda6", MountPoint: "/", Options: "subvol=@"},
+			write: true,
+			want:  `mount-options "subvol=@" "/dev/sda6" "/"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, mountCommandLine(tt.spec, tt.write))
+		})
+	}
+}
+
+func TestBuildGuestfishMountScript(t *testing.T) {
+	plan := mountPlan{
+		Root: "/dev/sda6",
+		Mounts: []mountSpec{
+			{Device: "/dev/sda6", MountPoint: "/"},
+			{Device: "/dev/sda2", MountPoint: "/boot"},
+		},
+	}
+
+	got := buildGuestfishMountScript(plan, true)
+
+	// "/" must be fatal on failure, everything else best effort - this mirrors
+	// inspect_mount_root in libguestfs common/options/inspect.c.
+	want := "run\n" +
+		`mount "/dev/sda6" "/"` + "\n" +
+		`- mount "/dev/sda2" "/boot"` + "\n"
+	assert.Equal(t, want, got)
+}
+
+func TestBuildGuestfishMountScriptNeverEmitsInspector(t *testing.T) {
+	// Regression guard. Reintroducing -i anywhere in this path resurrects the
+	// "multi-boot operating systems are not supported" failure on any guest
+	// whose root filesystem spans more than one device.
+	plan := mountPlan{
+		Root:   "/dev/sda6",
+		Mounts: []mountSpec{{Device: "/dev/sda6", MountPoint: "/"}},
+	}
+
+	for _, write := range []bool{false, true} {
+		script := buildGuestfishMountScript(plan, write)
+		assert.NotContains(t, script, "-i")
+		assert.NotContains(t, script, "inspect-os")
+		assert.True(t, strings.HasPrefix(script, "run\n"), "script must launch the appliance first")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// formatGuestfishCommand
+// ---------------------------------------------------------------------------
+
+func TestFormatGuestfishCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		args    []string
+		want    string
+	}{
+		{
+			name:    "no args",
+			command: "list-partitions",
+			want:    "list-partitions",
+		},
+		{
+			name:    "upload two paths",
+			command: "upload",
+			args:    []string{"/home/fedora/get-bootable-partition.sh", "/tmp/get-bootable-partition.sh"},
+			want:    `upload "/home/fedora/get-bootable-partition.sh" "/tmp/get-bootable-partition.sh"`,
+		},
+		{
+			// RunMountPersistenceScript passes script + flags as ONE argv token.
+			// Quoting keeps it one token on stdin instead of splitting on space.
+			name:    "single arg containing spaces stays one token",
+			command: "sh",
+			args:    []string{"/tmp/generate-mount-persistence.sh --replace-fstab"},
+			want:    `sh "/tmp/generate-mount-persistence.sh --replace-fstab"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, formatGuestfishCommand(tt.command, tt.args...))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildPlanProbeScript
+// ---------------------------------------------------------------------------
+
+func TestBuildPlanProbeScript(t *testing.T) {
+	got := buildPlanProbeScript([]string{"/dev/sdb", "/dev/sda6"})
+
+	want := "run\n" +
+		"echo " + planProbeUUIDMarker + ` "/dev/sdb"` + "\n" +
+		`- vfs-uuid "/dev/sdb"` + "\n" +
+		"echo " + planProbeMPMarker + ` "/dev/sdb"` + "\n" +
+		`- inspect-get-mountpoints "/dev/sdb"` + "\n" +
+		"echo " + planProbeUUIDMarker + ` "/dev/sda6"` + "\n" +
+		`- vfs-uuid "/dev/sda6"` + "\n" +
+		"echo " + planProbeMPMarker + ` "/dev/sda6"` + "\n" +
+		`- inspect-get-mountpoints "/dev/sda6"` + "\n"
+
+	assert.Equal(t, want, got)
+}
+
+// ---------------------------------------------------------------------------
+// planFromProbe - the whole reduction, end to end, without touching guestfish
+// ---------------------------------------------------------------------------
+
+func TestPlanFromProbe(t *testing.T) {
+	t.Run("multi-device btrfs resolves to a single root", func(t *testing.T) {
+		roots := []string{"/dev/sdb", "/dev/sda6"}
+		uuids := map[string]string{
+			"/dev/sdb":  "aaaa",
+			"/dev/sda6": "aaaa",
+		}
+		mounts := map[string][]mountSpec{
+			"/dev/sda6": {
+				{Device: "/dev/sda2", MountPoint: "/boot"},
+				{Device: "/dev/sda6", MountPoint: "/"},
+			},
+		}
+
+		plan, err := planFromProbe(roots, uuids, mounts)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "/dev/sda6", plan.Root)
+		assert.Equal(t, []mountSpec{
+			{Device: "/dev/sda6", MountPoint: "/"},
+			{Device: "/dev/sda2", MountPoint: "/boot"},
+		}, plan.Mounts)
+	})
+
+	t.Run("genuine multi-boot is rejected with a useful message", func(t *testing.T) {
+		roots := []string{"/dev/sda1", "/dev/sdb1"}
+		uuids := map[string]string{"/dev/sda1": "aaaa", "/dev/sdb1": "bbbb"}
+
+		_, err := planFromProbe(roots, uuids, nil)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "multi-boot")
+		assert.Contains(t, err.Error(), "/dev/sda1")
+		assert.Contains(t, err.Error(), "/dev/sdb1")
+	})
+
+	t.Run("no roots is an error", func(t *testing.T) {
+		_, err := planFromProbe(nil, nil, nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("guest without fstab falls back to mounting only the root", func(t *testing.T) {
+		// Windows guests: inspect_get_mountpoints returns just the root
+		// (daemon/inspect.ml).
+		plan, err := planFromProbe(
+			[]string{"/dev/sda2"},
+			map[string]string{"/dev/sda2": "aaaa"},
+			nil,
+		)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "/dev/sda2", plan.Root)
+		assert.Equal(t, []mountSpec{{Device: "/dev/sda2", MountPoint: "/"}}, plan.Mounts)
+	})
+
+	t.Run("root mount is synthesised when fstab omits it", func(t *testing.T) {
+		plan, err := planFromProbe(
+			[]string{"/dev/sda6"},
+			map[string]string{"/dev/sda6": "aaaa"},
+			map[string][]mountSpec{
+				"/dev/sda6": {{Device: "/dev/sda2", MountPoint: "/boot"}},
+			},
+		)
+
+		assert.NoError(t, err)
+		assert.Equal(t, []mountSpec{
+			{Device: "/dev/sda6", MountPoint: "/"},
+			{Device: "/dev/sda2", MountPoint: "/boot"},
+		}, plan.Mounts)
+	})
+}

--- a/v2v-helper/virtv2v/guestfish_test.go
+++ b/v2v-helper/virtv2v/guestfish_test.go
@@ -3,15 +3,14 @@
 package virtv2v
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// ---------------------------------------------------------------------------
 // parseInspectOSOutput
-// ---------------------------------------------------------------------------
 
 func TestParseInspectOSOutput(t *testing.T) {
 	tests := []struct {
@@ -56,9 +55,7 @@ func TestParseInspectOSOutput(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // parseMountpointsOutput
-// ---------------------------------------------------------------------------
 
 func TestParseMountpointsOutput(t *testing.T) {
 	tests := []struct {
@@ -104,14 +101,10 @@ func TestParseMountpointsOutput(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // parsePlanProbeOutput
-// ---------------------------------------------------------------------------
 
 func TestParsePlanProbeOutput(t *testing.T) {
-	// Exactly the shape buildPlanProbeScript produces for the failing
-	// openSUSE 15.5 guest: two roots that are two members of one btrfs
-	// filesystem, so both report the same UUID (the btrfs fsid).
+	// Two members of one btrfs filesystem: same UUID (the fsid).
 	out := strings.Join([]string{
 		planProbeUUIDMarker + " /dev/sdb",
 		"b1f0a2c4-1111-4222-8333-444455556666",
@@ -140,9 +133,7 @@ func TestParsePlanProbeOutput(t *testing.T) {
 }
 
 func TestParsePlanProbeOutputToleratesMissingUUID(t *testing.T) {
-	// "- vfs-uuid" is error tolerant, so a root can come back with no UUID at
-	// all. That must not be silently treated as "same filesystem as everything
-	// else with no UUID".
+	// "- vfs-uuid" is error tolerant, so a root can come back with no UUID.
 	out := strings.Join([]string{
 		planProbeUUIDMarker + " /dev/sda2",
 		planProbeMPMarker + " /dev/sda2",
@@ -156,9 +147,7 @@ func TestParsePlanProbeOutputToleratesMissingUUID(t *testing.T) {
 	assert.Equal(t, []mountSpec{{Device: "/dev/sda2", MountPoint: "/"}}, mounts["/dev/sda2"])
 }
 
-// ---------------------------------------------------------------------------
 // groupRootsByUUID
-// ---------------------------------------------------------------------------
 
 func TestGroupRootsByUUID(t *testing.T) {
 	tests := []struct {
@@ -219,9 +208,7 @@ func TestGroupRootsByUUID(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // chooseRootFromGroup
-// ---------------------------------------------------------------------------
 
 func TestChooseRootFromGroup(t *testing.T) {
 	tests := []struct {
@@ -230,8 +217,7 @@ func TestChooseRootFromGroup(t *testing.T) {
 		want  string
 	}{
 		{
-			// A partition beats a bare member disk: downstream part-to-dev,
-			// device-index and fstab handling all assume a partition.
+			// Downstream part-to-dev and device-index assume a partition.
 			name:  "partition preferred over bare disk",
 			group: []string{"/dev/sdb", "/dev/sda6"},
 			want:  "/dev/sda6",
@@ -270,13 +256,10 @@ func TestChooseRootFromGroup(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // sortMountsShortestFirst
-// ---------------------------------------------------------------------------
 
 func TestSortMountsShortestFirst(t *testing.T) {
-	// Mirrors compare_keys_len in libguestfs common/options/inspect.c: shortest
-	// mount point first so "/" is mounted before anything nested under it.
+	// Mirrors compare_keys_len in libguestfs common/options/inspect.c.
 	mounts := []mountSpec{
 		{Device: "/dev/sda9", MountPoint: "/var/log"},
 		{Device: "/dev/sda2", MountPoint: "/boot"},
@@ -293,9 +276,7 @@ func TestSortMountsShortestFirst(t *testing.T) {
 	assert.Equal(t, []string{"/", "/var", "/boot", "/var/log"}, got)
 }
 
-// ---------------------------------------------------------------------------
 // quoteGuestfishArg
-// ---------------------------------------------------------------------------
 
 func TestQuoteGuestfishArg(t *testing.T) {
 	tests := []struct {
@@ -307,8 +288,7 @@ func TestQuoteGuestfishArg(t *testing.T) {
 		{name: "space is protected", in: "/tmp/x.sh --flag", want: `"/tmp/x.sh --flag"`},
 		{name: "double quote escaped", in: `a"b`, want: `"a\"b"`},
 		{name: "backslash escaped", in: `a\b`, want: `"a\\b"`},
-		// Escaping the backslash first is what stops "\n" in a path from being
-		// reinterpreted as a newline by guestfish's double-quote parser.
+		// Escaping backslash first stops guestfish reading "\n" as a newline.
 		{name: "backslash n is not a newline", in: `a\nb`, want: `"a\\nb"`},
 		{name: "empty", in: "", want: `""`},
 	}
@@ -320,9 +300,7 @@ func TestQuoteGuestfishArg(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // mountCommandLine / buildGuestfishMountScript
-// ---------------------------------------------------------------------------
 
 func TestMountCommandLine(t *testing.T) {
 	tests := []struct {
@@ -375,8 +353,7 @@ func TestBuildGuestfishMountScript(t *testing.T) {
 
 	got := buildGuestfishMountScript(plan, true)
 
-	// "/" must be fatal on failure, everything else best effort - this mirrors
-	// inspect_mount_root in libguestfs common/options/inspect.c.
+	// "/" fatal on failure, everything else best effort, per inspect_mount_root.
 	want := "run\n" +
 		`mount "/dev/sda6" "/"` + "\n" +
 		`- mount "/dev/sda2" "/boot"` + "\n"
@@ -384,9 +361,7 @@ func TestBuildGuestfishMountScript(t *testing.T) {
 }
 
 func TestBuildGuestfishMountScriptNeverEmitsInspector(t *testing.T) {
-	// Regression guard. Reintroducing -i anywhere in this path resurrects the
-	// "multi-boot operating systems are not supported" failure on any guest
-	// whose root filesystem spans more than one device.
+	// Regression guard: reintroducing -i resurrects the multi-boot failure.
 	plan := mountPlan{
 		Root:   "/dev/sda6",
 		Mounts: []mountSpec{{Device: "/dev/sda6", MountPoint: "/"}},
@@ -400,9 +375,7 @@ func TestBuildGuestfishMountScriptNeverEmitsInspector(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
 // formatGuestfishCommand
-// ---------------------------------------------------------------------------
 
 func TestFormatGuestfishCommand(t *testing.T) {
 	tests := []struct {
@@ -423,8 +396,7 @@ func TestFormatGuestfishCommand(t *testing.T) {
 			want:    `upload "/home/fedora/get-bootable-partition.sh" "/tmp/get-bootable-partition.sh"`,
 		},
 		{
-			// RunMountPersistenceScript passes script + flags as ONE argv token.
-			// Quoting keeps it one token on stdin instead of splitting on space.
+			// RunMountPersistenceScript passes script + flags as one argv token.
 			name:    "single arg containing spaces stays one token",
 			command: "sh",
 			args:    []string{"/tmp/generate-mount-persistence.sh --replace-fstab"},
@@ -439,9 +411,111 @@ func TestFormatGuestfishCommand(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
+// buildGuestfishBatchScript / splitGuestfishBatchOutput
+
+func TestBuildGuestfishBatchScript(t *testing.T) {
+	plan := mountPlan{
+		Root:   "/dev/sda6",
+		Mounts: []mountSpec{{Device: "/dev/sda6", MountPoint: "/"}},
+	}
+
+	got := buildGuestfishBatchScript(plan, true, []guestfishCmd{
+		{Name: "upload", Args: []string{"/home/fedora/x.sh", "/tmp/x.sh"}},
+		{Name: "chmod", Args: []string{"0755", "/tmp/x.sh"}},
+		{Name: "stat", Args: []string{"/sbin/dracut"}, Tolerate: true},
+	})
+
+	want := "run\n" +
+		`mount "/dev/sda6" "/"` + "\n" +
+		"echo " + guestfishBatchMarker + " 0\n" +
+		`upload "/home/fedora/x.sh" "/tmp/x.sh"` + "\n" +
+		"echo " + guestfishBatchMarker + " 1\n" +
+		`chmod "0755" "/tmp/x.sh"` + "\n" +
+		"echo " + guestfishBatchMarker + " 2\n" +
+		`- stat "/sbin/dracut"` + "\n"
+
+	assert.Equal(t, want, got)
+}
+
+func TestSplitGuestfishBatchOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		n    int
+		want []string
+	}{
+		{
+			name: "one line per command",
+			out: strings.Join([]string{
+				guestfishBatchMarker + " 0", "/dev/sda",
+				guestfishBatchMarker + " 1", "1",
+				guestfishBatchMarker + " 2", "true",
+				"",
+			}, "\n"),
+			n:    3,
+			want: []string{"/dev/sda", "1", "true"},
+		},
+		{
+			// A tolerated failure prints nothing, so its slot stays empty
+			// rather than absorbing the next command's output.
+			name: "tolerated failure yields an empty slot",
+			out: strings.Join([]string{
+				guestfishBatchMarker + " 0",
+				guestfishBatchMarker + " 1", "dracut found",
+				"",
+			}, "\n"),
+			n:    2,
+			want: []string{"", "dracut found"},
+		},
+		{
+			name: "multi-line output is preserved",
+			out: strings.Join([]string{
+				guestfishBatchMarker + " 0", "/dev/sda1", "/dev/sda2",
+				"",
+			}, "\n"),
+			n:    1,
+			want: []string{"/dev/sda1\n/dev/sda2"},
+		},
+		{
+			name: "output before any marker is discarded",
+			out:  "noise\n" + guestfishBatchMarker + " 0\nok\n",
+			n:    1,
+			want: []string{"ok"},
+		},
+		{
+			name: "missing trailing markers leave empty slots",
+			out:  guestfishBatchMarker + " 0\nok\n",
+			n:    3,
+			want: []string{"ok", "", ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, splitGuestfishBatchOutput(tt.out, tt.n))
+		})
+	}
+}
+
+func TestGuestfishBatchRoundTrip(t *testing.T) {
+	// Whatever buildGuestfishBatchScript numbers, splitGuestfishBatchOutput must
+	// be able to take apart again.
+	cmds := []guestfishCmd{
+		{Name: "part-to-dev", Args: []string{"/dev/sda1"}},
+		{Name: "part-to-partnum", Args: []string{"/dev/sda1"}},
+	}
+	plan := mountPlan{Root: "/dev/sda1", Mounts: []mountSpec{{Device: "/dev/sda1", MountPoint: "/"}}}
+
+	script := buildGuestfishBatchScript(plan, false, cmds)
+	for i := range cmds {
+		assert.Contains(t, script, "echo "+guestfishBatchMarker+" "+strconv.Itoa(i)+"\n")
+	}
+
+	simulated := guestfishBatchMarker + " 0\n/dev/sda\n" + guestfishBatchMarker + " 1\n1\n"
+	assert.Equal(t, []string{"/dev/sda", "1"}, splitGuestfishBatchOutput(simulated, len(cmds)))
+}
+
 // buildPlanProbeScript
-// ---------------------------------------------------------------------------
 
 func TestBuildPlanProbeScript(t *testing.T) {
 	got := buildPlanProbeScript([]string{"/dev/sdb", "/dev/sda6"})
@@ -459,9 +533,7 @@ func TestBuildPlanProbeScript(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
-// ---------------------------------------------------------------------------
 // planFromProbe - the whole reduction, end to end, without touching guestfish
-// ---------------------------------------------------------------------------
 
 func TestPlanFromProbe(t *testing.T) {
 	t.Run("multi-device btrfs resolves to a single root", func(t *testing.T) {
@@ -505,8 +577,7 @@ func TestPlanFromProbe(t *testing.T) {
 	})
 
 	t.Run("guest without fstab falls back to mounting only the root", func(t *testing.T) {
-		// Windows guests: inspect_get_mountpoints returns just the root
-		// (daemon/inspect.ml).
+		// Windows: inspect_get_mountpoints returns just the root.
 		plan, err := planFromProbe(
 			[]string{"/dev/sda2"},
 			map[string]string{"/dev/sda2": "aaaa"},

--- a/v2v-helper/virtv2v/guestfish_test.go
+++ b/v2v-helper/virtv2v/guestfish_test.go
@@ -520,7 +520,10 @@ func TestGuestfishBatchRoundTrip(t *testing.T) {
 func TestBuildPlanProbeScript(t *testing.T) {
 	got := buildPlanProbeScript([]string{"/dev/sdb", "/dev/sda6"})
 
+	// inspect-os must be re-run in this appliance or inspect-get-mountpoints
+	// fails with "no inspection data" - inspection state is per-process.
 	want := "run\n" +
+		"inspect-os\n" +
 		"echo " + planProbeUUIDMarker + ` "/dev/sdb"` + "\n" +
 		`- vfs-uuid "/dev/sdb"` + "\n" +
 		"echo " + planProbeMPMarker + ` "/dev/sdb"` + "\n" +
@@ -531,6 +534,20 @@ func TestBuildPlanProbeScript(t *testing.T) {
 		`- inspect-get-mountpoints "/dev/sda6"` + "\n"
 
 	assert.Equal(t, want, got)
+}
+
+func TestBuildPlanProbeScriptRunsInspectOSBeforeMarkers(t *testing.T) {
+	// Regression guard: both the openSUSE and Ubuntu runs of 2026-07-30 logged
+	// "inspect_get_mountpoints: no inspection data: call guestfs_inspect_os
+	// first" because this script omitted inspect-os, which silently reduced every
+	// mount plan to the root alone and broke UEFI ESP detection.
+	script := buildPlanProbeScript([]string{"/dev/sda1"})
+
+	inspectIdx := strings.Index(script, "inspect-os\n")
+	markerIdx := strings.Index(script, planProbeUUIDMarker)
+
+	assert.NotEqual(t, -1, inspectIdx, "probe script must run inspect-os")
+	assert.Less(t, inspectIdx, markerIdx, "inspect-os must precede the first marker")
 }
 
 // planFromProbe - the whole reduction, end to end, without touching guestfish

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -863,12 +863,8 @@ func RunCommandInGuestAllVolumes(disks []vm.VMDisk, command string, write bool, 
 }
 
 // GetBootableVolumeIndex returns the index of the disk holding the bootable
-// partition.
-//
-// Three appliance boots regardless of partition count: list the partitions,
-// resolve every partition's device and number in one batch, then read the
-// bootable flag and disk index for all of them in a second batch. Doing this one
-// partition at a time previously cost 4N+1 boots.
+// partition, in three appliance boots regardless of partition count: list, then
+// resolve every partition, then inspect them all. Per-partition cost 4N+1.
 func GetBootableVolumeIndex(disks []vm.VMDisk) (int, error) {
 	partitionsStr, err := RunCommandInGuestAllVolumes(disks, "list-partitions", false)
 	if err != nil {
@@ -1038,10 +1034,8 @@ func GetOsReleaseAllVolumes(disks []vm.VMDisk) (string, error) {
 		"/etc/SuSE-release",   // SUSE 11 and older
 	}
 
-	// Read every candidate in one appliance boot rather than paying a boot per
-	// file. The reads have to be error tolerant, which on its own would make an
-	// unreadable file look identical to a missing one - so probe with exists too
-	// and keep the distinction for the error message.
+	// One boot for all candidates. The reads must be error tolerant, which alone
+	// would make an unreadable file look missing, so probe with exists as well.
 	cmds := make([]guestfishCmd, 0, len(releaseFiles)*2)
 	for _, file := range releaseFiles {
 		cmds = append(cmds,
@@ -1208,8 +1202,7 @@ func FixLegacyMkinitrd(disks []vm.VMDisk) error {
 
 	log.Printf("FixLegacyMkinitrd: old mkinitrd detected (no dracut), installing LVM path translation wrapper")
 
-	// Back up the original, install the wrapper and make it executable, in one
-	// boot. Not tolerated: any failure leaves the guest half-patched.
+	// One boot. Not tolerated: a partial failure leaves the guest half-patched.
 	if _, err := runCommandsInGuestAllVolumes(disks, true,
 		guestfishCmd{Name: "cp", Args: []string{"/sbin/mkinitrd", "/sbin/mkinitrd.orig"}},
 		guestfishCmd{Name: "upload", Args: []string{mkinitrdLVMWrapperPath, "/sbin/mkinitrd"}},
@@ -1233,9 +1226,8 @@ func RunGetBootablePartitionScript(disks []vm.VMDisk) (string, error) {
 		return "", fmt.Errorf("get-bootable-partition.sh script not found at %s", scriptPath)
 	}
 
-	// Upload, chmod and run in a single appliance boot. The script writes its
-	// diagnostics to stderr and the answer to stdout, so only the "sh" output
-	// matters here.
+	// One boot. The script writes diagnostics to stderr and its answer to stdout,
+	// so only the "sh" slot matters.
 	const runIdx = 2
 	out, err := runCommandsInGuestAllVolumes(disks, true,
 		guestfishCmd{Name: "upload", Args: []string{scriptPath, "/tmp/get-bootable-partition.sh"}},
@@ -1267,8 +1259,8 @@ func RunNetworkPersistence(disks []vm.VMDisk, diskPath string, ostype string, is
 	}
 	defer os.RemoveAll(mountPoint)
 
-	// guestmount's -i shares inspect_mount_handle() with guestfish and fails the
-	// same way, so mount the resolved plan instead.
+	// guestmount's -i shares inspect_mount_handle() with guestfish, so it fails the
+	// same way; mount the resolved plan instead.
 	plan, err := resolveMountPlan(disks)
 	if err != nil {
 		return fmt.Errorf("failed to resolve guest mount plan: %w", err)
@@ -1292,8 +1284,8 @@ func RunNetworkPersistence(disks []vm.VMDisk, diskPath string, ostype string, is
 	log.Printf("Mounting disk to %s using guestmount...", mountPoint)
 	mountCmd := exec.Command("guestmount", buildArgs(plan.Mounts)...)
 	if out, mountErr := mountCmd.CombinedOutput(); mountErr != nil {
-		// guestmount cannot tolerate one failed mount, so retry with just the
-		// root: a stale fstab entry should not break network persistence.
+		// guestmount cannot tolerate one failed mount; a stale fstab entry should
+		// not break network persistence outright.
 		log.Printf("guestmount with the full mount plan failed (%v: %s); retrying with the root filesystem only",
 			mountErr, strings.TrimSpace(string(out)))
 

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -790,11 +790,8 @@ func AddFirstBootScript(firstbootscript, firstbootscriptname string) error {
 	return nil
 }
 
-// Runs command inside temporary qemu-kvm that virt-v2v creates.
-//
-// The guest is mounted from an explicitly resolved mount plan rather than with
-// guestfish's -i option. See guestfish.go for why: -i aborts on any guest whose
-// root filesystem spans more than one device.
+// Runs command inside temporary qemu-kvm that virt-v2v creates. Mounts come from
+// a resolved plan rather than guestfish's -i; see guestfish.go.
 func RunCommandInGuest(path string, command string, write bool) (string, error) {
 	os.Setenv("LIBGUESTFS_BACKEND", "direct")
 
@@ -812,8 +809,7 @@ func RunCommandInGuest(path string, command string, write bool) (string, error) 
 		option,
 		"-a",
 		path)
-	// The command text is passed through verbatim - callers already supply a
-	// complete guestfish command line here, not a command plus separate args.
+	// Callers pass a complete guestfish command line here, so no quoting.
 	cmd.Stdin = strings.NewReader(buildGuestfishMountScript(plan, write) + command + "\n")
 	log.Printf("Executing %s", cmd.String()+" "+command)
 	out, err := cmd.CombinedOutput()
@@ -840,9 +836,7 @@ func prepareGuestfishCommand(disks []vm.VMDisk, command string, write bool, args
 	for _, disk := range disks {
 		cmd.Args = append(cmd.Args, "-a", disk.Path)
 	}
-	// Commands go on stdin rather than after "--" so that the mount preamble can
-	// be prepended, and so that a failed non-root mount can be tolerated with
-	// guestfish's "-" command prefix.
+	// stdin rather than "--" so the mount preamble can be prepended.
 	cmd.Stdin = strings.NewReader(
 		buildGuestfishMountScript(plan, write) + formatGuestfishCommand(command, args...) + "\n")
 	return cmd, nil
@@ -868,57 +862,75 @@ func RunCommandInGuestAllVolumes(disks []vm.VMDisk, command string, write bool, 
 	return strings.ToLower(stdoutBuf.String()), nil
 }
 
-// GetDeviceNumberFromPartition returns the device index for a given partition name
-func GetDeviceNumberFromPartition(disks []vm.VMDisk, partition string) (int, error) {
-	command := "part-to-dev"
-	device, err := RunCommandInGuestAllVolumes(disks, command, false, strings.TrimSpace(partition))
-	if err != nil {
-		fmt.Printf("failed to run command (%s): %v: %s\n", device, err, strings.TrimSpace(device))
-		return -1, err
-	}
-
-	command = "part-to-partnum"
-	num, err := RunCommandInGuestAllVolumes(disks, command, false, strings.TrimSpace(partition))
-	if err != nil {
-		fmt.Printf("failed to run command (%s): %v: %s\n", num, err, strings.TrimSpace(num))
-		return -1, err
-	}
-
-	command = "part-get-bootable"
-	bootable, err := RunCommandInGuestAllVolumes(disks, command, false, strings.TrimSpace(device), strings.TrimSpace(num))
-	if err != nil {
-		fmt.Printf("failed to run command (%s): %v: %s\n", bootable, err, strings.TrimSpace(bootable))
-		return -1, err
-	}
-
-	if strings.TrimSpace(bootable) == "true" {
-		command = "device-index"
-		index, err := RunCommandInGuestAllVolumes(disks, command, false, strings.TrimSpace(device))
-		if err != nil {
-			fmt.Printf("failed to run command (%s): %v: %s\n", index, err, strings.TrimSpace(index))
-			return -1, err
-		}
-		return strconv.Atoi(strings.TrimSpace(index))
-	}
-
-	return -1, errors.New("partition is not bootable")
-}
-
+// GetBootableVolumeIndex returns the index of the disk holding the bootable
+// partition.
+//
+// Three appliance boots regardless of partition count: list the partitions,
+// resolve every partition's device and number in one batch, then read the
+// bootable flag and disk index for all of them in a second batch. Doing this one
+// partition at a time previously cost 4N+1 boots.
 func GetBootableVolumeIndex(disks []vm.VMDisk) (int, error) {
-	command := "list-partitions"
-	partitionsStr, err := RunCommandInGuestAllVolumes(disks, command, false)
+	partitionsStr, err := RunCommandInGuestAllVolumes(disks, "list-partitions", false)
 	if err != nil {
-		return -1, fmt.Errorf("failed to run command (%s): %v: %s", command, err, strings.TrimSpace(partitionsStr))
+		return -1, fmt.Errorf("failed to run command (list-partitions): %v: %s", err, strings.TrimSpace(partitionsStr))
 	}
 
-	partitions := strings.Split(strings.TrimSpace(partitionsStr), "\n")
-	for _, partition := range partitions {
-		deviceNum, err := GetDeviceNumberFromPartition(disks, partition)
-		if err == nil {
-			return deviceNum, nil
+	var partitions []string
+	for _, partition := range strings.Split(partitionsStr, "\n") {
+		if partition = strings.TrimSpace(partition); partition != "" {
+			partitions = append(partitions, partition)
 		}
-		// Continue to next partition if this one is not bootable or has an error
 	}
+	if len(partitions) == 0 {
+		return -1, errors.New("bootable volume not found")
+	}
+
+	resolve := make([]guestfishCmd, 0, len(partitions)*2)
+	for _, partition := range partitions {
+		resolve = append(resolve,
+			guestfishCmd{Name: "part-to-dev", Args: []string{partition}, Tolerate: true},
+			guestfishCmd{Name: "part-to-partnum", Args: []string{partition}, Tolerate: true},
+		)
+	}
+	resolved, err := runCommandsInGuestAllVolumes(disks, false, resolve...)
+	if err != nil {
+		return -1, fmt.Errorf("failed to resolve partitions: %w", err)
+	}
+
+	type candidate struct{ device, num string }
+	var candidates []candidate
+	inspect := make([]guestfishCmd, 0, len(partitions)*2)
+	for i := range partitions {
+		device, num := strings.TrimSpace(resolved[i*2]), strings.TrimSpace(resolved[i*2+1])
+		if device == "" || num == "" {
+			continue
+		}
+		candidates = append(candidates, candidate{device: device, num: num})
+		inspect = append(inspect,
+			guestfishCmd{Name: "part-get-bootable", Args: []string{device, num}, Tolerate: true},
+			guestfishCmd{Name: "device-index", Args: []string{device}, Tolerate: true},
+		)
+	}
+	if len(candidates) == 0 {
+		return -1, errors.New("bootable volume not found")
+	}
+
+	inspected, err := runCommandsInGuestAllVolumes(disks, false, inspect...)
+	if err != nil {
+		return -1, fmt.Errorf("failed to inspect partitions: %w", err)
+	}
+
+	for i := range candidates {
+		if strings.TrimSpace(inspected[i*2]) != "true" {
+			continue
+		}
+		index, convErr := strconv.Atoi(strings.TrimSpace(inspected[i*2+1]))
+		if convErr != nil {
+			continue
+		}
+		return index, nil
+	}
+
 	return -1, errors.New("bootable volume not found")
 }
 
@@ -1026,26 +1038,41 @@ func GetOsReleaseAllVolumes(disks []vm.VMDisk) (string, error) {
 		"/etc/SuSE-release",   // SUSE 11 and older
 	}
 
-	var errors []string
+	// Read every candidate in one appliance boot rather than paying a boot per
+	// file. The reads have to be error tolerant, which on its own would make an
+	// unreadable file look identical to a missing one - so probe with exists too
+	// and keep the distinction for the error message.
+	cmds := make([]guestfishCmd, 0, len(releaseFiles)*2)
 	for _, file := range releaseFiles {
-		output, err := RunCommandInGuestAllVolumes(disks, "cat", false, file)
-		if err == nil {
+		cmds = append(cmds,
+			guestfishCmd{Name: "exists", Args: []string{file}, Tolerate: true},
+			guestfishCmd{Name: "cat", Args: []string{file}, Tolerate: true},
+		)
+	}
+
+	out, err := runCommandsInGuestAllVolumes(disks, false, cmds...)
+	if err != nil {
+		return "", fmt.Errorf("failed to read OS release files: %w", err)
+	}
+
+	var unreadable []string
+	for i, file := range releaseFiles {
+		exists, content := strings.TrimSpace(out[i*2]) == "true", out[i*2+1]
+		if strings.TrimSpace(content) != "" {
 			log.Printf("Successfully read OS release from %s", file)
-			return output, nil
+			return content, nil
 		}
-
-		// Log the failure and continue to next file
-		log.Printf("Failed to get %s: %v", file, err)
-		errors = append(errors, fmt.Sprintf("%s: %v", file, err))
-
-		// If it's not a "file not found" error, stop trying
-		if !strings.Contains(err.Error(), "No such file or directory") {
-			break
+		if exists {
+			log.Printf("WARNING: %s exists but could not be read", file)
+			unreadable = append(unreadable, file)
 		}
 	}
 
-	// All attempts failed
-	return "", fmt.Errorf("failed to get OS release from any known location: %s", strings.Join(errors, "; "))
+	if len(unreadable) > 0 {
+		return "", fmt.Errorf("OS release file(s) present but unreadable: %s", strings.Join(unreadable, ", "))
+	}
+
+	return "", fmt.Errorf("failed to get OS release from any known location: %s", strings.Join(releaseFiles, ", "))
 }
 
 // GetWindowsVersion detects the Windows version using guestfish inspect commands
@@ -1115,44 +1142,19 @@ func RunMountPersistenceScript(disks []vm.VMDisk, diskPath string, osRelease str
 
 	log.Printf("Running generate-mount-persistence.sh with %s option(s)", scriptArgs)
 
-	// Upload the script to the guest VM
-	var uploadErr error
-	var uploadOutput string
-
-	command := "upload"
-	uploadOutput, uploadErr = RunCommandInGuestAllVolumes(disks, command, true, scriptPath, "/tmp/generate-mount-persistence.sh")
-
-	if uploadErr != nil {
-		return fmt.Errorf("failed to upload generate-mount-persistence.sh: %v: %s", uploadErr, strings.TrimSpace(uploadOutput))
-	}
-
-	log.Printf("Successfully uploaded generate-mount-persistence.sh to guest")
-
-	// Make the script executable
-	var chmodErr error
-	var chmodOutput string
-
-	command = "chmod"
-	chmodOutput, chmodErr = RunCommandInGuestAllVolumes(disks, command, true, "0755", "/tmp/generate-mount-persistence.sh")
-
-	if chmodErr != nil {
-		return fmt.Errorf("failed to make script executable: %v: %s", chmodErr, strings.TrimSpace(chmodOutput))
-	}
-
-	log.Printf("Made generate-mount-persistence.sh executable")
-
-	// Run the script with the chosen flag
-	var runErr error
-	var runOutput string
-
-	command = "sh"
-	runOutput, runErr = RunCommandInGuestAllVolumes(disks, command, true, "/tmp/generate-mount-persistence.sh "+scriptArgs)
-
-	if runErr != nil {
-		log.Printf("Warning: generate-mount-persistence.sh execution failed: %v: %s", runErr, strings.TrimSpace(runOutput))
+	// Upload, chmod and run in a single appliance boot.
+	const runIdx = 2
+	out, err := runCommandsInGuestAllVolumes(disks, true,
+		guestfishCmd{Name: "upload", Args: []string{scriptPath, "/tmp/generate-mount-persistence.sh"}},
+		guestfishCmd{Name: "chmod", Args: []string{"0755", "/tmp/generate-mount-persistence.sh"}},
+		guestfishCmd{Name: "sh", Args: []string{"/tmp/generate-mount-persistence.sh " + scriptArgs}},
+	)
+	if err != nil {
+		log.Printf("Warning: generate-mount-persistence.sh execution failed: %v", err)
 		// Don't return error, just log warning as this is not critical
 		return nil
 	}
+	runOutput := out[runIdx]
 
 	log.Printf("Successfully executed generate-mount-persistence.sh with %s", scriptArgs)
 	log.Printf("Script output: %s", strings.TrimSpace(runOutput))
@@ -1170,41 +1172,50 @@ const mkinitrdLVMWrapperPath = "/home/fedora/mkinitrd-lvm-wrapper.sh"
 func FixLegacyMkinitrd(disks []vm.VMDisk) error {
 	os.Setenv("LIBGUESTFS_BACKEND", "direct")
 
-	// 1. Does /sbin/mkinitrd exist on the guest?
-	if _, err := RunCommandInGuestAllVolumes(disks, "stat", false, "/sbin/mkinitrd"); err != nil {
+	// All four probes in one appliance boot rather than one boot each.
+	const (
+		probeMkinitrd = iota
+		probeDracutUsrBin
+		probeDracutSbin
+		probeAlreadyPatched
+	)
+	probes, err := runCommandsInGuestAllVolumes(disks, false,
+		guestfishCmd{Name: "exists", Args: []string{"/sbin/mkinitrd"}, Tolerate: true},
+		guestfishCmd{Name: "exists", Args: []string{"/usr/bin/dracut"}, Tolerate: true},
+		guestfishCmd{Name: "exists", Args: []string{"/sbin/dracut"}, Tolerate: true},
+		guestfishCmd{Name: "exists", Args: []string{"/sbin/mkinitrd.orig"}, Tolerate: true},
+	)
+	if err != nil {
+		log.Printf("FixLegacyMkinitrd: could not probe the guest, skipping: %v", err)
+		return nil
+	}
+
+	if probes[probeMkinitrd] != "true" {
 		log.Printf("FixLegacyMkinitrd: /sbin/mkinitrd not found on guest, skipping")
 		return nil
 	}
 
-	// 2. Is dracut absent? (dracut == modern SUSE, no patch needed)
-	for _, draculPath := range []string{"/usr/bin/dracut", "/sbin/dracut"} {
-		if _, err := RunCommandInGuestAllVolumes(disks, "stat", false, draculPath); err == nil {
-			log.Printf("FixLegacyMkinitrd: dracut found at %s, modern system – skipping", draculPath)
-			return nil
-		}
+	// dracut means a modern SUSE, no patch needed.
+	if probes[probeDracutUsrBin] == "true" || probes[probeDracutSbin] == "true" {
+		log.Printf("FixLegacyMkinitrd: dracut found, modern system – skipping")
+		return nil
 	}
 
-	// 3. Already patched by a previous run?
-	if _, err := RunCommandInGuestAllVolumes(disks, "stat", false, "/sbin/mkinitrd.orig"); err == nil {
+	if probes[probeAlreadyPatched] == "true" {
 		log.Printf("FixLegacyMkinitrd: wrapper already installed (/sbin/mkinitrd.orig present), skipping")
 		return nil
 	}
 
 	log.Printf("FixLegacyMkinitrd: old mkinitrd detected (no dracut), installing LVM path translation wrapper")
 
-	// 4. Back up original mkinitrd inside the guest.
-	if out, err := RunCommandInGuestAllVolumes(disks, "cp", true, "/sbin/mkinitrd", "/sbin/mkinitrd.orig"); err != nil {
-		return fmt.Errorf("FixLegacyMkinitrd: failed to backup /sbin/mkinitrd: %v: %s", err, strings.TrimSpace(out))
-	}
-
-	// 5. Upload the wrapper as the new /sbin/mkinitrd.
-	if out, err := RunCommandInGuestAllVolumes(disks, "upload", true, mkinitrdLVMWrapperPath, "/sbin/mkinitrd"); err != nil {
-		return fmt.Errorf("FixLegacyMkinitrd: failed to upload wrapper: %v: %s", err, strings.TrimSpace(out))
-	}
-
-	// 6. Ensure the wrapper is executable.
-	if out, err := RunCommandInGuestAllVolumes(disks, "chmod", true, "0755", "/sbin/mkinitrd"); err != nil {
-		return fmt.Errorf("FixLegacyMkinitrd: failed to chmod wrapper: %v: %s", err, strings.TrimSpace(out))
+	// Back up the original, install the wrapper and make it executable, in one
+	// boot. Not tolerated: any failure leaves the guest half-patched.
+	if _, err := runCommandsInGuestAllVolumes(disks, true,
+		guestfishCmd{Name: "cp", Args: []string{"/sbin/mkinitrd", "/sbin/mkinitrd.orig"}},
+		guestfishCmd{Name: "upload", Args: []string{mkinitrdLVMWrapperPath, "/sbin/mkinitrd"}},
+		guestfishCmd{Name: "chmod", Args: []string{"0755", "/sbin/mkinitrd"}},
+	); err != nil {
+		return fmt.Errorf("FixLegacyMkinitrd: failed to install wrapper: %w", err)
 	}
 
 	log.Printf("FixLegacyMkinitrd: wrapper installed successfully at /sbin/mkinitrd (original at /sbin/mkinitrd.orig)")
@@ -1222,55 +1233,23 @@ func RunGetBootablePartitionScript(disks []vm.VMDisk) (string, error) {
 		return "", fmt.Errorf("get-bootable-partition.sh script not found at %s", scriptPath)
 	}
 
-	// Upload the script to the guest VM
-	var uploadErr error
-	var uploadOutput string
-
-	command := "upload"
-	uploadOutput, uploadErr = RunCommandInGuestAllVolumes(disks, command, true, scriptPath, "/tmp/get-bootable-partition.sh")
-
-	if uploadErr != nil {
-		return "", fmt.Errorf("failed to upload get-bootable-partition.sh: %v: %s", uploadErr, strings.TrimSpace(uploadOutput))
+	// Upload, chmod and run in a single appliance boot. The script writes its
+	// diagnostics to stderr and the answer to stdout, so only the "sh" output
+	// matters here.
+	const runIdx = 2
+	out, err := runCommandsInGuestAllVolumes(disks, true,
+		guestfishCmd{Name: "upload", Args: []string{scriptPath, "/tmp/get-bootable-partition.sh"}},
+		guestfishCmd{Name: "chmod", Args: []string{"0755", "/tmp/get-bootable-partition.sh"}},
+		guestfishCmd{Name: "sh", Args: []string{"/tmp/get-bootable-partition.sh"}},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to run get-bootable-partition.sh: %w", err)
 	}
 
-	log.Printf("Successfully uploaded get-bootable-partition.sh to guest")
+	result := strings.TrimSpace(out[runIdx])
+	log.Printf("Successfully executed get-bootable-partition.sh, output: %s", result)
 
-	// Make the script executable
-	var chmodErr error
-	var chmodOutput string
-
-	command = "chmod"
-	chmodOutput, chmodErr = RunCommandInGuestAllVolumes(disks, command, true, "0755", "/tmp/get-bootable-partition.sh")
-
-	if chmodErr != nil {
-		return "", fmt.Errorf("failed to make script executable: %v: %s", chmodErr, strings.TrimSpace(chmodOutput))
-	}
-
-	log.Printf("Made get-bootable-partition.sh executable")
-
-	// Run the script
-	var runErr error
-
-	cmd, cmdErr := prepareGuestfishCommand(disks, "sh", true, "/tmp/get-bootable-partition.sh")
-	if cmdErr != nil {
-		return "", fmt.Errorf("failed to prepare get-bootable-partition.sh invocation: %w", cmdErr)
-	}
-	var stdoutBuf, stderrBuf bytes.Buffer
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
-	log.Printf("Executing %s", cmd.String())
-	runErr = cmd.Run()
-	if stderrBuf.Len() > 0 {
-		log.Printf("get-bootable-partition.sh debug output:\n%s", strings.TrimSpace(stderrBuf.String()))
-	}
-	if runErr != nil {
-		return "", fmt.Errorf("failed to run get-bootable-partition.sh: %v: %s", runErr, strings.TrimSpace(stderrBuf.String()))
-	}
-
-	log.Printf("Successfully executed get-bootable-partition.sh")
-	log.Printf("Script output: %s", strings.TrimSpace(stdoutBuf.String()))
-
-	return strings.TrimSpace(stdoutBuf.String()), nil
+	return result, nil
 }
 
 // RunNetworkPersistence mounts the disk locally and runs the network persistence script
@@ -1288,11 +1267,8 @@ func RunNetworkPersistence(disks []vm.VMDisk, diskPath string, ostype string, is
 	}
 	defer os.RemoveAll(mountPoint)
 
-	// Construct the guestmount command.
-	//
-	// guestmount's -i option shares inspect_mount_handle() with guestfish, so it
-	// fails identically on a guest whose root filesystem spans several devices.
-	// Mount the explicitly resolved plan instead.
+	// guestmount's -i shares inspect_mount_handle() with guestfish and fails the
+	// same way, so mount the resolved plan instead.
 	plan, err := resolveMountPlan(disks)
 	if err != nil {
 		return fmt.Errorf("failed to resolve guest mount plan: %w", err)
@@ -1316,10 +1292,8 @@ func RunNetworkPersistence(disks []vm.VMDisk, diskPath string, ostype string, is
 	log.Printf("Mounting disk to %s using guestmount...", mountPoint)
 	mountCmd := exec.Command("guestmount", buildArgs(plan.Mounts)...)
 	if out, mountErr := mountCmd.CombinedOutput(); mountErr != nil {
-		// Unlike a guestfish script, guestmount cannot tolerate one failed mount,
-		// and inspect-get-mountpoints is documented as possibly returning
-		// filesystems that are absent or unmountable. Retry with the root alone so
-		// that a stale fstab entry cannot break network persistence outright.
+		// guestmount cannot tolerate one failed mount, so retry with just the
+		// root: a stale fstab entry should not break network persistence.
 		log.Printf("guestmount with the full mount plan failed (%v: %s); retrying with the root filesystem only",
 			mountErr, strings.TrimSpace(string(out)))
 

--- a/v2v-helper/virtv2v/virtv2vops.go
+++ b/v2v-helper/virtv2v/virtv2vops.go
@@ -534,9 +534,15 @@ func GetOsRelease(path string) (string, error) {
 		"/etc/SuSE-release", // SLES 11
 	}
 
+	plan, planErr := resolveMountPlan([]vm.VMDisk{{Path: path}})
+	if planErr != nil {
+		return "", fmt.Errorf("failed to get OS release from %s: %w", path, planErr)
+	}
+
 	runGuestfishCat := func(imgPath, file string) (string, error) {
-		cmd := exec.Command("guestfish", "--ro", "-a", imgPath, "-i")
-		cmd.Stdin = strings.NewReader(fmt.Sprintf("cat %s", file))
+		cmd := exec.Command("guestfish", "--ro", "-a", imgPath)
+		cmd.Stdin = strings.NewReader(
+			buildGuestfishMountScript(plan, false) + formatGuestfishCommand("cat", file) + "\n")
 		log.Printf("Executing %s with input: cat %s", cmd.String(), file)
 
 		out, err := cmd.CombinedOutput()
@@ -784,9 +790,19 @@ func AddFirstBootScript(firstbootscript, firstbootscriptname string) error {
 	return nil
 }
 
-// Runs command inside temporary qemu-kvm that virt-v2v creates
+// Runs command inside temporary qemu-kvm that virt-v2v creates.
+//
+// The guest is mounted from an explicitly resolved mount plan rather than with
+// guestfish's -i option. See guestfish.go for why: -i aborts on any guest whose
+// root filesystem spans more than one device.
 func RunCommandInGuest(path string, command string, write bool) (string, error) {
 	os.Setenv("LIBGUESTFS_BACKEND", "direct")
+
+	plan, err := resolveMountPlan([]vm.VMDisk{{Path: path}})
+	if err != nil {
+		return "", fmt.Errorf("failed to run command (%s): %w", command, err)
+	}
+
 	option := "--ro"
 	if write {
 		option = "--rw"
@@ -795,9 +811,10 @@ func RunCommandInGuest(path string, command string, write bool) (string, error) 
 		"guestfish",
 		option,
 		"-a",
-		path,
-		"-i")
-	cmd.Stdin = strings.NewReader(command)
+		path)
+	// The command text is passed through verbatim - callers already supply a
+	// complete guestfish command line here, not a command plus separate args.
+	cmd.Stdin = strings.NewReader(buildGuestfishMountScript(plan, write) + command + "\n")
 	log.Printf("Executing %s", cmd.String()+" "+command)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -806,7 +823,12 @@ func RunCommandInGuest(path string, command string, write bool) (string, error) 
 	return strings.ToLower(strings.TrimSpace(string(out))), nil
 }
 
-func prepareGuestfishCommand(disks []vm.VMDisk, command string, write bool, args ...string) *exec.Cmd {
+func prepareGuestfishCommand(disks []vm.VMDisk, command string, write bool, args ...string) (*exec.Cmd, error) {
+	plan, err := resolveMountPlan(disks)
+	if err != nil {
+		return nil, err
+	}
+
 	option := "--ro"
 	if write {
 		option = "--rw"
@@ -818,19 +840,25 @@ func prepareGuestfishCommand(disks []vm.VMDisk, command string, write bool, args
 	for _, disk := range disks {
 		cmd.Args = append(cmd.Args, "-a", disk.Path)
 	}
-	cmd.Args = append(cmd.Args, "-i", "--", command)
-	cmd.Args = append(cmd.Args, args...)
-	return cmd
+	// Commands go on stdin rather than after "--" so that the mount preamble can
+	// be prepended, and so that a failed non-root mount can be tolerated with
+	// guestfish's "-" command prefix.
+	cmd.Stdin = strings.NewReader(
+		buildGuestfishMountScript(plan, write) + formatGuestfishCommand(command, args...) + "\n")
+	return cmd, nil
 }
 
 func RunCommandInGuestAllVolumes(disks []vm.VMDisk, command string, write bool, args ...string) (string, error) {
 	os.Setenv("LIBGUESTFS_BACKEND", "direct")
-	cmd := prepareGuestfishCommand(disks, command, write, args...)
-	log.Printf("Executing %s", cmd.String())
+	cmd, err := prepareGuestfishCommand(disks, command, write, args...)
+	if err != nil {
+		return "", fmt.Errorf("failed to run command (%s): %w", command, err)
+	}
+	log.Printf("Executing %s -- %s", cmd.String(), formatGuestfishCommand(command, args...))
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
-	err := cmd.Run()
+	err = cmd.Run()
 	if stderrBuf.Len() > 0 {
 		log.Printf("guestfish stderr (%s): %s", command, strings.TrimSpace(stderrBuf.String()))
 	}
@@ -1223,7 +1251,10 @@ func RunGetBootablePartitionScript(disks []vm.VMDisk) (string, error) {
 	// Run the script
 	var runErr error
 
-	cmd := prepareGuestfishCommand(disks, "sh", true, "/tmp/get-bootable-partition.sh")
+	cmd, cmdErr := prepareGuestfishCommand(disks, "sh", true, "/tmp/get-bootable-partition.sh")
+	if cmdErr != nil {
+		return "", fmt.Errorf("failed to prepare get-bootable-partition.sh invocation: %w", cmdErr)
+	}
 	var stdoutBuf, stderrBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
@@ -1257,18 +1288,45 @@ func RunNetworkPersistence(disks []vm.VMDisk, diskPath string, ostype string, is
 	}
 	defer os.RemoveAll(mountPoint)
 
-	// Construct the guestmount command
-	args := []string{"-i", "--rw"}
-
-	for _, disk := range disks {
-		args = append(args, "-a", disk.Path)
+	// Construct the guestmount command.
+	//
+	// guestmount's -i option shares inspect_mount_handle() with guestfish, so it
+	// fails identically on a guest whose root filesystem spans several devices.
+	// Mount the explicitly resolved plan instead.
+	plan, err := resolveMountPlan(disks)
+	if err != nil {
+		return fmt.Errorf("failed to resolve guest mount plan: %w", err)
 	}
-	args = append(args, mountPoint)
+
+	buildArgs := func(mounts []mountSpec) []string {
+		args := []string{"--rw"}
+		for _, disk := range disks {
+			args = append(args, "-a", disk.Path)
+		}
+		for _, spec := range mounts {
+			mountArg := spec.Device + ":" + spec.MountPoint
+			if spec.Options != "" {
+				mountArg += ":" + spec.Options
+			}
+			args = append(args, "-m", mountArg)
+		}
+		return append(args, mountPoint)
+	}
 
 	log.Printf("Mounting disk to %s using guestmount...", mountPoint)
-	mountCmd := exec.Command("guestmount", args...)
-	if out, err := mountCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("guestmount failed: %v, output: %s", err, string(out))
+	mountCmd := exec.Command("guestmount", buildArgs(plan.Mounts)...)
+	if out, mountErr := mountCmd.CombinedOutput(); mountErr != nil {
+		// Unlike a guestfish script, guestmount cannot tolerate one failed mount,
+		// and inspect-get-mountpoints is documented as possibly returning
+		// filesystems that are absent or unmountable. Retry with the root alone so
+		// that a stale fstab entry cannot break network persistence outright.
+		log.Printf("guestmount with the full mount plan failed (%v: %s); retrying with the root filesystem only",
+			mountErr, strings.TrimSpace(string(out)))
+
+		mountCmd = exec.Command("guestmount", buildArgs([]mountSpec{{Device: plan.Root, MountPoint: "/"}})...)
+		if out, mountErr := mountCmd.CombinedOutput(); mountErr != nil {
+			return fmt.Errorf("guestmount failed: %v, output: %s", mountErr, string(out))
+		}
 	}
 
 	// Unmount even if the script execution fails


### PR DESCRIPTION
## What this PR does / why we need it

Guests whose root filesystem spans several devices fail with:

    guestfish: multi-boot operating systems are not supported

Reproduced on openSUSE Leap 15.5 after `btrfs device add /dev/sdb /`.

Every guest operation used `guestfish -i`, which aborts whenever `inspect_os()`
returns more than one root. It counts roots, it does not compare them — and
every btrfs member device carries a full superblock, with no `btrfs_member`
type for libguestfs' `_member` filter to catch. So each member is reported as a
separate root.

Resolve mounts explicitly instead of using `-i`: enumerate roots without `-i`,
collapse roots sharing a filesystem UUID (for btrfs, the `fsid`), then mount
shortest-path-first with a fatal `/` and best-effort everything else, matching
`inspect_mount_root`. Genuine multi-boot guests still fail, now naming the roots.

Also batches independent guestfish commands into single appliance boots, and
drops the per-disk boot probe, which cannot work when the root spans disks and
whose result was discarded anyway.

Fixes: #2257 

