### PR TITLE
#2228: Cannot create cred with same name if previous attempt failed

### DIFF
--- a/ui/src/api/helpers.ts
+++ b/ui/src/api/helpers.ts
@@ -117,26 +117,37 @@ export const createOpenstackCredsWithSecretFlow = async (
   // First create the secret
   await createOpenstackCredsSecret(secretName, credentials, namespace)
 
-  // Then create the OpenStack credentials with the label
-  const credBody: any = {
-    apiVersion: 'vjailbreak.k8s.pf9.io/v1alpha1',
-    kind: 'OpenstackCreds',
-    metadata: {
-      name: credName,
-      namespace,
-      labels: {
-        'vjailbreak.k8s.pf9.io/is-pcd': isPcd ? 'true' : 'false'
-      }
-    },
-    spec: {
-      secretRef: {
-        name: secretName
+  try {
+    // Then create the OpenStack credentials with the label
+    const credBody: any = {
+      apiVersion: 'vjailbreak.k8s.pf9.io/v1alpha1',
+      kind: 'OpenstackCreds',
+      metadata: {
+        name: credName,
+        namespace,
+        labels: {
+          'vjailbreak.k8s.pf9.io/is-pcd': isPcd ? 'true' : 'false'
+        }
       },
-      projectName: projectName
+      spec: {
+        secretRef: {
+          name: secretName
+        },
+        projectName: projectName
+      }
     }
-  }
 
-  return postOpenstackCredentials(credBody, namespace)
+    return await postOpenstackCredentials(credBody, namespace)
+  } catch (error) {
+    // If postOpenstackCredentials fails, clean up the orphaned secret so a
+    // retry with the same credName doesn't hit a stale "already exists" error
+    try {
+      await deleteSecret(secretName, namespace)
+    } catch (cleanupError) {
+      console.error(`Failed to clean up orphaned secret ${secretName}:`, cleanupError)
+    }
+    throw error
+  }
 }
 
 // Create VMware credentials with secret
@@ -149,12 +160,23 @@ export const createVMwareCredsWithSecretFlow = async (
 
   await createVMwareCredsSecret(secretName, credentials, namespace)
 
-  return createVMwareCredsWithSecret(
-    credName,
-    secretName,
-    namespace,
-    credentials.VCENTER_DATACENTER
-  )
+  try {
+    return await createVMwareCredsWithSecret(
+      credName,
+      secretName,
+      namespace,
+      credentials.VCENTER_DATACENTER
+    )
+  } catch (error) {
+    // If createVMwareCredsWithSecret fails, clean up the orphaned secret so a
+    // retry with the same credName doesn't hit a stale "already exists" error
+    try {
+      await deleteSecret(secretName, namespace)
+    } catch (cleanupError) {
+      console.error(`Failed to clean up orphaned secret ${secretName}:`, cleanupError)
+    }
+    throw error
+  }
 }
 
 export const deleteVMwareCredsWithSecretFlow = async (

--- a/ui/src/api/secrets/secrets.ts
+++ b/ui/src/api/secrets/secrets.ts
@@ -166,7 +166,7 @@ export const createOpenstackCredsSecret = async (
     secretData.OS_INSECURE = credentials.OS_INSECURE.toString()
   }
 
-  return createSecret(name, secretData, namespace)
+  return upsertSecret(name, secretData, namespace)
 }
 
 // Function to create VMware credentials secret
@@ -197,7 +197,7 @@ export const createVMwareCredsSecret = async (
     VCENTER_INSECURE: credentials.VCENTER_INSECURE ? 'true' : 'false'
   }
 
-  return createSecret(name, secretData, namespace)
+  return upsertSecret(name, secretData, namespace)
 }
 
 // Function to create BMConfig user-data secret


### PR DESCRIPTION

## What this PR does / why we need it
- fix: handle orphaned secrets during OpenStack and VMware credential creation

## Which issue(s) this PR fixes
fixes #2228 

## Testing done
[Screencast from 04-08-26 11:02:07 AM IST.webm](https://github.com/user-attachments/assets/391ee5ae-e42c-4adc-b9a0-9cc25cd1f96d)
