### PR TITLE
[2247] Fix: 403 Forbidden fetching migration ConfigMap on migration details page

### DIFF
--- a/deploy/05controller-deployment.yaml
+++ b/deploy/05controller-deployment.yaml
@@ -42,7 +42,7 @@ spec:
         - configMapRef:
             name: pf9-env
             optional: true
-        image: quay.io/platform9/vjailbreak-controller:v0.4.8
+        image: quay.io/platform9/vjailbreak-controller:main
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:

--- a/deploy/06vpwned-deployment.yaml
+++ b/deploy/06vpwned-deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - configMapRef:
             name: pf9-env
             optional: true
-        image: quay.io/platform9/vjailbreak-vpwned:v0.4.8
+        image: quay.io/platform9/vjailbreak-vpwned:main
         imagePullPolicy: IfNotPresent
         name: vpwned
         ports:

--- a/deploy/07ui-deployment.yaml
+++ b/deploy/07ui-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: ui-manager-sa
       containers:
         - name: vjailbreak-ui-container
-          image: quay.io/platform9/vjailbreak-ui:v0.4.8
+          image: quay.io/platform9/vjailbreak-ui:main
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80

--- a/deploy/08vjailbreak-ai-deployment.yaml
+++ b/deploy/08vjailbreak-ai-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: vjailbreak-ai-sa
       containers:
         - name: vjailbreak-ai
-          image: quay.io/platform9/vjailbreak-ai:v0.4.8
+          image: quay.io/platform9/vjailbreak-ai:main
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/deploy/installer.yaml
+++ b/deploy/installer.yaml
@@ -5199,7 +5199,7 @@ spec:
         - configMapRef:
             name: pf9-env
             optional: true
-        image: quay.io/platform9/vjailbreak-controller:v0.4.8
+        image: quay.io/platform9/vjailbreak-controller:main
         imagePullPolicy: IfNotPresent
         lifecycle:
           preStop:
@@ -5306,7 +5306,7 @@ spec:
         - configMapRef:
             name: pf9-env
             optional: true
-        image: quay.io/platform9/vjailbreak-vpwned:v0.4.8
+        image: quay.io/platform9/vjailbreak-vpwned:main
         imagePullPolicy: IfNotPresent
         name: vpwned
         ports:
@@ -5435,7 +5435,7 @@ spec:
       serviceAccountName: ui-manager-sa
       containers:
         - name: vjailbreak-ui-container
-          image: quay.io/platform9/vjailbreak-ui:v0.4.8
+          image: quay.io/platform9/vjailbreak-ui:main
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
@@ -5724,7 +5724,7 @@ spec:
       serviceAccountName: vjailbreak-ai-sa
       containers:
         - name: vjailbreak-ai
-          image: quay.io/platform9/vjailbreak-ai:v0.4.8
+          image: quay.io/platform9/vjailbreak-ai:main
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/k8s/migration/config/addons/kustomization.yaml
+++ b/k8s/migration/config/addons/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: vpwned
   newName: quay.io/platform9/vjailbreak-vpwned
-  newTag: v0.4.8
+  newTag: main

--- a/k8s/migration/config/manager/kustomization.yaml
+++ b/k8s/migration/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/platform9/vjailbreak-controller
-  newTag: v0.4.8
+  newTag: main

--- a/pkg/vpwned/server/k8s_proxy_handler.go
+++ b/pkg/vpwned/server/k8s_proxy_handler.go
@@ -36,6 +36,7 @@ var allowedRoutes = []allowedRoute{
 	// Pods — read and admin-cutover patch
 	{http.MethodGet, regexp.MustCompile(`^/api/v1/namespaces/migration-system/pods(/[^/?]+(/log)?)?$`)},
 	{http.MethodPatch, regexp.MustCompile(`^/api/v1/namespaces/migration-system/pods/[^/?]+$`)},
+	{http.MethodGet, regexp.MustCompile(`^/api/v1/namespaces/migration-system/configmaps(/[^/?]+)?$`)},
 	// Secrets — full CRUD, migration-system only
 	{http.MethodGet, regexp.MustCompile(`^/api/v1/namespaces/migration-system/secrets(/[^/?]+)?$`)},
 	{http.MethodPost, regexp.MustCompile(`^/api/v1/namespaces/migration-system/secrets$`)},

--- a/pkg/vpwned/server/k8s_proxy_handler_test.go
+++ b/pkg/vpwned/server/k8s_proxy_handler_test.go
@@ -213,6 +213,16 @@ func TestHandleK8sProxy_AllowedPaths(t *testing.T) {
 		{"get pod", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods/my-pod", http.StatusOK},
 		{"stream pod logs", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods/my-pod/log", http.StatusOK},
 		{"patch pod (admin cutover)", http.MethodPatch, "/vpw/v1/k8s/api/v1/namespaces/migration-system/pods/my-pod", http.StatusOK},
+		// configmaps — read only
+		{"list configmaps", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/configmaps", http.StatusOK},
+		{"get migration configmap", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/configmaps/migration-config-testvm", http.StatusOK},
+		{"get settings configmap", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/configmaps/vjailbreak-settings", http.StatusOK},
+		// configmaps — writes and other namespaces blocked
+		{"post configmap forbidden", http.MethodPost, "/vpw/v1/k8s/api/v1/namespaces/migration-system/configmaps", http.StatusForbidden},
+		{"put configmap forbidden", http.MethodPut, "/vpw/v1/k8s/api/v1/namespaces/migration-system/configmaps/migration-config-testvm", http.StatusForbidden},
+		{"patch configmap forbidden", http.MethodPatch, "/vpw/v1/k8s/api/v1/namespaces/migration-system/configmaps/migration-config-testvm", http.StatusForbidden},
+		{"delete configmap forbidden", http.MethodDelete, "/vpw/v1/k8s/api/v1/namespaces/migration-system/configmaps/migration-config-testvm", http.StatusForbidden},
+		{"configmaps kube-system forbidden", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/kube-system/configmaps", http.StatusForbidden},
 		// secrets — allowed CRUD
 		{"list secrets", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/secrets", http.StatusOK},
 		{"get secret", http.MethodGet, "/vpw/v1/k8s/api/v1/namespaces/migration-system/secrets/my-secret", http.StatusOK},

--- a/ui/src/features/migration/utils/migrationDetailFields.test.ts
+++ b/ui/src/features/migration/utils/migrationDetailFields.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import axios from 'src/api/axios'
+import { getMigrationConfigMap } from 'src/api/migrations/migrations'
 import { normalizeVmDisks, resolveFlavorDisplay } from './migrationDetailFields'
+
+vi.mock('src/api/axios', () => ({
+  default: { get: vi.fn() }
+}))
 
 const flavors = [
   { id: 'flavor-1', name: 'm1.small' },
@@ -73,3 +79,49 @@ describe('normalizeVmDisks', () => {
     ])
   })
 })
+
+/**
+ * The flavor shown above comes from TARGET_FLAVOR_ID in the migration ConfigMap,
+ * which the details page fetches through the vpwned k8s proxy. That proxy rejects
+ * any path missing from its allowlist with a 403, so the path is pinned here
+ * against a mirror of the backend regex in pkg/vpwned/server/k8s_proxy_handler.go
+ */
+const PROXY_PREFIX = '/dev-api/sdk/vpw/v1/k8s'
+const ALLOWED_CONFIGMAP_PATH = /^\/api\/v1\/namespaces\/migration-system\/configmaps(\/[^/?]+)?$/
+
+describe('getMigrationConfigMap — source of the flavor above', () => {
+  const mockedGet = vi.mocked(axios.get)
+
+  beforeEach(() => {
+    mockedGet.mockReset()
+    mockedGet.mockResolvedValue({ data: { TARGET_FLAVOR_ID: 'flavor-1' } })
+  })
+
+  it('requests the migration ConfigMap through the k8s proxy', async () => {
+    const result = await getMigrationConfigMap('testvm')
+
+    expect(mockedGet).toHaveBeenCalledWith({
+      endpoint:
+        '/dev-api/sdk/vpw/v1/k8s/api/v1/namespaces/migration-system/configmaps/migration-config-testvm',
+    })
+    expect(result).toEqual({ data: { TARGET_FLAVOR_ID: 'flavor-1' } })
+  })
+
+  it('builds a path the vpwned k8s proxy allowlist accepts', async () => {
+    await getMigrationConfigMap('testvm')
+
+    const { endpoint } = mockedGet.mock.calls[0][0]
+    expect(endpoint.startsWith(PROXY_PREFIX)).toBe(true)
+    expect(endpoint.slice(PROXY_PREFIX.length)).toMatch(ALLOWED_CONFIGMAP_PATH)
+  })
+
+  it('honours an explicit namespace', async () => {
+    await getMigrationConfigMap('testvm', 'other-ns')
+
+    expect(mockedGet).toHaveBeenCalledWith({
+      endpoint:
+        '/dev-api/sdk/vpw/v1/k8s/api/v1/namespaces/other-ns/configmaps/migration-config-testvm',
+    })
+  })
+})
+


### PR DESCRIPTION
## What this PR does / why we need it
Fix: 403 Forbidden fetching migration ConfigMap on migration details page

## Which issue(s) this PR fixes
fixes #2247

## Testing done

<img width="1440" height="814" alt="image" src="https://github.com/user-attachments/assets/e1e3ed36-19bc-4e44-8c66-819338f27009" />
