### PR TITLE
[docs] remove incorrect port 5480 from prerequisites table

### DIFF
--- a/docs/src/content/docs/introduction/prerequisites.md
+++ b/docs/src/content/docs/introduction/prerequisites.md
@@ -105,10 +105,9 @@ Please refer the following table for the required ports:
 
 | Port | Protocol | Source | Destination | Purpose |
 | --- | --- | --- | --- | --- |
-| 443 | TCP | PCD nodes | VMware vCenter API endpiont | VMware provider inventory<br><br>Disk transfer authentication |
+| 443 | TCP | PCD nodes | VMware vCenter API endpoint | VMware provider inventory<br><br>Disk transfer authentication |
 | 443 | TCP | PCD nodes | VMware ESXi hosts | Disk transfer authentication |
 | 902 | TCP | PCD nodes | VMware ESXi hosts | Disk transfer data copy via NFC protocol (see NFC limitations above) |
-| 5480 | TCP | PCD nodes | VMware vCenter API endpoint | VMware Site Recovery Manager Appliance Management Interface |
 | 22 | TCP | vJailbreak VM | Proxy VM | vJailbreak Accelerated Copy only: SSH control of the Proxy VM |
 | 10809–11808 | TCP | vJailbreak VM | Proxy VM | vJailbreak Accelerated Copy only: `qemu-nbd` disk transfer (one port per disk copied in parallel) |
 


### PR DESCRIPTION
## Summary

- Removes port 5480 (VMware VCSA VAMI) from the required ports table — vJailbreak never communicates with this interface
- Fixes typo: `endpiont` → `endpoint` in the same table row

## Why port 5480 is wrong

Port 5480 is the **vCenter Server Appliance Management Interface (VAMI)** — used by admins to patch, back up, and configure the VCSA appliance itself. It has no relevance to VM migration.

vJailbreak only needs:
- **443 → vCenter** (vSphere API `/sdk` via govmomi)
- **902 → ESXi hosts** (NFC disk copy via VDDK/nbdkit)

Verified by searching the entire codebase — zero references to port 5480. All vCenter connections go through `NormalizeVCenterURL` which appends `/sdk` (port 443).

## Test plan

- [ ] Verify prerequisites page renders correctly on gh-pages after merge
- [ ] Confirm remaining ports table is accurate (443 vCenter, 443 ESXi, 902 ESXi, 22 Proxy VM, 10809–11808 Proxy VM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)