### PR TITLE
[2245] Fix: Persist data-only, source tags and custom metadata when retrying a failed migration

### DIFF
--- a/ui/src/features/migration/hooks/useRetryPrefill.ts
+++ b/ui/src/features/migration/hooks/useRetryPrefill.ts
@@ -11,18 +11,13 @@ import { getStorageMapping } from 'src/api/storage-mappings/storageMappings'
 import { getVmwareCredentials } from 'src/api/vmware-creds/vmwareCreds'
 import { getOpenstackCredentials } from 'src/api/openstack-creds/openstackCreds'
 import { getVMwareMachine, mapToVmData } from 'src/api/vmware-machines/vmwareMachines'
-import { CUTOVER_TYPES } from '../constants'
 import type { RetryMigrationConfig } from '../context/MigrationFormContext'
 import type {
   FormValues,
   MigrationDrawerRHFValues,
   SelectedMigrationOptionsType
 } from '../types'
-
-const ZERO_TIME = '0001-01-01T00:00:00Z'
-const DEFAULT_FIRSTBOOT_SCRIPT = 'echo "Add your startup script here!"'
-
-const isSetTime = (value?: string) => Boolean(value && value !== ZERO_TIME)
+import { buildRetryFormState } from '../utils/retryFormState'
 
 interface RetryResources {
   plan: MigrationPlan
@@ -209,103 +204,24 @@ export function useRetryPrefill({
       networkMappings,
       storageMappings
     } = query.data
-    const strategy = plan.spec?.migrationStrategy
-    const advanced = plan.spec?.advancedOptions
-    const pcd = pcdData.find((p) => p.name === template.spec?.targetPCDClusterName)
-
-    const cutoverOption = strategy?.adminInitiatedCutOver
-      ? CUTOVER_TYPES.ADMIN_INITIATED
-      : isSetTime(strategy?.vmCutoverStart) || isSetTime(strategy?.vmCutoverEnd)
-        ? CUTOVER_TYPES.TIME_WINDOW
-        : CUTOVER_TYPES.IMMEDIATE
-
-    const firstBootScript =
-      plan.spec?.firstBootScript && plan.spec.firstBootScript !== DEFAULT_FIRSTBOOT_SCRIPT
-        ? plan.spec.firstBootScript
-        : undefined
-
     setMigrationTemplate(template)
 
-    updateParams({
-      vmwareCreds: { existingCredName: vmwareRef, datacenter } as FormValues['vmwareCreds'],
-      openstackCreds: { existingCredName: openstackRef } as FormValues['openstackCreds'],
-      vmwareCluster: `${vmwareRef}:${datacenter}:${clusterName}`,
-      pcdCluster: pcd?.id || template.spec?.targetPCDClusterName || '',
-      vms: [vmData],
+    const { params, selectedOptions, formDefaults } = buildRetryFormState({
+      plan,
+      template,
+      vmData,
+      clusterName,
+      datacenter,
+      vmwareRef,
+      openstackRef,
       networkMappings,
       storageMappings,
-      storageCopyMethod: (template.spec?.storageCopyMethod ||
-        'normal') as FormValues['storageCopyMethod'],
-      ...(template.spec?.proxyVMRef?.name && { proxyVMRef: template.spec.proxyVMRef.name }),
-      dataCopyMethod: strategy?.type || 'cold',
-      useGPU: template.spec?.useGPUFlavor || false,
-      disconnectSourceNetwork: strategy?.disconnectSourceNetwork || false,
-      fallbackToDHCP: plan.spec?.fallbackToDHCP || false,
-      securityGroups: plan.spec?.securityGroups ?? [],
-      serverGroup: plan.spec?.serverGroup ?? '',
-      ...(isSetTime(strategy?.dataCopyStart) && { dataCopyStartTime: strategy?.dataCopyStart }),
-      cutoverOption,
-      ...(isSetTime(strategy?.vmCutoverStart) && { cutoverStartTime: strategy?.vmCutoverStart }),
-      ...(isSetTime(strategy?.vmCutoverEnd) && { cutoverEndTime: strategy?.vmCutoverEnd }),
-      ...(firstBootScript && { postMigrationScript: firstBootScript }),
-      ...(plan.spec?.postMigrationAction && {
-        postMigrationAction: plan.spec.postMigrationAction
-      }),
-      ...(typeof advanced?.networkPersistence === 'boolean' && {
-        networkPersistence: advanced.networkPersistence
-      }),
-      ...(typeof advanced?.removeVMwareTools === 'boolean' && {
-        removeVMwareTools: advanced.removeVMwareTools
-      }),
-      ...(typeof advanced?.acknowledgeNetworkConflictRisk === 'boolean' && {
-        acknowledgeNetworkConflictRisk: advanced.acknowledgeNetworkConflictRisk
-      }),
-      ...(advanced?.imageProfiles?.length && { imageProfiles: advanced.imageProfiles }),
-      ...(advanced?.periodicSyncInterval && {
-        periodicSyncInterval: advanced.periodicSyncInterval
-      }),
-      preserveSourceTags: plan.spec?.preserveSourceTags || false,
-      ...(plan.spec?.customMetadata &&
-        Object.keys(plan.spec.customMetadata).length > 0 && {
-          customMetadata: Object.entries(plan.spec.customMetadata).map(([key, value]) => ({
-            key,
-            value
-          }))
-        })
+      pcdData
     })
 
-    updateSelectedOptions({
-      dataCopyMethod: true,
-      dataCopyStartTime: isSetTime(strategy?.dataCopyStart),
-      cutoverOption: cutoverOption !== CUTOVER_TYPES.IMMEDIATE,
-      cutoverStartTime: isSetTime(strategy?.vmCutoverStart),
-      cutoverEndTime: isSetTime(strategy?.vmCutoverEnd),
-      postMigrationScript: Boolean(firstBootScript),
-      useGPU: template.spec?.useGPUFlavor || false,
-      periodicSyncEnabled: advanced?.periodicSyncEnabled || false,
-      ...(plan.spec?.postMigrationAction && {
-        postMigrationAction: {
-          renameVm: Boolean(plan.spec.postMigrationAction.renameVm),
-          suffix: Boolean(plan.spec.postMigrationAction.suffix),
-          moveToFolder: Boolean(plan.spec.postMigrationAction.moveToFolder),
-          folderName: Boolean(plan.spec.postMigrationAction.folderName)
-        }
-      })
-    })
-
-    form.reset({
-      securityGroups: plan.spec?.securityGroups ?? [],
-      serverGroup: plan.spec?.serverGroup ?? '',
-      dataCopyStartTime: isSetTime(strategy?.dataCopyStart)
-        ? (strategy?.dataCopyStart as string)
-        : '',
-      cutoverStartTime: isSetTime(strategy?.vmCutoverStart)
-        ? (strategy?.vmCutoverStart as string)
-        : '',
-      cutoverEndTime: isSetTime(strategy?.vmCutoverEnd) ? (strategy?.vmCutoverEnd as string) : '',
-      postMigrationActionSuffix: plan.spec?.postMigrationAction?.suffix ?? '',
-      postMigrationActionFolderName: plan.spec?.postMigrationAction?.folderName ?? ''
-    })
+    updateParams(params)
+    updateSelectedOptions(selectedOptions)
+    form.reset(formDefaults)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query.data, pcdData])
 

--- a/ui/src/features/migration/hooks/useRetrySubmit.ts
+++ b/ui/src/features/migration/hooks/useRetrySubmit.ts
@@ -19,9 +19,9 @@ import {
 } from 'src/features/migration/api/migration-templates/migrationTemplates'
 import { MigrationTemplate, VmData } from 'src/features/migration/api/migration-templates/model'
 import { MIGRATIONS_QUERY_KEY } from 'src/hooks/api/useMigrationsQuery'
-import { CUTOVER_TYPES } from '../constants'
 import type { RetryMigrationConfig } from '../context/MigrationFormContext'
 import type { FormValues, SelectedMigrationOptionsType } from '../types'
+import { buildRetryPlanSpec } from '../utils/retryFormState'
 
 async function pollUntilGone(
   fetcher: () => Promise<unknown>,
@@ -97,92 +97,10 @@ export function useRetrySubmit({
     [queryClient, onSuccess, onClose, navigate]
   )
 
-  const buildPlanPatchSpec = useCallback(() => {
-    const timeWindow =
-      selectedMigrationOptions.cutoverOption && params.cutoverOption === CUTOVER_TYPES.TIME_WINDOW
-
-    const networkOverridesPerVM: Record<
-      string,
-      Array<{
-        interfaceIndex: number
-        preserveIP: boolean
-        preserveMAC: boolean
-        UserAssignedIP?: string
-      }>
-    > = {}
-    if (params.vms) {
-      params.vms.forEach((vm) => {
-        const preserveIp = vm.preserveIp || {}
-        const preserveMac = vm.preserveMac || {}
-        const nicAssignedIps: Record<number, string> = {}
-        ;(vm.networkInterfaces || []).forEach((nic, index) => {
-          const assigned = (Array.isArray(nic.ipAddress) ? nic.ipAddress : [])
-            .map((ip) => ip?.trim())
-            .filter((ip): ip is string => Boolean(ip))
-          if (assigned.length > 0) {
-            nicAssignedIps[index] = assigned.join(',')
-          }
-        })
-        const indices = new Set<string>([
-          ...Object.keys(preserveIp),
-          ...Object.keys(preserveMac),
-          ...Object.keys(nicAssignedIps)
-        ])
-        if (indices.size === 0) return
-        networkOverridesPerVM[vm.vmKey || vm.name] = Array.from(indices)
-          .map((indexStr) => {
-            const interfaceIndex = Number(indexStr)
-            const ipFlag = preserveIp[interfaceIndex]
-            const macFlag = preserveMac[interfaceIndex]
-            const preserveIP = ipFlag !== false
-            const preserveMAC = macFlag !== false
-            const userAssigned = !preserveIP ? nicAssignedIps[interfaceIndex] : undefined
-            return {
-              interfaceIndex,
-              preserveIP,
-              preserveMAC,
-              ...(userAssigned ? { UserAssignedIP: userAssigned } : {})
-            }
-          })
-          .sort((a, b) => a.interfaceIndex - b.interfaceIndex)
-      })
-    }
-
-    return {
-      migrationStrategy: {
-        type: params.dataCopyMethod || retryPlan?.spec?.migrationStrategy?.type || 'cold',
-        adminInitiatedCutOver: Boolean(
-          selectedMigrationOptions.cutoverOption &&
-            params.cutoverOption === CUTOVER_TYPES.ADMIN_INITIATED
-        ),
-        dataCopyStart:
-          (selectedMigrationOptions.dataCopyStartTime && params.dataCopyStartTime) || null,
-        vmCutoverStart: (timeWindow && params.cutoverStartTime) || null,
-        vmCutoverEnd: (timeWindow && params.cutoverEndTime) || null,
-        disconnectSourceNetwork: params.disconnectSourceNetwork || false
-      },
-      securityGroups: params.securityGroups?.length ? params.securityGroups : null,
-      serverGroup: params.serverGroup || null,
-      fallbackToDHCP: params.fallbackToDHCP || false,
-      firstBootScript:
-        (selectedMigrationOptions.postMigrationScript && params.postMigrationScript) || null,
-      postMigrationAction: selectedMigrationOptions.postMigrationAction
-        ? params.postMigrationAction
-        : null,
-      // Send overrides when present; null explicitly clears any existing overrides
-      // that the user removed (merge-patch omit would silently keep stale values).
-      networkOverridesPerVM:
-        Object.keys(networkOverridesPerVM).length > 0 ? networkOverridesPerVM : null,
-      advancedOptions: {
-        periodicSyncEnabled: Boolean(selectedMigrationOptions.periodicSyncEnabled),
-        periodicSyncInterval: params.periodicSyncInterval || null,
-        networkPersistence: Boolean(params.networkPersistence),
-        removeVMwareTools: Boolean(params.removeVMwareTools),
-        acknowledgeNetworkConflictRisk: Boolean(params.acknowledgeNetworkConflictRisk),
-        imageProfiles: params.imageProfiles?.length ? params.imageProfiles : null
-      }
-    }
-  }, [params, selectedMigrationOptions, retryPlan])
+  const buildPlanPatchSpec = useCallback(
+    () => buildRetryPlanSpec({ params, selectedMigrationOptions, retryPlan }),
+    [params, selectedMigrationOptions, retryPlan]
+  )
 
   const performEditAndRetry = useCallback(async () => {
     if (!retryConfig || !retryTemplate || !retryPlan) return

--- a/ui/src/features/migration/utils/retryFormState.test.ts
+++ b/ui/src/features/migration/utils/retryFormState.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest'
+import { buildRetryFormState, buildRetryPlanSpec } from './retryFormState'
+import { CUTOVER_TYPES } from '../constants'
+import type { MigrationPlan } from '../api/migration-plans/model'
+import type { MigrationTemplate, VmData } from '../api/migration-templates/model'
+import type { FormValues, SelectedMigrationOptionsType } from '../types'
+
+const makePlan = (spec: Record<string, unknown> = {}): MigrationPlan =>
+  ({
+    metadata: { name: 'plan-1', namespace: 'migration-system' },
+    spec: {
+      migrationTemplate: 'template-1',
+      retry: false,
+      virtualMachines: [['vm-1']],
+      migrationStrategy: { type: 'cold' },
+      ...spec
+    }
+  }) as unknown as MigrationPlan
+
+const makeTemplate = (spec: Record<string, unknown> = {}): MigrationTemplate =>
+  ({
+    metadata: { name: 'template-1', namespace: 'migration-system' },
+    spec: {
+      source: { vmwareRef: 'vmware-1', datacenter: 'dc-1' },
+      destination: { openstackRef: 'pcd-1' },
+      targetPCDClusterName: 'cluster-a',
+      ...spec
+    }
+  }) as unknown as MigrationTemplate
+
+const VM: VmData = { name: 'vm-1', vmKey: 'vm-1' } as unknown as VmData
+
+const formStateInput = (plan: MigrationPlan, template = makeTemplate()) => ({
+  plan,
+  template,
+  vmData: VM,
+  clusterName: 'source-cluster',
+  datacenter: 'dc-1',
+  vmwareRef: 'vmware-1',
+  openstackRef: 'pcd-1',
+  networkMappings: [],
+  storageMappings: [],
+  pcdData: [{ id: 'pcd-id-1', name: 'cluster-a' }]
+})
+
+const SELECTED: SelectedMigrationOptionsType = {
+  dataCopyMethod: true,
+  dataCopyStartTime: false,
+  cutoverOption: false,
+  cutoverStartTime: false,
+  cutoverEndTime: false,
+  postMigrationScript: false
+}
+
+describe('buildRetryFormState — dataOnly', () => {
+  it('restores dataOnly=true from the plan migration strategy', () => {
+    const { params } = buildRetryFormState(
+      formStateInput(makePlan({ migrationStrategy: { type: 'cold', dataOnly: true } }))
+    )
+    expect(params.dataOnly).toBe(true)
+  })
+
+  it('defaults dataOnly to false when the plan strategy omits it', () => {
+    const { params } = buildRetryFormState(formStateInput(makePlan()))
+    expect(params.dataOnly).toBe(false)
+  })
+})
+
+describe('buildRetryFormState — other prefilled fields', () => {
+  it('derives an admin-initiated cutover and preserves plan-level options', () => {
+    const { params, selectedOptions, formDefaults } = buildRetryFormState(
+      formStateInput(
+        makePlan({
+          migrationStrategy: {
+            type: 'hot',
+            adminInitiatedCutOver: true,
+            disconnectSourceNetwork: true
+          },
+          fallbackToDHCP: true,
+          securityGroups: ['sg-1'],
+          serverGroup: 'sg-group',
+          preserveSourceTags: true,
+          customMetadata: { owner: 'team-a' }
+        })
+      )
+    )
+
+    expect(params.cutoverOption).toBe(CUTOVER_TYPES.ADMIN_INITIATED)
+    expect(params.dataCopyMethod).toBe('hot')
+    expect(params.disconnectSourceNetwork).toBe(true)
+    expect(params.fallbackToDHCP).toBe(true)
+    expect(params.pcdCluster).toBe('pcd-id-1')
+    expect(params.preserveSourceTags).toBe(true)
+    expect(params.customMetadata).toEqual([{ key: 'owner', value: 'team-a' }])
+    expect(selectedOptions.cutoverOption).toBe(true)
+    expect(formDefaults.securityGroups).toEqual(['sg-1'])
+    expect(formDefaults.serverGroup).toBe('sg-group')
+  })
+
+  it('treats the zero time as unset and defaults to an immediate cutover', () => {
+    const { params, selectedOptions } = buildRetryFormState(
+      formStateInput(
+        makePlan({
+          migrationStrategy: {
+            type: 'cold',
+            dataCopyStart: '0001-01-01T00:00:00Z',
+            vmCutoverStart: '0001-01-01T00:00:00Z',
+            vmCutoverEnd: '0001-01-01T00:00:00Z'
+          }
+        })
+      )
+    )
+
+    expect(params.cutoverOption).toBe(CUTOVER_TYPES.IMMEDIATE)
+    expect(params.dataCopyStartTime).toBeUndefined()
+    expect(selectedOptions.dataCopyStartTime).toBe(false)
+    expect(selectedOptions.cutoverOption).toBe(false)
+  })
+
+  it('drops the placeholder first-boot script', () => {
+    const { params, selectedOptions } = buildRetryFormState(
+      formStateInput(makePlan({ firstBootScript: 'echo "Add your startup script here!"' }))
+    )
+    expect(params.postMigrationScript).toBeUndefined()
+    expect(selectedOptions.postMigrationScript).toBe(false)
+  })
+})
+
+describe('buildRetryPlanSpec — dataOnly', () => {
+  it('sends dataOnly=true so the retried plan keeps data-only mode', () => {
+    const spec = buildRetryPlanSpec({
+      params: { dataOnly: true } as Partial<FormValues>,
+      selectedMigrationOptions: SELECTED,
+      retryPlan: makePlan({ migrationStrategy: { type: 'cold', dataOnly: true } })
+    })
+    expect(spec.migrationStrategy.dataOnly).toBe(true)
+  })
+
+  it('sends dataOnly=false explicitly when the user unchecks it on retry', () => {
+    const spec = buildRetryPlanSpec({
+      params: { dataOnly: false } as Partial<FormValues>,
+      selectedMigrationOptions: SELECTED,
+      retryPlan: makePlan({ migrationStrategy: { type: 'cold', dataOnly: true } })
+    })
+    expect(spec.migrationStrategy).toHaveProperty('dataOnly', false)
+  })
+})
+
+describe('preserveSourceTags and customMetadata round-trip', () => {
+  it('prefills both from the failed plan', () => {
+    const { params } = buildRetryFormState(
+      formStateInput(
+        makePlan({
+          preserveSourceTags: true,
+          customMetadata: { owner: 'team-a', env: 'prod' }
+        })
+      )
+    )
+
+    expect(params.preserveSourceTags).toBe(true)
+    expect(params.customMetadata).toEqual([
+      { key: 'owner', value: 'team-a' },
+      { key: 'env', value: 'prod' }
+    ])
+  })
+
+  it('writes both back onto the retried plan', () => {
+    const spec = buildRetryPlanSpec({
+      params: {
+        preserveSourceTags: true,
+        customMetadata: [
+          { key: 'owner', value: 'team-a' },
+          { key: 'env', value: 'prod' }
+        ]
+      } as Partial<FormValues>,
+      selectedMigrationOptions: SELECTED,
+      retryPlan: makePlan()
+    })
+
+    expect(spec.preserveSourceTags).toBe(true)
+    expect(spec.customMetadata).toEqual({ owner: 'team-a', env: 'prod' })
+  })
+
+  it('clears metadata the user removed and defaults tags to false', () => {
+    const spec = buildRetryPlanSpec({
+      params: { customMetadata: [] } as Partial<FormValues>,
+      selectedMigrationOptions: SELECTED,
+      retryPlan: makePlan({ preserveSourceTags: true, customMetadata: { owner: 'team-a' } })
+    })
+
+    expect(spec.preserveSourceTags).toBe(false)
+    expect(spec.customMetadata).toBeNull()
+  })
+
+  it('drops blank metadata keys and trims the rest', () => {
+    const spec = buildRetryPlanSpec({
+      params: {
+        customMetadata: [
+          { key: '  ', value: 'ignored' },
+          { key: ' owner ', value: ' team-a ' }
+        ]
+      } as Partial<FormValues>,
+      selectedMigrationOptions: SELECTED,
+      retryPlan: makePlan()
+    })
+
+    expect(spec.customMetadata).toEqual({ owner: 'team-a' })
+  })
+
+  it('prefills no metadata rows when the plan has an empty map', () => {
+    const { params } = buildRetryFormState(formStateInput(makePlan({ customMetadata: {} })))
+    expect(params.customMetadata).toBeUndefined()
+    expect(params.preserveSourceTags).toBe(false)
+  })
+})
+
+describe('buildRetryPlanSpec — unchanged behaviour', () => {
+  it('falls back to the original plan strategy type and nulls unset times', () => {
+    const spec = buildRetryPlanSpec({
+      params: {} as Partial<FormValues>,
+      selectedMigrationOptions: SELECTED,
+      retryPlan: makePlan({ migrationStrategy: { type: 'hot' } })
+    })
+
+    expect(spec.migrationStrategy.type).toBe('hot')
+    expect(spec.migrationStrategy.dataCopyStart).toBeNull()
+    expect(spec.migrationStrategy.vmCutoverStart).toBeNull()
+    expect(spec.migrationStrategy.vmCutoverEnd).toBeNull()
+    expect(spec.networkOverridesPerVM).toBeNull()
+    expect(spec.securityGroups).toBeNull()
+  })
+
+  it('emits per-VM network overrides sorted by interface index', () => {
+    const spec = buildRetryPlanSpec({
+      params: {
+        vms: [
+          {
+            name: 'vm-1',
+            vmKey: 'vm-1',
+            preserveIp: { 1: false, 0: true },
+            networkInterfaces: [{ ipAddress: [] }, { ipAddress: [' 10.0.0.5 '] }]
+          }
+        ]
+      } as unknown as Partial<FormValues>,
+      selectedMigrationOptions: SELECTED,
+      retryPlan: makePlan()
+    })
+
+    expect(spec.networkOverridesPerVM).toEqual({
+      'vm-1': [
+        { interfaceIndex: 0, preserveIP: true, preserveMAC: true },
+        { interfaceIndex: 1, preserveIP: false, preserveMAC: true, UserAssignedIP: '10.0.0.5' }
+      ]
+    })
+  })
+
+  it('honours the time-window cutover selection', () => {
+    const spec = buildRetryPlanSpec({
+      params: {
+        cutoverOption: CUTOVER_TYPES.TIME_WINDOW,
+        cutoverStartTime: '2026-08-06T10:00:00Z',
+        cutoverEndTime: '2026-08-06T12:00:00Z'
+      } as Partial<FormValues>,
+      selectedMigrationOptions: { ...SELECTED, cutoverOption: true },
+      retryPlan: makePlan()
+    })
+
+    expect(spec.migrationStrategy.adminInitiatedCutOver).toBe(false)
+    expect(spec.migrationStrategy.vmCutoverStart).toBe('2026-08-06T10:00:00Z')
+    expect(spec.migrationStrategy.vmCutoverEnd).toBe('2026-08-06T12:00:00Z')
+  })
+})

--- a/ui/src/features/migration/utils/retryFormState.ts
+++ b/ui/src/features/migration/utils/retryFormState.ts
@@ -1,0 +1,257 @@
+import { MigrationPlan } from 'src/features/migration/api/migration-plans/model'
+import { MigrationTemplate, VmData } from 'src/features/migration/api/migration-templates/model'
+import { CUTOVER_TYPES } from '../constants'
+import type {
+  FormValues,
+  MigrationDrawerRHFValues,
+  SelectedMigrationOptionsType
+} from '../types'
+import { customMetadataToRecord } from './metadataUtils'
+
+const ZERO_TIME = '0001-01-01T00:00:00Z'
+export const DEFAULT_FIRSTBOOT_SCRIPT = 'echo "Add your startup script here!"'
+
+export const isSetTime = (value?: string) => Boolean(value && value !== ZERO_TIME)
+
+export interface RetryFormStateInput {
+  plan: MigrationPlan
+  template: MigrationTemplate
+  vmData: VmData
+  clusterName: string
+  datacenter: string
+  vmwareRef: string
+  openstackRef: string
+  networkMappings: Array<{ source: string; target: string }>
+  storageMappings: Array<{ source: string; target: string }>
+  pcdData: Array<{ id: string; name?: string }>
+}
+
+export interface RetryFormState {
+  params: Partial<FormValues>
+  selectedOptions: Partial<SelectedMigrationOptionsType>
+  formDefaults: MigrationDrawerRHFValues
+}
+
+// Reverse-maps a failed migration's MigrationPlan + MigrationTemplate back into the
+// migration form's state so the retry drawer opens pre-populated with exactly what the
+// original migration ran with. Pure: every value is derived from the inputs.
+export function buildRetryFormState({
+  plan,
+  template,
+  vmData,
+  clusterName,
+  datacenter,
+  vmwareRef,
+  openstackRef,
+  networkMappings,
+  storageMappings,
+  pcdData
+}: RetryFormStateInput): RetryFormState {
+  const strategy = plan.spec?.migrationStrategy
+  const advanced = plan.spec?.advancedOptions
+  const pcd = pcdData.find((p) => p.name === template.spec?.targetPCDClusterName)
+
+  const cutoverOption = strategy?.adminInitiatedCutOver
+    ? CUTOVER_TYPES.ADMIN_INITIATED
+    : isSetTime(strategy?.vmCutoverStart) || isSetTime(strategy?.vmCutoverEnd)
+      ? CUTOVER_TYPES.TIME_WINDOW
+      : CUTOVER_TYPES.IMMEDIATE
+
+  const firstBootScript =
+    plan.spec?.firstBootScript && plan.spec.firstBootScript !== DEFAULT_FIRSTBOOT_SCRIPT
+      ? plan.spec.firstBootScript
+      : undefined
+
+  const params: Partial<FormValues> = {
+    vmwareCreds: { existingCredName: vmwareRef, datacenter } as FormValues['vmwareCreds'],
+    openstackCreds: { existingCredName: openstackRef } as FormValues['openstackCreds'],
+    vmwareCluster: `${vmwareRef}:${datacenter}:${clusterName}`,
+    pcdCluster: pcd?.id || template.spec?.targetPCDClusterName || '',
+    vms: [vmData],
+    networkMappings,
+    storageMappings,
+    storageCopyMethod: (template.spec?.storageCopyMethod ||
+      'normal') as FormValues['storageCopyMethod'],
+    ...(template.spec?.proxyVMRef?.name && { proxyVMRef: template.spec.proxyVMRef.name }),
+    dataCopyMethod: strategy?.type || 'cold',
+    useGPU: template.spec?.useGPUFlavor || false,
+    disconnectSourceNetwork: strategy?.disconnectSourceNetwork || false,
+    // Data-only is part of the plan's migration strategy, so it must be restored here or
+    // the retry silently downgrades to a full migration that creates an OpenStack VM.
+    dataOnly: strategy?.dataOnly || false,
+    fallbackToDHCP: plan.spec?.fallbackToDHCP || false,
+    securityGroups: plan.spec?.securityGroups ?? [],
+    serverGroup: plan.spec?.serverGroup ?? '',
+    ...(isSetTime(strategy?.dataCopyStart) && { dataCopyStartTime: strategy?.dataCopyStart }),
+    cutoverOption,
+    ...(isSetTime(strategy?.vmCutoverStart) && { cutoverStartTime: strategy?.vmCutoverStart }),
+    ...(isSetTime(strategy?.vmCutoverEnd) && { cutoverEndTime: strategy?.vmCutoverEnd }),
+    ...(firstBootScript && { postMigrationScript: firstBootScript }),
+    ...(plan.spec?.postMigrationAction && {
+      postMigrationAction: plan.spec.postMigrationAction
+    }),
+    ...(typeof advanced?.networkPersistence === 'boolean' && {
+      networkPersistence: advanced.networkPersistence
+    }),
+    ...(typeof advanced?.removeVMwareTools === 'boolean' && {
+      removeVMwareTools: advanced.removeVMwareTools
+    }),
+    ...(typeof advanced?.acknowledgeNetworkConflictRisk === 'boolean' && {
+      acknowledgeNetworkConflictRisk: advanced.acknowledgeNetworkConflictRisk
+    }),
+    ...(advanced?.imageProfiles?.length && { imageProfiles: advanced.imageProfiles }),
+    ...(advanced?.periodicSyncInterval && {
+      periodicSyncInterval: advanced.periodicSyncInterval
+    }),
+    preserveSourceTags: plan.spec?.preserveSourceTags || false,
+    ...(plan.spec?.customMetadata &&
+      Object.keys(plan.spec.customMetadata).length > 0 && {
+        customMetadata: Object.entries(plan.spec.customMetadata).map(([key, value]) => ({
+          key,
+          value
+        }))
+      })
+  }
+
+  const selectedOptions: Partial<SelectedMigrationOptionsType> = {
+    dataCopyMethod: true,
+    dataCopyStartTime: isSetTime(strategy?.dataCopyStart),
+    cutoverOption: cutoverOption !== CUTOVER_TYPES.IMMEDIATE,
+    cutoverStartTime: isSetTime(strategy?.vmCutoverStart),
+    cutoverEndTime: isSetTime(strategy?.vmCutoverEnd),
+    postMigrationScript: Boolean(firstBootScript),
+    useGPU: template.spec?.useGPUFlavor || false,
+    periodicSyncEnabled: advanced?.periodicSyncEnabled || false,
+    ...(plan.spec?.postMigrationAction && {
+      postMigrationAction: {
+        renameVm: Boolean(plan.spec.postMigrationAction.renameVm),
+        suffix: Boolean(plan.spec.postMigrationAction.suffix),
+        moveToFolder: Boolean(plan.spec.postMigrationAction.moveToFolder),
+        folderName: Boolean(plan.spec.postMigrationAction.folderName)
+      }
+    })
+  }
+
+  const formDefaults: MigrationDrawerRHFValues = {
+    securityGroups: plan.spec?.securityGroups ?? [],
+    serverGroup: plan.spec?.serverGroup ?? '',
+    dataCopyStartTime: isSetTime(strategy?.dataCopyStart)
+      ? (strategy?.dataCopyStart as string)
+      : '',
+    cutoverStartTime: isSetTime(strategy?.vmCutoverStart)
+      ? (strategy?.vmCutoverStart as string)
+      : '',
+    cutoverEndTime: isSetTime(strategy?.vmCutoverEnd) ? (strategy?.vmCutoverEnd as string) : '',
+    postMigrationActionSuffix: plan.spec?.postMigrationAction?.suffix ?? '',
+    postMigrationActionFolderName: plan.spec?.postMigrationAction?.folderName ?? ''
+  }
+
+  return { params, selectedOptions, formDefaults }
+}
+
+export interface RetryPlanSpecInput {
+  params: Partial<FormValues>
+  selectedMigrationOptions: SelectedMigrationOptionsType
+  retryPlan: MigrationPlan | undefined
+}
+
+// Builds the MigrationPlan spec for the replacement plan created by edit-and-retry.
+// Pure: mirrors useMigrationFormSubmit's plan payload for the single retrying VM.
+export function buildRetryPlanSpec({
+  params,
+  selectedMigrationOptions,
+  retryPlan
+}: RetryPlanSpecInput) {
+  const timeWindow =
+    selectedMigrationOptions.cutoverOption && params.cutoverOption === CUTOVER_TYPES.TIME_WINDOW
+
+  const networkOverridesPerVM: Record<
+    string,
+    Array<{
+      interfaceIndex: number
+      preserveIP: boolean
+      preserveMAC: boolean
+      UserAssignedIP?: string
+    }>
+  > = {}
+  if (params.vms) {
+    params.vms.forEach((vm) => {
+      const preserveIp = vm.preserveIp || {}
+      const preserveMac = vm.preserveMac || {}
+      const nicAssignedIps: Record<number, string> = {}
+      ;(vm.networkInterfaces || []).forEach((nic, index) => {
+        const assigned = (Array.isArray(nic.ipAddress) ? nic.ipAddress : [])
+          .map((ip) => ip?.trim())
+          .filter((ip): ip is string => Boolean(ip))
+        if (assigned.length > 0) {
+          nicAssignedIps[index] = assigned.join(',')
+        }
+      })
+      const indices = new Set<string>([
+        ...Object.keys(preserveIp),
+        ...Object.keys(preserveMac),
+        ...Object.keys(nicAssignedIps)
+      ])
+      if (indices.size === 0) return
+      networkOverridesPerVM[vm.vmKey || vm.name] = Array.from(indices)
+        .map((indexStr) => {
+          const interfaceIndex = Number(indexStr)
+          const ipFlag = preserveIp[interfaceIndex]
+          const macFlag = preserveMac[interfaceIndex]
+          const preserveIP = ipFlag !== false
+          const preserveMAC = macFlag !== false
+          const userAssigned = !preserveIP ? nicAssignedIps[interfaceIndex] : undefined
+          return {
+            interfaceIndex,
+            preserveIP,
+            preserveMAC,
+            ...(userAssigned ? { UserAssignedIP: userAssigned } : {})
+          }
+        })
+        .sort((a, b) => a.interfaceIndex - b.interfaceIndex)
+    })
+  }
+
+  return {
+    migrationStrategy: {
+      type: params.dataCopyMethod || retryPlan?.spec?.migrationStrategy?.type || 'cold',
+      adminInitiatedCutOver: Boolean(
+        selectedMigrationOptions.cutoverOption &&
+          params.cutoverOption === CUTOVER_TYPES.ADMIN_INITIATED
+      ),
+      dataCopyStart:
+        (selectedMigrationOptions.dataCopyStartTime && params.dataCopyStartTime) || null,
+      vmCutoverStart: (timeWindow && params.cutoverStartTime) || null,
+      vmCutoverEnd: (timeWindow && params.cutoverEndTime) || null,
+      disconnectSourceNetwork: params.disconnectSourceNetwork || false,
+      // Always sent (not omitted when false) so unchecking data-only on retry clears the
+      // flag instead of the merge keeping the failed migration's value.
+      dataOnly: params.dataOnly || false
+    },
+    securityGroups: params.securityGroups?.length ? params.securityGroups : null,
+    serverGroup: params.serverGroup || null,
+    fallbackToDHCP: params.fallbackToDHCP || false,
+    // Tags and metadata are prefilled into the retry form from the failed plan, so they
+    // must be written back too — otherwise a retry silently drops them. null clears
+    // metadata the user removed rather than leaving the stale map in place.
+    preserveSourceTags: params.preserveSourceTags || false,
+    customMetadata: customMetadataToRecord(params.customMetadata) ?? null,
+    firstBootScript:
+      (selectedMigrationOptions.postMigrationScript && params.postMigrationScript) || null,
+    postMigrationAction: selectedMigrationOptions.postMigrationAction
+      ? params.postMigrationAction
+      : null,
+    // Send overrides when present; null explicitly clears any existing overrides
+    // that the user removed (merge-patch omit would silently keep stale values).
+    networkOverridesPerVM:
+      Object.keys(networkOverridesPerVM).length > 0 ? networkOverridesPerVM : null,
+    advancedOptions: {
+      periodicSyncEnabled: Boolean(selectedMigrationOptions.periodicSyncEnabled),
+      periodicSyncInterval: params.periodicSyncInterval || null,
+      networkPersistence: Boolean(params.networkPersistence),
+      removeVMwareTools: Boolean(params.removeVMwareTools),
+      acknowledgeNetworkConflictRisk: Boolean(params.acknowledgeNetworkConflictRisk),
+      imageProfiles: params.imageProfiles?.length ? params.imageProfiles : null
+    }
+  }
+}


### PR DESCRIPTION
## What this PR does / why we need it
Retrying a failed migration silently dropped three plan-level settings. The retry drawer opened with them looking correct (or blank), but the replacement MigrationPlan didn't carry them — so the retry ran with different behaviour than the migration it was retrying.

## Which issue(s) this PR fixes
fixes #2245 

## Testing done
